### PR TITLE
Add query tracking for traces

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,6 +1,7 @@
 import { DataQueryResponse } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { OpenSearchQuery, QueryType } from 'types';
+import { getTraceIdFromLuceneQueryString } from 'traces/queryTraces';
+import { LuceneQueryType, OpenSearchQuery, QueryType } from 'types';
 
 export function trackQuery(response: DataQueryResponse, queries: OpenSearchQuery[], app: string): void {
   for (const query of queries) {
@@ -24,6 +25,13 @@ export function trackQuery(response: DataQueryResponse, queries: OpenSearchQuery
 function getQueryType(query: OpenSearchQuery) {
   if (query.isLogsQuery) {
     return 'logs';
+  }
+
+  if (query.luceneQueryType === LuceneQueryType.Traces) {
+    if (getTraceIdFromLuceneQueryString(query.query)) {
+      return 'traceDetails';
+    }
+    return 'traces';
   }
 
   // PPL queries are a bit special, as they can be either raw_data or metric, depending on the format

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,6 +1,5 @@
 import { DataQueryResponse } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { getTraceIdFromLuceneQueryString } from 'traces/queryTraces';
 import { LuceneQueryType, OpenSearchQuery, QueryType } from 'types';
 
 export function trackQuery(response: DataQueryResponse, queries: OpenSearchQuery[], app: string): void {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -28,9 +28,6 @@ function getQueryType(query: OpenSearchQuery) {
   }
 
   if (query.luceneQueryType === LuceneQueryType.Traces) {
-    if (getTraceIdFromLuceneQueryString(query.query)) {
-      return 'traceDetails';
-    }
     return 'traces';
   }
 


### PR DESCRIPTION
Adding tracking for traces. We will be able to add them to our plugin query tracking in [ops.grafana-ops.net](https://ops.grafana-ops.net/d/OpensearchQueryUsage/opensearch-queries-usage-tracking?orgId=1). I didn't separate queries for trace list and for trace details, just returning 'traces'. Does separating them make more sense? 

