### PR TITLE
PPL: Fix timestamps in `table` visualisation

### DIFF
--- a/src/OpenSearchResponse.ts
+++ b/src/OpenSearchResponse.ts
@@ -609,9 +609,11 @@ export class OpenSearchResponse {
     const dataFrame: DataFrame[] = [];
 
     //map the schema into an array of string containing its name
-    const schema = this.response.schema.map((a: { name: any }) => a.name);
+    const schema = new Map<string, string>(
+      this.response.schema.map((a: { name: string; type: string }) => [a.name, a.type])
+    );
     //combine the schema key and response value
-    const response = _.map(this.response.datarows, arr => _.zipObject(schema, arr));
+    const response = _.map(this.response.datarows, arr => _.zipObject([...schema.keys()], arr));
     //flatten the response
     const { flattenSchema, docs } = flattenResponses(response);
 
@@ -630,6 +632,20 @@ export class OpenSearchResponse {
           // Remap level field based on the datasource config. This field is then used in explore to figure out the
           // log level. We may rewrite some actual data in the level field if they are different.
           doc['level'] = doc[logLevelField];
+        }
+
+        // Convert every property that is a timestamp or datetime to the local time representation.
+        // Log visualisation in Grafana will handle this, so we don't need to do this on logs requests.
+        // Format is based on https://opensearch.org/docs/latest/search-plugins/sql/datatypes/
+        if (!isLogsRequest) {
+          for (let [property, type] of schema) {
+            // based on https://opensearch.org/docs/1.3/observability-plugin/ppl/datatypes/ we only need to support those two formats.
+            if (type === 'timestamp' || type === 'datetime') {
+              doc[property] = toUtc(doc[property])
+                .local()
+                .format('YYYY-MM-DD HH:mm:ss.SSS');
+            }
+          }
         }
         series.add(doc);
       }

--- a/src/specs/OpenSearchResponse.test.ts
+++ b/src/specs/OpenSearchResponse.test.ts
@@ -1,4 +1,4 @@
-import { DataFrameView, FieldCache, KeyValue, MutableDataFrame } from '@grafana/data';
+import { DataFrameView, FieldCache, KeyValue, MutableDataFrame, toUtc } from '@grafana/data';
 import { OpenSearchResponse } from '../OpenSearchResponse';
 import flatten from '../dependencies/flatten';
 import { OpenSearchQuery, QueryType } from '../types';
@@ -1398,9 +1398,9 @@ describe('OpenSearchResponse', () => {
     ];
     const response = {
       datarows: [
-        [5, '2020-11-01 00:39:02.912Z'],
-        [1, '2020-11-01 03:26:21.326Z'],
-        [4, '2020-11-01 03:34:43.399Z'],
+        [5, '2020-11-01 00:39:02.912'],
+        [1, '2020-11-01 03:26:21.326'],
+        [4, '2020-11-01 03:34:43.399'],
       ],
       schema: [
         { name: 'test', type: 'string' },
@@ -1435,7 +1435,11 @@ describe('OpenSearchResponse', () => {
       for (let i = 0; i < rows.length; i++) {
         const r = rows.get(i);
         expect(r.test).toEqual(response.datarows[i][0]);
-        expect(r.timestamp).toEqual(response.datarows[i][1]);
+        expect(r.timestamp).toEqual(
+          toUtc(response.datarows[i][1])
+            .local()
+            .format('YYYY-MM-DD HH:mm:ss.SSS')
+        );
       }
     });
   });


### PR DESCRIPTION
## Description
Timestamps in `table` visualisation were shown as UTC. This PR will convert every property in a dataframe, that is type `timestamp` or `datetime` to the local time format.