### PR TITLE
Add 'Use time range' option, skip date type field validation

### DIFF
--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
@@ -19,6 +19,7 @@ describe('Settings Editor', () => {
             type: 'raw_data',
             settings: {
               size: initialSize,
+              useTimeRange: true,
             },
           },
         ],

--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -54,13 +54,24 @@ export const SettingsEditor = ({ metric, previousMetrics }: Props) => {
       )}
 
       {(metric.type === 'raw_data' || metric.type === 'raw_document') && (
-        <InlineField label="Size" {...inlineFieldProps}>
-          <Input
-            id={`ES-query-${query.refId}_metric-${metric.id}-size`}
-            onBlur={e => dispatch(changeMetricSetting(metric, 'size', e.target.value))}
-            defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
-          />
-        </InlineField>
+        <>
+          <InlineField label="Size" {...inlineFieldProps}>
+            <Input
+              id={`ES-query-${query.refId}_metric-${metric.id}-size`}
+              onBlur={e => dispatch(changeMetricSetting(metric, 'size', e.target.value))}
+              defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
+            />
+          </InlineField>
+          <InlineField label="Use time range" {...inlineFieldProps}>
+            <Switch
+              id={`ES-query-${query.refId}_metric-${metric.id}-use-time-range`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                dispatch(changeMetricSetting(metric, 'useTimeRange', e.target.checked))
+              }
+              value={metric.settings?.useTimeRange}
+            />
+          </InlineField>
+        </>
       )}
 
       {metric.type === 'cardinality' && (

--- a/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -134,6 +134,8 @@ interface RawDocument extends BaseMetricAggregation {
   type: 'raw_document';
   settings?: {
     size?: string;
+    useTimeRange: boolean;
+    customIndex: string;
   };
 }
 
@@ -141,6 +143,8 @@ interface RawData extends BaseMetricAggregation {
   type: 'raw_data';
   settings?: {
     size?: string;
+    useTimeRange: boolean;
+    customIndex: string;
   };
 }
 

--- a/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -135,7 +135,6 @@ interface RawDocument extends BaseMetricAggregation {
   settings?: {
     size?: string;
     useTimeRange: boolean;
-    customIndex: string;
   };
 }
 
@@ -144,7 +143,6 @@ interface RawData extends BaseMetricAggregation {
   settings?: {
     size?: string;
     useTimeRange: boolean;
-    customIndex: string;
   };
 }
 

--- a/src/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -183,6 +183,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
     defaults: {
       settings: {
         size: '500',
+        useTimeRange: true,
       },
     },
   },
@@ -199,6 +200,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
     defaults: {
       settings: {
         size: '500',
+        useTimeRange: true,
       },
     },
   },

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -356,13 +356,14 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
 
   testDatasource() {
     // validate that the index exist and has date field
+    // TODO this doesn't work with many indices have different date field names
     return this.getFields('date').then(
       (dateFields: any) => {
         const timeField: any = _.find(dateFields, { text: this.timeField });
         if (!timeField) {
           return {
-            status: 'error',
-            message: 'No date field named ' + this.timeField + ' found',
+            status: 'success',
+            message: 'Index OK. Note: No date field named ' + this.timeField + ' found',
           };
         }
         return { status: 'success', message: 'Index OK. Time field name OK.' };

--- a/src/specs/QueryBuilder.test.ts
+++ b/src/specs/QueryBuilder.test.ts
@@ -221,7 +221,7 @@ describe('QueryBuilder', () => {
       it('should return correct query for raw_document metric', () => {
         const target: OpenSearchQuery = {
           refId: 'A',
-          metrics: [{ type: 'raw_document', id: '1', settings: {} }],
+          metrics: [{ type: 'raw_document', id: '1', settings: { useTimeRange: true } }],
           timeField: '@timestamp',
           bucketAggs: [] as any[],
         };
@@ -263,7 +263,7 @@ describe('QueryBuilder', () => {
       it('should set query size from settings when raw_documents', () => {
         const query = builder.build({
           refId: 'A',
-          metrics: [{ type: 'raw_document', id: '1', settings: { size: '1337' } }],
+          metrics: [{ type: 'raw_document', id: '1', settings: { size: '1337', useTimeRange: true } }],
           timeField: '@timestamp',
           bucketAggs: [],
         });

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -10,7 +10,7 @@ export function trackQuery(response: DataQueryResponse, queries: OpenSearchQuery
         with_lucene_query: query.queryType === QueryType.Lucene,
         with_ppl_query: query.queryType === QueryType.PPL,
         query_type: getQueryType(query),
-        has_data: response.data.some(frame => frame.datapoints.length > 0),
+        has_data: response.data.some(frame => frame.datapoints?.length > 0),
         has_error: response.error !== undefined,
         simultaneously_sent_query_count: queries.length,
         alias: query.alias,


### PR DESCRIPTION
**What this PR does / why we need it**:
1) When we have many indices in elasticsearch with different names of `date` type (not universally @timestamp) field.
2) In some cases we have indices that doesn't contain any `date` type field.

We can't search data for this cases.

**Which issue(s) this PR fixes**:
1) This PR allows to skip validation for `date` field, and doesn't block adding new datasource.
![image](https://user-images.githubusercontent.com/16907995/230025782-69583d0b-60ad-4502-90fb-8e791dfa1e9a.png)

2) This PR also adds switch option `Use time range` for `raw_data` and `raw_document` search type. This option includes/excludes time range filter and sort in query request for `raw_data` and `raw_document` types only. Default value is enabled.
![image](https://user-images.githubusercontent.com/16907995/230026237-471bf44c-a605-4ddd-93ba-a219079e55ac.png)
