### PR TITLE
Apply default version to a serverless config

### DIFF
--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -9,7 +9,7 @@ export const coerceOptions = (
 ): DataSourceSettings<OpenSearchOptions, {}> => {
   let version = valid(options.jsonData.version);
   let flavor = options.jsonData.flavor;
-  if (!config.featureToggles.opensearchDetectVersion) {
+  if (!config.featureToggles.opensearchDetectVersion || options.jsonData.serverless) {
     flavor = flavor || Flavor.OpenSearch;
     version =
       version ||


### PR DESCRIPTION
An edge case that I didn't catch while developing. It can be reproduced by using the aws provisioner app to provision a serverless OpenSearch version (we have one in `US East (Ohio)`) and opening and trying to save the config. Before this fix, we would get the `No version set` error, but this applys a version when the config editor is open (which is what it did before the detecting version change). We don't really have any tests for this code path at the moment, but I can whip together a `coerceOptions` test if we think we need one.