### PR TITLE
PPL: Fixed queries being made and interpreted in local timezones

### DIFF
--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -20,8 +20,8 @@ var newPPLHandler = func(client es.Client, req *backend.QueryDataRequest) *pplHa
 }
 
 func (h *pplHandler) processQuery(q *Query) error {
-	from := h.req.Queries[0].TimeRange.From.Local().Format("2006-01-02 15:04:05")
-	to := h.req.Queries[0].TimeRange.To.Local().Format("2006-01-02 15:04:05")
+	from := h.req.Queries[0].TimeRange.From.UTC().Format("2006-01-02 15:04:05")
+	to := h.req.Queries[0].TimeRange.To.UTC().Format("2006-01-02 15:04:05")
 
 	builder := h.client.PPL()
 	builder.AddPPLQueryString(h.client.GetTimeField(), to, from, q.RawQuery)

--- a/src/OpenSearchResponse.ts
+++ b/src/OpenSearchResponse.ts
@@ -3,13 +3,13 @@ import flatten from './dependencies/flatten';
 import * as queryDef from './query_def';
 import TableModel from './dependencies/table_model';
 import {
-  dateTime,
   DataQueryResponse,
   DataFrame,
   toDataFrame,
   FieldType,
   MutableDataFrame,
   PreferredVisualisationType,
+  toUtc,
 } from '@grafana/data';
 import { Aggregation, OpenSearchQuery, QueryType } from './types';
 import {
@@ -738,7 +738,7 @@ const getPPLDatapoints = (response: any): { datapoints: any; targetVal: any; inv
   const datapoints = _.map(response.datarows, datarow => {
     const newDatarow = _.clone(datarow);
     const [timestamp] = newDatarow.splice(timeFieldIndex, 1);
-    newDatarow.push(dateTime(timestamp).unix() * 1000);
+    newDatarow.push(toUtc(timestamp).unix() * 1000);
     return newDatarow;
   });
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -625,7 +625,7 @@ describe('OpenSearchDatasource', function(this: any) {
 
   describe('PPL Queries', () => {
     const defaultPPLQuery =
-      "source=`test` | where `@time` >= timestamp('2015-05-30 08:00:00') and `@time` <= timestamp('2015-06-01 08:00:00')";
+      "source=`test` | where `@time` >= timestamp('2015-05-30 10:00:00') and `@time` <= timestamp('2015-06-01 10:00:00')";
 
     function setup(targets: OpenSearchQuery[]) {
       createDatasource({
@@ -646,7 +646,7 @@ describe('OpenSearchDatasource', function(this: any) {
         timezone: '',
         app: CoreApp.Dashboard,
         startTime: 0,
-        range: createTimeRange(dateTime([2015, 4, 30, 10]), dateTime([2015, 5, 1, 10])),
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
         targets,
       };
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -625,7 +625,7 @@ describe('OpenSearchDatasource', function(this: any) {
 
   describe('PPL Queries', () => {
     const defaultPPLQuery =
-      "source=`test` | where `@time` >= timestamp('2015-05-30 10:00:00') and `@time` <= timestamp('2015-06-01 10:00:00')";
+      "source=`test` | where `@time` >= timestamp('2015-05-30 08:00:00') and `@time` <= timestamp('2015-06-01 08:00:00')";
 
     function setup(targets: OpenSearchQuery[]) {
       createDatasource({

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -524,8 +524,12 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
     for (const target of targets) {
       let payload = this.createPPLQuery(target, options);
 
-      const rangeFrom = dateTime(options.range.from.valueOf()).format('YYYY-MM-DD HH:mm:ss');
-      const rangeTo = dateTime(options.range.to.valueOf()).format('YYYY-MM-DD HH:mm:ss');
+      const rangeFrom = dateTime(options.range.from.valueOf())
+        .utc()
+        .format('YYYY-MM-DD HH:mm:ss');
+      const rangeTo = dateTime(options.range.to.valueOf())
+        .utc()
+        .format('YYYY-MM-DD HH:mm:ss');
       // Replace the range here for actual values.
       payload = payload.replace(/\$timeTo/g, rangeTo);
       payload = payload.replace(/\$timeFrom/g, rangeFrom);


### PR DESCRIPTION
The datasource was using timestamps in local format when requesting a query. That was changed to UTC.

Furthermore the datasource interpreted the receiving timestamps via a PPL query as local timestamps, whereas it should have interpreted them as UTC timestamps.