### PR TITLE
Backend: Fix missing custom headers

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -30,6 +30,8 @@ var (
 
 // TODO: use real settings for HTTP client
 var newDatasourceHttpClient = func(ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
+	//dsHttpOpts, err := ds.HTTPClientOptions()
+
 	jsonDataStr := ds.JSONData
 	jsonData, err := simplejson.NewJson([]byte(jsonDataStr))
 	if err != nil {
@@ -285,6 +287,14 @@ func (c *baseClientImpl) executeRequest(method, uriPath, uriQuery string, body [
 	req.Header.Set("User-Agent", "Grafana")
 	req.Header.Set("Content-Type", "application/json")
 
+	dsHttpOpts, err := c.ds.HTTPClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range dsHttpOpts.Headers {
+		req.Header.Set(k, v)
+	}
+
 	secureJsonData := c.ds.DecryptedSecureJSONData
 
 	if c.ds.BasicAuthEnabled {
@@ -500,6 +510,13 @@ func (c *baseClientImpl) executePPLQueryRequest(method, uriPath string, body []b
 
 	req.Header.Set("User-Agent", "Grafana")
 	req.Header.Set("Content-Type", "application/json")
+	dsHttpOpts, err := c.ds.HTTPClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range dsHttpOpts.Headers {
+		req.Header.Set(k, v)
+	}
 
 	secureJsonData := c.ds.DecryptedSecureJSONData
 

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -30,8 +30,6 @@ var (
 
 // TODO: use real settings for HTTP client
 var newDatasourceHttpClient = func(ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
-	//dsHttpOpts, err := ds.HTTPClientOptions()
-
 	jsonDataStr := ds.JSONData
 	jsonData, err := simplejson.NewJson([]byte(jsonDataStr))
 	if err != nil {

--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -118,6 +118,30 @@ func TestClient(t *testing.T) {
 		})
 	})
 
+	Convey("Test HTTP custom headers", t, func() {
+		httpClientScenario(t, "Given a fake http client", &backend.DataSourceInstanceSettings{
+			Database: "[metrics-]YYYY.MM.DD",
+			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
+				"version":   "1.0.0",
+				"timeField": "@timestamp",
+				"interval":  "Daily",
+				"httpHeaderName1": "X-Header-Name",
+			}),
+			DecryptedSecureJSONData: map[string]string{
+				"httpHeaderValue1": "X-Header-Value",
+			},
+		}, func(sc *scenarioContext) {
+			ppl, err := createPPLForTest(sc.client)
+			So(err, ShouldBeNil)
+			_, err = sc.client.ExecutePPLQuery(ppl)
+			So(err, ShouldBeNil)
+
+			Convey("Should send correct header", func() {
+				So(sc.request.Header.Get("X-Header-Name"), ShouldEqual, "X-Header-Value")
+			})
+		})
+	})
+
 	Convey("Test PPL opensearch client", t, func() {
 		httpClientScenario(t, "Given a fake http client and a v1.0.0 client with PPL response", &backend.DataSourceInstanceSettings{
 			Database: "[metrics-]YYYY.MM.DD",


### PR DESCRIPTION
As described in https://github.com/grafana/opensearch-datasource/issues/73 custom headers are currently not send when the datasource is in backend mode.

This PR adds a hotfix to add custom headers. Since this will be backported to OpenSearch datasource v1.2.x, I decided to not implement the "full" Grafana HTTP client but rather go with this trivial approach of setting the custom headers.