### PR TITLE
fix the moving_avg modes

### DIFF
--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/MovingAverageSettingsEditor.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/MovingAverageSettingsEditor.tsx
@@ -41,8 +41,15 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
         <>
           <InlineField label="Alpha">
             <Input
-              onBlur={e => dispatch(changeMetricSetting(metric, 'alpha', parseFloat(e.target.value!)))}
-              defaultValue={metric.settings?.alpha}
+              onBlur={e =>
+                dispatch(
+                  changeMetricSetting(metric, 'settings', {
+                    ...metric.settings?.settings,
+                    alpha: parseFloat(e.target.value!),
+                  })
+                )
+              }
+              defaultValue={metric.settings?.settings?.alpha}
             />
           </InlineField>
 

--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/MovingAverageSettingsEditor.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/MovingAverageSettingsEditor.tsx
@@ -41,7 +41,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
         <>
           <InlineField label="Alpha">
             <Input
-              onBlur={e => dispatch(changeMetricSetting(metric, 'alpha', parseInt(e.target.value!, 10)))}
+              onBlur={e => dispatch(changeMetricSetting(metric, 'alpha', parseFloat(e.target.value!)))}
               defaultValue={metric.settings?.alpha}
             />
           </InlineField>
@@ -65,7 +65,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
                 dispatch(
                   changeMetricSetting(metric, 'settings', {
                     ...metric.settings?.settings,
-                    alpha: parseInt(e.target.value!, 10),
+                    alpha: parseFloat(e.target.value!),
                   })
                 )
               }
@@ -78,7 +78,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
                 dispatch(
                   changeMetricSetting(metric, 'settings', {
                     ...metric.settings?.settings,
-                    beta: parseInt(e.target.value!, 10),
+                    beta: parseFloat(e.target.value!),
                   })
                 )
               }
@@ -105,7 +105,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
                 dispatch(
                   changeMetricSetting(metric, 'settings', {
                     ...metric.settings?.settings,
-                    alpha: parseInt(e.target.value!, 10),
+                    alpha: parseFloat(e.target.value!),
                   })
                 )
               }
@@ -118,7 +118,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
                 dispatch(
                   changeMetricSetting(metric, 'settings', {
                     ...metric.settings?.settings,
-                    beta: parseInt(e.target.value!, 10),
+                    beta: parseFloat(e.target.value!),
                   })
                 )
               }
@@ -131,7 +131,7 @@ export const MovingAverageSettingsEditor = ({ metric }: Props) => {
                 dispatch(
                   changeMetricSetting(metric, 'settings', {
                     ...metric.settings?.settings,
-                    gamma: parseInt(e.target.value!, 10),
+                    gamma: parseFloat(e.target.value!),
                   })
                 )
               }

--- a/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -180,7 +180,9 @@ interface MovingAverageLinearModelSettings extends BaseMovingAverageModelSetting
 
 interface MovingAverageEWMAModelSettings extends BaseMovingAverageModelSettings {
   model: 'ewma';
-  alpha: number;
+  settings: {
+    alpha: number;
+  };
   minimize: boolean;
 }
 interface MovingAverageHoltModelSettings extends BaseMovingAverageModelSettings {


### PR DESCRIPTION
(fixes https://github.com/grafana/opensearch-datasource/issues/98)

when using the `moving_avg` metric, for certain modes there are coefficients (`alpha`, `beta`, `gamma`) that can be configured. the code used `parseInt` to parse them, so when floating-point values are entered (for example `0.35`), it was parsed incorrectly).

also the `MovingAverageEWMAModelSettings` type was defined incorrectly.

how to test:
1. make sure you have an opensearch datasource plugin configured ( read https://github.com/grafana/opensearch-datasource/blob/main/devenv/README.md if unsure)
1. open the opensearch datasource in explore
2. you should see a working "count" metric query
3. add another metric, choose `moving_avg`. configure it:
   - `field`: choose `count`
   - in `options`, choose `model=holt-winters`
   - set some values, for example:
       - window=5, predict=2, alpha=0.1, beta=0.2, gamma=0.3 (make sure `alpha` `beta` and `gamma` are floating-point values, not integers
4. make sure the browser-devtools are open
5. run the query
6. verify that it did not crash
7. look at the ajax request (`_msearch`)'s request-payload, it contains two lines of json, the second json should contain the correct `alpha`,`beta` and `gamma` values.
8. change the model to `exponentially weighted`, and repeat the test
9. change the model to `holt linear`, and repeat the test
10. go to dashboards, create a panel, and create the above-mentioned query there. verify it works. save the panel, then reload the page, and verify that the query is persisted correctly, meaning `alpha`, `beta` and `gamma` contain the correct values after a page reload. test all 3 models (`holt-winters`, `holt-linear`, `exponentially-weighted`)
