### PR TITLE
Fix backend pipeline aggregation query parsing and data frame building

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -151,6 +151,7 @@ func (h *luceneHandler) processQuery(q *Query) error {
 }
 
 func getPipelineAggField(m *MetricAgg) string {
+	// From https://github.com/grafana/grafana/pull/60337
 	// In frontend we are using Field as pipelineAggField
 	// There might be historical reason why in backend we were using PipelineAggregate as pipelineAggField
 	// So for now let's check Field first and then PipelineAggregate to ensure that we are not breaking anything

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -117,16 +117,17 @@ func (h *luceneHandler) processQuery(q *Query) error {
 					continue
 				}
 			} else {
-				if _, err := strconv.Atoi(m.PipelineAggregate); err == nil {
+				pipelineAggField := getPipelineAggField(m)
+				if _, err := strconv.Atoi(pipelineAggField); err == nil {
 					var appliedAgg *MetricAgg
 					for _, pipelineMetric := range q.Metrics {
-						if pipelineMetric.ID == m.PipelineAggregate {
+						if pipelineMetric.ID == pipelineAggField {
 							appliedAgg = pipelineMetric
 							break
 						}
 					}
 					if appliedAgg != nil {
-						bucketPath := m.PipelineAggregate
+						bucketPath := pipelineAggField
 						if appliedAgg.Type == countType {
 							bucketPath = "_count"
 						}
@@ -147,6 +148,19 @@ func (h *luceneHandler) processQuery(q *Query) error {
 	}
 
 	return nil
+}
+
+func getPipelineAggField(m *MetricAgg) string {
+	// In frontend we are using Field as pipelineAggField
+	// There might be historical reason why in backend we were using PipelineAggregate as pipelineAggField
+	// So for now let's check Field first and then PipelineAggregate to ensure that we are not breaking anything
+	// TODO: Investigate, if we can remove check for PipelineAggregate
+	pipelineAggField := m.Field
+
+	if pipelineAggField == "" {
+		pipelineAggField = m.PipelineAggregate
+	}
+	return pipelineAggField
 }
 
 func (h *luceneHandler) executeQueries() (*backend.QueryDataResponse, error) {

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -293,7 +293,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 		default:
 			buckets := esAgg.Get("buckets").MustArray()
 			tags := make(map[string]string, len(props))
-			timeVector := make([]time.Time, 0, len(buckets))
+			timeVector := make([]*time.Time, 0, len(buckets))
 			values := make([]*float64, 0, len(buckets))
 
 			for k, v := range props {
@@ -319,7 +319,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				} else {
 					value = castToFloat(bucket.GetPath(metric.ID, "value"))
 				}
-				timeVector = append(timeVector, timeValue)
+				timeVector = append(timeVector, &timeValue)
 				values = append(values, value)
 			}
 			*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, tags, values)}...)
@@ -328,7 +328,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 	return nil
 }
 
-func newTimeSeriesFrame(timeData []time.Time, tags map[string]string, values []*float64) *data.Frame {
+func newTimeSeriesFrame(timeData []*time.Time, tags map[string]string, values []*float64) *data.Frame {
 	frame := data.NewFrame("",
 		data.NewField(data.TimeSeriesTimeFieldName, nil, timeData),
 		data.NewField(data.TimeSeriesValueFieldName, tags, values))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,3 +29,5 @@ func NullFloatToNullableTime(ts null.Float) *time.Time {
 	timestamp := time.UnixMilli(int64(ts.Float64)).UTC()
 	return &timestamp
 }
+
+func Pointer[T any](v T) *T { return &v }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
* Queries weren't being parsed correctly for the pipeline aggregation field. The same change as this one in Elasticsearch datasource was applied https://github.com/grafana/grafana/pull/60337
* The time vectors are now appended instead of created with nil placeholders the same length as the response buckets. If an entry was missing, then it left the time for that field “nil”. This would run into the following server-side expression error: https://github.com/grafana/grafana/blob/33ba5310ab82c615b158535d869119a8f3c85224/pkg/expr/mathexp/type_series.go#L93-L92 (This should be the same behavior as currently in the Elasticsearch datasource, by the way)

**Which issue(s) this PR fixes**:

Fixes #154

**Special notes**
I still notice an issue with the time series labels are being duplicated. I also observed this on Elasticsearch on play.grafana.org. I couldn't find the source yet but if it's still present after this is reviewed, I'll create an issue. 
![Screenshot 2023-05-12 at 16 42 45](https://github.com/grafana/opensearch-datasource/assets/4163034/ee190cfb-9818-4239-98af-e9fadf62d7af)


