### PR TITLE
Backend: Fix index being read from the wrong place

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -140,8 +140,14 @@ var NewClient = func(ctx context.Context, ds *backend.DataSourceInstanceSettings
 		return nil, fmt.Errorf("time field name is required, err=%v", err)
 	}
 
+	db, err := jsonData.Get("database").String()
+	if err != nil {
+		// `jsonData.database` is optional
+		db = ""
+	}
+
 	indexInterval := jsonData.Get("interval").MustString()
-	ip, err := newIndexPattern(indexInterval, ds.Database)
+	ip, err := newIndexPattern(indexInterval, db)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -56,12 +56,12 @@ func TestClient(t *testing.T) {
 		})
 
 		httpClientScenario(t, "Given a fake http client and a v1.0.0 client with response", &backend.DataSourceInstanceSettings{
-			Database: "[metrics-]YYYY.MM.DD",
 			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
 				"version":                    "1.0.0",
 				"maxConcurrentShardRequests": 6,
 				"timeField":                  "@timestamp",
 				"interval":                   "Daily",
+				"database":                   "[metrics-]YYYY.MM.DD",
 			}),
 		}, func(sc *scenarioContext) {
 			sc.responseBody = `{
@@ -120,12 +120,12 @@ func TestClient(t *testing.T) {
 
 	Convey("Test HTTP custom headers", t, func() {
 		httpClientScenario(t, "Given a fake http client", &backend.DataSourceInstanceSettings{
-			Database: "[metrics-]YYYY.MM.DD",
 			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
-				"version":   "1.0.0",
-				"timeField": "@timestamp",
-				"interval":  "Daily",
+				"version":         "1.0.0",
+				"timeField":       "@timestamp",
+				"interval":        "Daily",
 				"httpHeaderName1": "X-Header-Name",
+				"database":        "[metrics-]YYYY.MM.DD",
 			}),
 			DecryptedSecureJSONData: map[string]string{
 				"httpHeaderValue1": "X-Header-Value",
@@ -144,11 +144,11 @@ func TestClient(t *testing.T) {
 
 	Convey("Test PPL opensearch client", t, func() {
 		httpClientScenario(t, "Given a fake http client and a v1.0.0 client with PPL response", &backend.DataSourceInstanceSettings{
-			Database: "[metrics-]YYYY.MM.DD",
 			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
 				"version":   "1.0.0",
 				"timeField": "@timestamp",
 				"interval":  "Daily",
+				"database":  "[metrics-]YYYY.MM.DD",
 			}),
 		}, func(sc *scenarioContext) {
 			sc.responseBody = `{


### PR DESCRIPTION
As reported in #78 alert conditions are failing for some users. Reason for this is that the index pattern was read from `DataSourceSettings.Database` but is actually stored at `jsonData.database`.

This PR fixes #78 by also reading the database from `jsonData`.