### PR TITLE
Backend: Set field.Config.DisplayNameFromDS instead of frame.name

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -495,8 +495,7 @@ func (rp *responseParser) nameSeries(frames *data.Frames, target *Query) {
 			if valueField.Config == nil {
 				valueField.Config = &data.FieldConfig{}
 			}
-			fluffles := rp.getSeriesName(series, target, metricTypeCount)
-			valueField.Config.DisplayNameFromDS = fluffles
+			valueField.Config.DisplayNameFromDS = rp.getSeriesName(series, target, metricTypeCount)
 		}
 	}
 }

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -86,7 +86,7 @@ func (rp *responseParser) getTimeSeries() (*backend.QueryDataResponse, error) {
 		if err != nil {
 			return nil, err
 		}
-		rp.nameSeries(queryRes.Frames, target)
+		rp.nameSeries(&queryRes.Frames, target)
 		rp.trimDatapoints(&queryRes.Frames, target)
 
 		// if len(table.Rows) > 0 {
@@ -184,14 +184,14 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 		switch metric.Type {
 		case countType:
 			buckets := esAgg.Get("buckets").MustArray()
-			tags := make(map[string]string, len(props))
+			labels := make(map[string]string, len(props))
 			timeVector := make([]*time.Time, 0, len(buckets))
 			values := make([]*float64, 0, len(buckets))
 
 			for k, v := range props {
-				tags[k] = v
+				labels[k] = v
 			}
-			tags["metric"] = countType
+			labels["metric"] = countType
 
 			for _, v := range buckets {
 				bucket := utils.NewJsonFromAny(v)
@@ -202,7 +202,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				timeVector = append(timeVector, &timeValue)
 				values = append(values, castToFloat(bucket.Get("doc_count")))
 			}
-			*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, tags, values)}...)
+			*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, labels, values)}...)
 
 		case percentilesType:
 			buckets := esAgg.Get("buckets").MustArray()
@@ -219,15 +219,15 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			}
 			sort.Strings(percentileKeys)
 			for _, percentileName := range percentileKeys {
-				tags := make(map[string]string, len(props))
+				labels := make(map[string]string, len(props))
 				timeVector := make([]*time.Time, 0, len(buckets))
 				values := make([]*float64, 0, len(buckets))
 
 				for k, v := range props {
-					tags[k] = v
+					labels[k] = v
 				}
-				tags["metric"] = "p" + percentileName
-				tags["field"] = metric.Field
+				labels["metric"] = "p" + percentileName
+				labels["field"] = metric.Field
 
 				for _, v := range buckets {
 					bucket := utils.NewJsonFromAny(v)
@@ -238,7 +238,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 					timeVector = append(timeVector, &timeValue)
 					values = append(values, castToFloat(bucket.GetPath(metric.ID, "values", percentileName)))
 				}
-				*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, tags, values)}...)
+				*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, labels, values)}...)
 			}
 		case extendedStatsType:
 			buckets := esAgg.Get("buckets").MustArray()
@@ -249,7 +249,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			}
 			sort.Strings(metaKeys)
 			for _, statName := range metaKeys {
-				tags := make(map[string]string, len(props))
+				labels := make(map[string]string, len(props))
 				timeVector := make([]*time.Time, 0, len(buckets))
 				values := make([]*float64, 0, len(buckets))
 				v := meta[statName]
@@ -258,10 +258,10 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				}
 
 				for k, v := range props {
-					tags[k] = v
+					labels[k] = v
 				}
-				tags["metric"] = statName
-				tags["field"] = metric.Field
+				labels["metric"] = statName
+				labels["field"] = metric.Field
 
 				for _, v := range buckets {
 					bucket := utils.NewJsonFromAny(v)
@@ -281,7 +281,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 					timeVector = append(timeVector, &timeValue)
 					values = append(values, value)
 				}
-				*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, tags, values)}...)
+				*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, labels, values)}...)
 			}
 		default:
 			buckets := esAgg.Get("buckets").MustArray()
@@ -321,10 +321,10 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 	return nil
 }
 
-func newTimeSeriesFrame(timeData []*time.Time, tags map[string]string, values []*float64) *data.Frame {
+func newTimeSeriesFrame(timeData []*time.Time, labels map[string]string, values []*float64) *data.Frame {
 	frame := data.NewFrame("",
 		data.NewField(data.TimeSeriesTimeFieldName, nil, timeData),
-		data.NewField(data.TimeSeriesValueFieldName, tags, values))
+		data.NewField(data.TimeSeriesValueFieldName, labels, values))
 	frame.Meta = &data.FrameMeta{
 		Type: data.FrameTypeTimeSeriesMulti,
 	}
@@ -472,9 +472,9 @@ func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
 	}
 }
 
-func (rp *responseParser) nameSeries(frames data.Frames, target *Query) {
+func (rp *responseParser) nameSeries(frames *data.Frames, target *Query) {
 	set := make(map[string]string)
-	for _, v := range frames {
+	for _, v := range *frames {
 		if len(v.Fields) > 1 {
 			valueField := v.Fields[1]
 			if metricType, exists := valueField.Labels["metric"]; exists {
@@ -485,7 +485,7 @@ func (rp *responseParser) nameSeries(frames data.Frames, target *Query) {
 		}
 	}
 	metricTypeCount := len(set)
-	for _, series := range frames {
+	for _, series := range *frames {
 		if series.Meta != nil && series.Meta.Type == data.FrameTypeTimeSeriesMulti {
 			// if it is a time-series-multi, it means it has two columns, one is "time",
 			// another is "number"

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -188,20 +188,21 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			timeVector := make([]*time.Time, 0, len(buckets))
 			values := make([]*float64, 0, len(buckets))
 
-			for k, v := range props {
-				labels[k] = v
-			}
-			labels["metric"] = countType
-
 			for _, v := range buckets {
 				bucket := utils.NewJsonFromAny(v)
 				timeValue, err := getAsTime(bucket.Get("key"))
 				if err != nil {
 					return err
 				}
+
 				timeVector = append(timeVector, &timeValue)
 				values = append(values, castToFloat(bucket.Get("doc_count")))
 			}
+
+			for k, v := range props {
+				labels[k] = v
+			}
+			labels["metric"] = countType
 			*frames = append(*frames, data.Frames{newTimeSeriesFrame(timeVector, labels, values)}...)
 
 		case percentilesType:
@@ -249,13 +250,14 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			}
 			sort.Strings(metaKeys)
 			for _, statName := range metaKeys {
-				labels := make(map[string]string, len(props))
-				timeVector := make([]*time.Time, 0, len(buckets))
-				values := make([]*float64, 0, len(buckets))
 				v := meta[statName]
 				if enabled, ok := v.(bool); !ok || !enabled {
 					continue
 				}
+
+				labels := make(map[string]string, len(props))
+				timeVector := make([]*time.Time, 0, len(buckets))
+				values := make([]*float64, 0, len(buckets))
 
 				for k, v := range props {
 					labels[k] = v

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -495,7 +495,8 @@ func (rp *responseParser) nameSeries(frames *data.Frames, target *Query) {
 			if valueField.Config == nil {
 				valueField.Config = &data.FieldConfig{}
 			}
-			valueField.Config.DisplayNameFromDS = rp.getSeriesName(series, target, metricTypeCount)
+			fluffles := rp.getSeriesName(series, target, metricTypeCount)
+			valueField.Config.DisplayNameFromDS = fluffles
 		}
 	}
 }
@@ -569,7 +570,7 @@ func (rp *responseParser) getSeriesName(series *data.Frame, target *Query, metri
 			found := false
 			for _, metric := range target.Metrics {
 				if metric.ID == field {
-					metricName += " " + describeMetric(metric.Type, field)
+					metricName += " " + describeMetric(metric.Type, metric.Field)
 					found = true
 				}
 			}

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -53,9 +53,9 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.NotNil(t, queryRes)
 		assert.Len(t, queryRes.Frames, 1)
 		series := queryRes.Frames[0]
-		assert.Equal(t, "Count", series.Name)
 
 		require.Len(t, series.Fields, 2)
+		assert.Equal(t, "Count", series.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, series.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *series.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *series.Fields[0].At(1).(*time.Time))
@@ -105,8 +105,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.Len(t, queryRes.Frames, 2)
 
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "Count", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "Count", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
@@ -115,8 +115,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 15, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "Average value", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "Average value", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
@@ -164,17 +164,25 @@ func Test_ResponseParser_test(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, responseForA.Frames, 2)
 
-		expectedFrame1 := data.NewFrame("Average rating",
+		expectedFrame1 := data.NewFrame("",
 			data.NewField("Time", nil, []*time.Time{utils.Pointer(time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC)), utils.Pointer(time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC))}),
-			data.NewField("Value", nil, []*float64{utils.Pointer(6.34), utils.Pointer(6.13)}),
+			data.NewField(
+				"Value",
+				nil,
+				[]*float64{utils.Pointer(6.34), utils.Pointer(6.13)},
+			).SetConfig(&data.FieldConfig{DisplayNameFromDS: "Average rating"}),
 		).SetMeta(&data.FrameMeta{Type: "timeseries-multi"})
 		if diff := cmp.Diff(expectedFrame1, responseForA.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
 
-		expectedFrame2 := data.NewFrame("Derivative Average 1",
+		expectedFrame2 := data.NewFrame("",
 			data.NewField("Time", nil, []*time.Time{utils.Pointer(time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC))}),
-			data.NewField("Value", nil, []*float64{utils.Pointer(-0.21)}),
+			data.NewField(
+				"Value",
+				nil,
+				[]*float64{utils.Pointer(-0.21)},
+			).SetConfig(&data.FieldConfig{DisplayNameFromDS: "Derivative Average 1"}),
 		).SetMeta(&data.FrameMeta{Type: "timeseries-multi"})
 		if diff := cmp.Diff(expectedFrame2, responseForA.Frames[1], data.FrameTestCompareOptions()...); diff != "" {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
@@ -228,7 +236,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.NotNil(t, queryRes)
 		assert.Len(t, queryRes.Frames, 2)
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "server1", seriesOne.Name)
+		assert.Equal(t, "server1", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesOne.Fields, 2)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
@@ -238,7 +246,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 3, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "server2", seriesTwo.Name)
+		assert.Equal(t, "server2", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesTwo.Fields, 2)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
@@ -301,7 +309,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.NotNil(t, queryRes)
 		assert.Len(t, queryRes.Frames, 4)
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "server1 Count", seriesOne.Name)
+		assert.Equal(t, "server1 Count", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesOne.Fields, 2)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.EqualValues(t, 1, *seriesOne.Fields[1].At(0).(*float64))
@@ -311,7 +319,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "server1 Average @value", seriesTwo.Name)
+		assert.Equal(t, "server1 Average @value", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesTwo.Fields, 2)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
@@ -321,7 +329,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 12, *seriesTwo.Fields[1].At(1).(*float64))
 
 		seriesThree := queryRes.Frames[2]
-		assert.Equal(t, "server2 Count", seriesThree.Name)
+		assert.Equal(t, "server2 Count", seriesThree.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesThree.Fields, 2)
 		require.Equal(t, 2, seriesThree.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesThree.Fields[0].At(0).(*time.Time))
@@ -331,7 +339,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 3, *seriesThree.Fields[1].At(1).(*float64))
 
 		seriesFour := queryRes.Frames[3]
-		assert.Equal(t, "server2 Average @value", seriesFour.Name)
+		assert.Equal(t, "server2 Average @value", seriesFour.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesFour.Fields, 2)
 		require.Equal(t, 2, seriesFour.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesFour.Fields[0].At(0).(*time.Time))
@@ -381,8 +389,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.NotNil(t, queryRes)
 		assert.Len(t, queryRes.Frames, 2)
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "p75", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "p75", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
@@ -391,8 +399,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 2.3, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "p90", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "p90", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
@@ -467,31 +475,31 @@ func Test_ResponseParser_test(t *testing.T) {
 		require.Len(t, queryRes.Frames, 6)
 
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "server1 Max", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "server1 Max", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesOne.Fields[1].Len())
 		assert.EqualValues(t, 10.2, *seriesOne.Fields[1].At(0).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "server1 Std Dev Lower", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "server1 Std Dev Lower", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesTwo.Fields[1].Len())
 		assert.EqualValues(t, -2, *seriesTwo.Fields[1].At(0).(*float64))
 
 		seriesThree := queryRes.Frames[2]
-		assert.Equal(t, "server1 Std Dev Upper", seriesThree.Name)
 		require.Len(t, seriesThree.Fields, 2)
+		assert.Equal(t, "server1 Std Dev Upper", seriesThree.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesThree.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesThree.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesThree.Fields[1].Len())
 		assert.EqualValues(t, 3, *seriesThree.Fields[1].At(0).(*float64))
 
 		seriesFour := queryRes.Frames[3]
-		assert.Equal(t, "server2 Max", seriesFour.Name)
+		assert.Equal(t, "server2 Max", seriesFour.Fields[1].Config.DisplayNameFromDS)
 		require.Len(t, seriesFour.Fields, 2)
 		require.Equal(t, 1, seriesFour.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesFour.Fields[0].At(0).(*time.Time))
@@ -499,16 +507,16 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 15.5, *seriesFour.Fields[1].At(0).(*float64))
 
 		seriesFive := queryRes.Frames[4]
-		assert.Equal(t, "server2 Std Dev Lower", seriesFive.Name)
 		require.Len(t, seriesFive.Fields, 2)
+		assert.Equal(t, "server2 Std Dev Lower", seriesFive.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesFive.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesFive.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesFive.Fields[1].Len())
 		assert.EqualValues(t, -1, *seriesFive.Fields[1].At(0).(*float64))
 
 		seriesSix := queryRes.Frames[5]
-		assert.Equal(t, "server2 Std Dev Upper", seriesSix.Name)
 		require.Len(t, seriesSix.Fields, 2)
+		assert.Equal(t, "server2 Std Dev Upper", seriesSix.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesSix.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesSix.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesSix.Fields[1].Len())
@@ -571,8 +579,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.Len(t, queryRes.Frames, 3)
 
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "server1 Count and {{not_exist}} server1", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "server1 Count and {{not_exist}} server1", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
@@ -581,8 +589,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 3, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "server2 Count and {{not_exist}} server2", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "server2 Count and {{not_exist}} server2", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
@@ -591,8 +599,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 8, *seriesTwo.Fields[1].At(1).(*float64))
 
 		seriesThree := queryRes.Frames[2]
-		assert.Equal(t, "0 Count and {{not_exist}} 0", seriesThree.Name)
 		require.Len(t, seriesThree.Fields, 2)
+		assert.Equal(t, "0 Count and {{not_exist}} 0", seriesThree.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesThree.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesThree.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesThree.Fields[0].At(1).(*time.Time))
@@ -698,8 +706,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.Len(t, queryRes.Frames, 2)
 
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "@metric:cpu", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "@metric:cpu", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
@@ -708,8 +716,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 3, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "@metric:logins.count", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "@metric:logins.count", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
@@ -771,16 +779,16 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.Len(t, queryRes.Frames, 2)
 
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "Average", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "Average", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesOne.Fields[1].Len())
 		assert.EqualValues(t, 22, *seriesOne.Fields[1].At(0).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "Count", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "Count", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 1, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		require.Equal(t, 1, seriesTwo.Fields[1].Len())
@@ -950,8 +958,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.NotNil(t, queryRes)
 		assert.Len(t, queryRes.Frames, 3)
 		seriesOne := queryRes.Frames[0]
-		assert.Equal(t, "Sum @value", seriesOne.Name)
 		require.Len(t, seriesOne.Fields, 2)
+		assert.Equal(t, "Sum @value", seriesOne.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesOne.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
@@ -960,8 +968,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 3, *seriesOne.Fields[1].At(1).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
-		assert.Equal(t, "Max @value", seriesTwo.Name)
 		require.Len(t, seriesTwo.Fields, 2)
+		assert.Equal(t, "Max @value", seriesTwo.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesTwo.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
@@ -970,8 +978,8 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 4, *seriesTwo.Fields[1].At(1).(*float64))
 
 		seriesThree := queryRes.Frames[2]
-		assert.Equal(t, "Sum @value * Max @value", seriesThree.Name)
 		require.Len(t, seriesThree.Fields, 2)
+		assert.Equal(t, "Sum @value * Max @value", seriesThree.Fields[1].Config.DisplayNameFromDS)
 		require.Equal(t, 2, seriesThree.Fields[0].Len())
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 1, 0, time.UTC), *seriesThree.Fields[0].At(0).(*time.Time))
 		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesThree.Fields[0].At(1).(*time.Time))

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -182,7 +182,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				"Value",
 				nil,
 				[]*float64{utils.Pointer(-0.21)},
-			).SetConfig(&data.FieldConfig{DisplayNameFromDS: "Derivative Average 1"}),
+			).SetConfig(&data.FieldConfig{DisplayNameFromDS: "Derivative Average rating"}),
 		).SetMeta(&data.FrameMeta{Type: "timeseries-multi"})
 		if diff := cmp.Diff(expectedFrame2, responseForA.Frames[1], data.FrameTestCompareOptions()...); diff != "" {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

The time series legend when displayed from a backend query (alerting, expressions) was duplicating.

This PR applies a [change from Elasticsearch](https://github.com/grafana/grafana/pull/60169) to generate field names for the value field of time series frames. 

It applies the fixes from [another PR in Elasticsearch ](https://github.com/grafana/grafana/pull/66039) to move from putting the frame name in `frame.name` to `field.Config.DisplayNameFromDS` and getting the metric name from `metric.Field` instead of `metric.ID`. 

The screenshot illustrates the same label for a backend flow and frontend flow. 
![Screenshot 2023-05-22 at 18 48 19](https://github.com/grafana/opensearch-datasource/assets/4163034/7aa3b41a-a65f-4c24-8f15-db13f5d7b342)

Thank you @idastambuk for pointing out where to set the legend.

**Which issue(s) this PR fixes**:

Fixes #178
