### PR TITLE
Release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+
+## v1.2.0
+### Features and enhancements
+- Upgrade of `@grafana/data`, `@grafana/ui`, `@grafana/runtime`, `@grafana/toolkit` to 8.5.5 (#35, #41)
+- Upgrade of further frontend and backend dependencies (#42, #43)
+
 ## v1.1.2
 ### Bug fixes
 - Improve error handling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -27,8 +27,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaVersion": "7.5.7",
-    "grafanaDependency": ">=7.5.7",
+    "grafanaDependency": ">=8.5.5",
     "plugins": []
   },
   "queryOptions": {


### PR DESCRIPTION
**What this PR does / why we need it:**

Release version 1.20 of the OpenSearch datasource plugin containing several dependency updates.