### PR TITLE
Improve error handling

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -106,9 +106,11 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
     return getBackendSrv()
       .datasourceRequest(options)
       .catch((err: any) => {
-        if (err.data && err.data.error) {
+        if (err.data) {
+          const message = err.data.error?.reason ?? err.data.message ?? 'Unknown error';
+
           throw {
-            message: `OpenSearch error: ${err.data.error.reason}. ${err.data.error.details}`,
+            message: 'OpenSearch error: ' + message,
             error: err.data.error,
           };
         }


### PR DESCRIPTION
Slightly improves error handling. the logic to extract the error message is mirroring what is currently being done in the upstream Elasticsearch datasource.

![Screenshot 2021-11-11 at 11 41 22](https://user-images.githubusercontent.com/1170767/141292197-d6482d40-4560-477a-ab68-5096a3485352.png)

Fixes #6 

cc. @ifrost I also wanted to prefix the error based on the configured "flavor" (OpenSearch / Elasticsearch) but it felt even more confusing in the following situation:
- I have an OpenSearch cluster running
- I set Elasticsearch 7.0.0 in settings
- the error would be "Elasticsearch error: ..." while in fact I'm getting the error from an OpenSearch cluster.

also, I might even not connect at all to an OpenSearch/ES cluster (wrong URL or any network misconfiguration for instance), therefore i'd leave it like it is now, assuming "OpenSearch" in the error message refers to "OpenSearch plugin"
 