### PR TITLE
Release: Release version `2.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.1
+### Bug fixes
+- Fixed timestamps in the backend beeing handled wrong (#31)
+- Fixed timestamps in the frontend being assumed as local, whereas they should be UTC (#21)
+
 ## v2.0.0
 ### Features and enhancements
 - Upgrade of `@grafana/data`, `@grafana/ui`, `@grafana/runtime`, `@grafana/toolkit` to 9.0.2 (#46)
 
 ### Breaking Changes
 - Use `SIGV4ConnectionConfig` from `@grafana/ui` (#48)
+
 
 ## v1.2.0
 ### Features and enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v2.0.1
 ### Bug fixes
 - Fixed timestamps in the backend beeing handled wrong (#31)
-- Fixed timestamps in the frontend being assumed as local, whereas they should be UTC (#21)
+- Fixed timestamps in the frontend being assumed as local, whereas they should be UTC (#21, #66)
 
 ## v2.0.0
 ### Features and enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4855,7 +4855,7 @@ dom-helpers@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-helpers@^5.0.1, dom-helpers@^5.2.1:
+dom-helpers@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -8926,7 +8926,7 @@ rc-util@^5.15.0, rc-util@^5.16.1, rc-util@^5.19.2, rc-util@^5.21.0, rc-util@^5.3
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.22.5.tgz#d4d6d886c5ecb6a2a51dde1840d780a2b70f5179"
   integrity sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==
   dependencies:
-    "@babel/runtime" "^7.12.5"
+    "@babel/runtime" "^7.18.3"
     react-is "^16.12.0"
     shallowequal "^1.1.0"
 
@@ -9196,7 +9196,7 @@ react-test-renderer@^17.0.0:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
 
-react-transition-group@4.4.2, react-transition-group@^4.3.0, react-transition-group@^4.4.2:
+react-transition-group@4.4.2, react-transition-group@^4.3.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==


### PR DESCRIPTION
Release https://github.com/grafana/opensearch-datasource/pull/62 and https://github.com/grafana/opensearch-datasource/pull/61 to OpenSearch in 2.0.1.