### PR TITLE
Tests for Traces Query Editor

### DIFF
--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
@@ -1,0 +1,125 @@
+import { DataSourcePluginMeta } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OpenSearchDatasource } from 'datasource';
+import React from 'react';
+import { Flavor, OpenSearchQuery } from 'types';
+import { OpenSearchProvider } from '../OpenSearchQueryContext';
+import { LuceneQueryEditor } from './LuceneQueryEditor';
+import { MetricAggregation } from '../MetricAggregationsEditor/aggregations';
+import { Histogram } from '../BucketAggregationsEditor/aggregations';
+
+const createMockQuery = (): OpenSearchQuery => ({
+  refId: '1',
+  metrics: [
+    {
+      id: '1',
+      type: 'count',
+    } as MetricAggregation,
+  ],
+  bucketAggs: [
+    {
+      id: '1',
+      type: 'histogram',
+      settings: {
+        interval: '',
+        min_doc_count: '',
+      },
+    } as Histogram,
+  ],
+  query: 'query',
+});
+const createMockOnChange = () => jest.fn();
+const createMockDatasource = () =>
+  new OpenSearchDatasource({
+    id: 123,
+    uid: '123',
+    type: '',
+    name: '',
+    meta: {} as DataSourcePluginMeta,
+    jsonData: {
+      database: '',
+      timeField: '',
+      version: '',
+      flavor: Flavor.OpenSearch,
+      timeInterval: '',
+    },
+    access: 'direct',
+  });
+
+describe('LuceneQueryEditor', () => {
+  it('renders a metric aggregations editor when the query is a metrics query', async () => {
+    const mockQuery = createMockQuery();
+    const mockOnChange = createMockOnChange();
+    const mockDatasource = createMockDatasource();
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    expect(screen.queryByText('Metric')).toBeInTheDocument();
+    expect(screen.queryByText('Traces')).not.toBeInTheDocument();
+  });
+
+  it('renders the traces query editor when traces is selected', async () => {
+    const mockQuery = createMockQuery();
+    const mockOnChange = createMockOnChange();
+    const mockDatasource = createMockDatasource();
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    expect(screen.queryByText('Metric')).toBeInTheDocument();
+    expect(screen.queryByText('Traces')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Metric'));
+
+    expect(screen.queryByText('Traces')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Traces'));
+
+    expect(mockOnChange).toBeCalledTimes(1);
+
+    expect(mockOnChange.mock.calls[0][0].luceneQueryType).toBe('Traces');
+  });
+
+  it('calls onChange to unset traces if the user resets back to metric', async () => {
+    const mockQuery = createMockQuery();
+    const mockOnChange = createMockOnChange();
+    const mockDatasource = createMockDatasource();
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    expect(screen.queryByText('Metric')).toBeInTheDocument();
+    expect(screen.queryByText('Traces')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Metric'));
+
+    expect(screen.queryByText('Traces')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Traces'));
+
+    expect(mockOnChange).toBeCalledTimes(1);
+
+    expect(mockOnChange.mock.calls[0][0].luceneQueryType).toBe('Traces');
+
+    await userEvent.click(screen.getByText('Traces'));
+
+    expect(screen.queryByText('Metric')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Metric'));
+
+    expect(mockOnChange).toBeCalledTimes(2);
+
+    expect(mockOnChange.mock.calls[1][0].luceneQueryType).toBe('Metric');
+  });
+});

--- a/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.test.tsx
+++ b/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { OpenSearchQuery } from 'types';
+import { getDefaultTraceListQuery, getSingleTraceQuery } from './traceQueries';
+import { TracesQueryEditor } from './TracesQueryEditor';
+
+describe('TracesQueryEditor', () => {
+  it('calls onChange with either a single trace id query or a trace list query depending on if a traceId is typed in the input field', async () => {
+    const mockOnChange = jest.fn();
+    const mockQuery: OpenSearchQuery = { refId: '1' };
+
+    render(<TracesQueryEditor onChange={mockOnChange} query={mockQuery} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole('textbox'), 'someTraceId');
+
+    await userEvent.tab();
+
+    expect(mockOnChange.mock.calls[0][0]).toMatchObject(getSingleTraceQuery('someTraceId'));
+
+    await userEvent.clear(screen.getByRole('textbox'));
+
+    await userEvent.tab();
+
+    expect(mockOnChange.mock.calls[1][0]).toMatchObject(getDefaultTraceListQuery());
+  });
+});

--- a/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.test.tsx
+++ b/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { OpenSearchQuery } from 'types';

--- a/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.tsx
+++ b/src/components/QueryEditor/TracesQueryEditor/TracesQueryEditor.tsx
@@ -12,9 +12,16 @@ export const TracesQueryEditor = (props: Props) => {
   const currentTrace = getTraceIdFromQuery(props.query);
   return (
     <InlineFieldRow>
-      <InlineField label="Trace Id" labelWidth={17} tooltip={'Optional, defaults to all traces'} grow>
+      <InlineField
+        label="Trace Id"
+        htmlFor="trace-input"
+        labelWidth={17}
+        tooltip={'Optional, defaults to all traces'}
+        grow
+      >
         <Input
-          placeholder="traceId"
+          id="trace-input"
+          placeholder="trace id"
           onBlur={e => {
             const traceId = e.target.value;
             const newQuery = traceId ? getSingleTraceQuery(traceId) : getDefaultTraceListQuery();

--- a/src/components/QueryEditor/TracesQueryEditor/formatTraces.ts
+++ b/src/components/QueryEditor/TracesQueryEditor/formatTraces.ts
@@ -37,7 +37,7 @@ export const createTracesDataFrame = (targets, response): DataQueryResponse => {
       { name: 'Trace Id', type: FieldType.string, values: traceIds },
       { name: 'Trace Group', type: FieldType.string, values: traceGroups },
       { name: 'Latency (ms)', type: FieldType.number, values: latency },
-      // { name: 'Percentile in trace group', type: FieldType.string, values: ['todo'] },
+      // TODO: { name: 'Percentile in trace group', type: FieldType.string, values: ['todo'] },
       { name: 'Error Count', type: FieldType.number, values: errors },
       { name: 'Last Updated', type: FieldType.time, values: lastUpdated },
     ],

--- a/src/components/QueryEditor/TracesQueryEditor/traceQueries.ts
+++ b/src/components/QueryEditor/TracesQueryEditor/traceQueries.ts
@@ -26,7 +26,7 @@ export const getDefaultTraceListQuery = (): Omit<OpenSearchQuery, 'refId'> => {
           // within each of those buckets we create further aggregations based on what's in that bucket
           aggs: {
             // one of those aggregations is a metric we call latency which is based on the durationInNanos
-            // this script was taken directly from the network tab in the traces dashboarhd
+            // this script was taken directly from the network tab in the traces dashboard
             latency: {
               max: {
                 script: {


### PR DESCRIPTION
Based on a work in progress branch: https://github.com/grafana/opensearch-datasource/pull/122

Adds some basic tests for our work in progress branch to support Trace Analytics:
- [x] tests the new top level query editor
- [x] tests the new traces query editor which sets the query to be for either a single query or a traces view list query

Once this is merged I think we can close https://github.com/grafana/opensearch-datasource/issues/107

