### PR TITLE
Add option to query serverless OpenSearch instances

### DIFF
--- a/config/setupTests.ts
+++ b/config/setupTests.ts
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+const crypto = require('crypto');
+Object.defineProperty(global, 'crypto', {
+  value: {
+    getRandomValues: (arr: any) => crypto.randomBytes(arr.length),
+    subtle: crypto.webcrypto.subtle,
+  },
+});

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -78,6 +78,7 @@
     "unmarshaling",
     "varname",
     "visualisation",
-    "wojtekmaj"
+    "wojtekmaj",
+    "aoss"
   ]
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,5 +1,5 @@
 {
-  "ignorePaths": ["node_modules/**", "dist/**"],
+  "ignorePaths": ["node_modules/**", "dist/**", "**/mage_output_file.go"],
   "words": [
     "aggs",
     "bodyclose",

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -82,8 +82,13 @@ func GetSigV4Config(ds *backend.DataSourceInstanceSettings) (*sigv4.Config, erro
 		return nil, err
 	}
 
+	serviceName := "es"
+	if jsonData.Get("serverless").MustBool() {
+		serviceName = "aoss"
+	}
+
 	sigV4Config := &sigv4.Config{
-		Service:       "es", // Always "es" for elasticsearch/opendistro/opensearch TODO: Check if this is correct
+		Service:       serviceName,
 		AccessKey:     decrypted["sigV4AccessKey"],
 		SecretKey:     decrypted["sigV4SecretKey"],
 		Region:        jsonData.Get("sigV4Region").MustString(),

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -321,10 +321,7 @@ func (c *baseClientImpl) executeRequest(method, uriPath, uriQuery string, body [
 
 	
 	if req.Method != http.MethodGet && c.getSettings().Get("serverless").MustBool(false) {
-		h := sha256.New()
-		h.Write(body)
-		bs := h.Sum(nil)
-		req.Header.Set("x-amz-content-sha256", fmt.Sprintf("%x", bs))
+		req.Header.Set("x-amz-content-sha256", fmt.Sprintf("%x", sha256.Sum256(body)))
 	}
 
 	httpClient, err := newDatasourceHttpClient(c.ds)

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -3,6 +3,7 @@ package es
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -316,6 +317,14 @@ func (c *baseClientImpl) executeRequest(method, uriPath, uriQuery string, body [
 		clientLog.Debug("Request configured to use basic authentication")
 		password := secureJsonData["password"]
 		req.SetBasicAuth(c.ds.User, password)
+	}
+
+	
+	if req.Method != http.MethodGet && c.getSettings().Get("serverless").MustBool(false) {
+		h := sha256.New()
+		h.Write(body)
+		bs := h.Sum(nil)
+		req.Header.Set("x-amz-content-sha256", fmt.Sprintf("%x", bs))
 	}
 
 	httpClient, err := newDatasourceHttpClient(c.ds)

--- a/src/configuration/OpenSearchDetails.test.tsx
+++ b/src/configuration/OpenSearchDetails.test.tsx
@@ -53,6 +53,38 @@ describe('OpenSearchDetails', () => {
     });
   });
 
+  describe('Serverless enabled setting', () => {
+    it('should set serverless', () => {
+      const onChangeMock = jest.fn();
+      const options = createDefaultConfigOptions();
+      options.jsonData.serverless = false;
+      const wrapper = mount(<OpenSearchDetails onChange={onChangeMock} value={options} />);
+
+      const switchEl = wrapper.find({ label: 'Serverless' }).find(Switch);
+      const event = {
+        currentTarget: { checked: true },
+      } as React.ChangeEvent<HTMLInputElement>;
+      switchEl.props().onChange(event);
+
+      expect(onChangeMock.mock.calls[0][0].jsonData.serverless).toBe(true);
+    });
+
+    it('should disable pplEnabled', async () => {
+      const onChangeMock = jest.fn();
+      const options = createDefaultConfigOptions();
+      options.jsonData.serverless = false;
+      const wrapper = mount(<OpenSearchDetails onChange={onChangeMock} value={options} />);
+
+      const switchEl = wrapper.find({ label: 'Serverless' }).find(Switch);
+      const event = {
+        currentTarget: { checked: true },
+      } as React.ChangeEvent<HTMLInputElement>;
+      switchEl.props().onChange(event);
+
+      expect(onChangeMock.mock.calls[0][0].jsonData.pplEnabled).toBe(false);
+    });
+  });
+
   describe('version change', () => {
     const testCases = [
       { version: '5.0.0', flavor: Flavor.Elasticsearch, expectedMaxConcurrentShardRequests: 256 },

--- a/src/configuration/OpenSearchDetails.tsx
+++ b/src/configuration/OpenSearchDetails.tsx
@@ -109,7 +109,25 @@ export const OpenSearchDetails = (props: Props) => {
             }
           />
         </div>
-        {shouldRenderMaxConcurrentShardRequests(value.jsonData.flavor, value.jsonData.version) && (
+        <div className="gf-form-inline">
+          <Switch
+            label="Serverless"
+            labelClass="width-10"
+            tooltip="If this is a DataSource to query a serverless OpenSearch service."
+            checked={value.jsonData.serverless ?? false}
+            onChange={event => {
+              onChange({
+                ...value,
+                jsonData: {
+                  ...value.jsonData,
+                  serverless: event.currentTarget.checked,
+                  pplEnabled: !event.currentTarget.checked,
+                },
+              });
+            }}
+          />
+        </div>
+        {shouldRenderMaxConcurrentShardRequests(value.jsonData) && (
           <div className="gf-form max-width-30">
             <FormField
               aria-label="Max concurrent Shard Requests input"
@@ -150,15 +168,17 @@ export const OpenSearchDetails = (props: Props) => {
             />
           </div>
         </div>
-        <div className="gf-form">
-          <Switch
-            label="PPL enabled"
-            labelClass="width-10"
-            tooltip="Allow Piped Processing Language as an alternative query syntax in the OpenSearch query editor."
-            checked={value.jsonData.pplEnabled ?? true}
-            onChange={jsonDataSwitchChangeHandler('pplEnabled', value, onChange)}
-          />
-        </div>
+        {!value.jsonData.serverless && (
+          <div className="gf-form">
+            <Switch
+              label="PPL enabled"
+              labelClass="width-10"
+              tooltip="Allow Piped Processing Language as an alternative query syntax in the OpenSearch query editor."
+              checked={value.jsonData.pplEnabled ?? true}
+              onChange={jsonDataSwitchChangeHandler('pplEnabled', value, onChange)}
+            />
+          </div>
+        )}
       </div>
     </>
   );
@@ -225,7 +245,12 @@ const intervalHandler = (value: Props['value'], onChange: Props['onChange']) => 
   }
 };
 
-function shouldRenderMaxConcurrentShardRequests(flavor: Flavor, version: string) {
+function shouldRenderMaxConcurrentShardRequests(settings: OpenSearchOptions) {
+  const { flavor, version, serverless } = settings;
+  if (serverless) {
+    return false;
+  }
+
   if (flavor === Flavor.OpenSearch) {
     return true;
   }

--- a/src/configuration/OpenSearchDetails.tsx
+++ b/src/configuration/OpenSearchDetails.tsx
@@ -68,47 +68,49 @@ export const OpenSearchDetails = (props: Props) => {
             required
           />
         </div>
-
-        <div className="gf-form">
-          <FormField
-            labelWidth={10}
-            inputWidth={15}
-            label="Version"
-            inputEl={
-              <Select
-                options={AVAILABLE_VERSIONS}
-                onChange={option => {
-                  onChange({
-                    ...value,
-                    jsonData: {
-                      ...value.jsonData,
-                      version: option.value.version,
-                      flavor: option.value.flavor,
-                      maxConcurrentShardRequests: getMaxConcurrentShardRequestOrDefault(
-                        option.value.flavor,
-                        option.value.version,
-                        value.jsonData.maxConcurrentShardRequests
-                      ),
-                    },
-                  });
-                }}
-                value={
-                  AVAILABLE_VERSIONS.find(
-                    version =>
-                      version.value.version === value.jsonData.version && version.value.flavor === value.jsonData.flavor
-                  ) || {
-                    value: {
-                      flavor: value.jsonData.flavor,
-                      version: value.jsonData.version,
-                    },
-                    label: `${AVAILABLE_FLAVORS.find(f => f.value === value.jsonData.flavor)?.label ||
-                      value.jsonData.flavor} ${value.jsonData.version}`,
+        {!value.jsonData.serverless && (
+          <div className="gf-form">
+            <FormField
+              labelWidth={10}
+              inputWidth={15}
+              label="Version"
+              inputEl={
+                <Select
+                  options={AVAILABLE_VERSIONS}
+                  onChange={option => {
+                    onChange({
+                      ...value,
+                      jsonData: {
+                        ...value.jsonData,
+                        version: option.value.version,
+                        flavor: option.value.flavor,
+                        maxConcurrentShardRequests: getMaxConcurrentShardRequestOrDefault(
+                          option.value.flavor,
+                          option.value.version,
+                          value.jsonData.maxConcurrentShardRequests
+                        ),
+                      },
+                    });
+                  }}
+                  value={
+                    AVAILABLE_VERSIONS.find(
+                      version =>
+                        version.value.version === value.jsonData.version &&
+                        version.value.flavor === value.jsonData.flavor
+                    ) || {
+                      value: {
+                        flavor: value.jsonData.flavor,
+                        version: value.jsonData.version,
+                      },
+                      label: `${AVAILABLE_FLAVORS.find(f => f.value === value.jsonData.flavor)?.label ||
+                        value.jsonData.flavor} ${value.jsonData.version}`,
+                    }
                   }
-                }
-              />
-            }
-          />
-        </div>
+                />
+              }
+            />
+          </div>
+        )}
         <div className="gf-form-inline">
           <Switch
             label="Serverless"

--- a/src/configuration/mocks.ts
+++ b/src/configuration/mocks.ts
@@ -14,5 +14,6 @@ export function createDefaultConfigOptions(): DataSourceSettings<OpenSearchOptio
     logLevelField: 'test.level',
     database: '',
     pplEnabled: false,
+    serverless: false,
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface OpenSearchOptions extends DataSourceJsonData {
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
   pplEnabled?: boolean;
+  sigV4Auth?: boolean;
+  serverless?: boolean;
 }
 
 interface MetricConfiguration<T extends MetricAggregationType> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,3 +52,11 @@ export const removeEmpty = <T>(obj: T): Partial<T> =>
       [key]: value,
     };
   }, {});
+
+export async function sha256(string) {
+  const utf8 = new TextEncoder().encode(string);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', utf8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(bytes => bytes.toString(16).padStart(2, '0')).join('');
+  return hashHex;
+}


### PR DESCRIPTION
**What is this feature?**
This PR adds the possibility to also query OpenSearch Serverless services.

**Special notes for your reviewer**:
PR in Grafana to add the needed changes: https://github.com/grafana/grafana/pull/60344

