### PR TITLE
Tech: Add workflow to automatically move issues to L&T project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+* @grafana/observability-logs-and-traces

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -3,6 +3,8 @@ name: Auto Assign to Logs and Traces Project
 on:
   issues:
     types: [opened]
+  pull_request:
+    types: [opened]
 
 env:
   MY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,20 @@
+name: Auto Assign to Logs and Traces Project
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Logs&Traces Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to Logs&Traces project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/grafana/projects/110'
+        column_name: For Triage


### PR DESCRIPTION
Added a workflow to move issues to the L&T project for better visibility.

This can not really be tested unless it is on `main`.

Workflow is also in use e.g. here: https://github.com/grafana/grafana-plugin-sdk-python/blob/master/.github/workflows/add-issues-to-project.yml