### PR TITLE
Tech: Changed workflow to automatically move issues to L&T project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -2,21 +2,18 @@ name: Auto Assign to Logs and Traces Project
 
 on:
   issues:
-    types: [opened]
+    types: 
+      - opened
   pull_request:
-    types: [opened]
-
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    types:
+      - opened
 
 jobs:
-  assign_one_project:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
-    name: Assign to Logs&Traces Project
     steps:
-    - name: Assign NEW issues and NEW pull requests to Logs&Traces project
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/grafana/projects/110'
-        column_name: For Triage
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/grafana/projects/110
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The old Github action was not working well. Switching the action to the "official" action/add-to-project from GitHub.