### PR TITLE
Backend: Convert tables to data frames

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -502,13 +502,12 @@ func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
 	}
 
 	for _, f := range *frames {
-		for _, field := range f.Fields {
-			if field.Len() > trimEdges*2 {
-				for i := 0; i < field.Len(); i++ {
-					if i < trimEdges || i > field.Len()-trimEdges {
-						field.Delete(i)
-					}
-				}
+		if f.Rows() > trimEdges*2 {
+			for i := 0; i < trimEdges; i++ {
+				f.DeleteRow(i)
+			}
+			for i := f.Rows() - trimEdges; i < f.Rows(); i++ {
+				f.DeleteRow(i)
 			}
 		}
 	}

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -11,9 +11,7 @@ import (
 	simplejson "github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/opensearch-datasource/pkg/null"
 	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
-	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/grafana/opensearch-datasource/pkg/utils"
 )
 
@@ -76,29 +74,20 @@ func (rp *responseParser) getTimeSeries() (*backend.QueryDataResponse, error) {
 		queryRes := backend.DataResponse{
 			Frames: data.Frames{},
 		}
-		// queryRes.Meta = debugInfo
 		props := make(map[string]string)
-		table := tsdb.Table{
-			Columns: make([]tsdb.TableColumn, 0),
-			Rows:    make([]tsdb.RowValues, 0),
-		}
-		err := rp.processBuckets(res.Aggregations, target, &queryRes.Frames, &table, props, 0)
+		err := rp.processBuckets(res.Aggregations, target, &queryRes, props, 0)
 		if err != nil {
 			return nil, err
 		}
-		rp.nameSeries(&queryRes.Frames, target)
+		rp.nameFields(&queryRes.Frames, target)
 		rp.trimDatapoints(&queryRes.Frames, target)
-
-		// if len(table.Rows) > 0 {
-		// 	queryRes.Tables = append(queryRes.Tables, &table)
-		// }
 
 		result.Responses[target.RefID] = queryRes
 	}
 	return result, nil
 }
 
-func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Query, series *data.Frames, table *tsdb.Table, props map[string]string, depth int) error {
+func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Query, queryResult *backend.DataResponse, props map[string]string, depth int) error {
 	var err error
 	maxDepth := len(target.BucketAggs) - 1
 
@@ -117,9 +106,9 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 
 		if depth == maxDepth {
 			if aggDef.Type == dateHistType {
-				err = rp.processMetrics(esAgg, target, series, props)
+				err = rp.processMetrics(esAgg, target, &queryResult.Frames, props)
 			} else {
-				err = rp.processAggregationDocs(esAgg, aggDef, target, table, props)
+				err = rp.processAggregationDocs(esAgg, aggDef, target, queryResult, props)
 			}
 			if err != nil {
 				return err
@@ -142,7 +131,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 				if key, err := bucket.Get("key_as_string").String(); err == nil {
 					newProps[aggDef.Field] = key
 				}
-				err = rp.processBuckets(bucket.MustMap(), target, series, table, newProps, depth+1)
+				err = rp.processBuckets(bucket.MustMap(), target, queryResult, newProps, depth+1)
 				if err != nil {
 					return err
 				}
@@ -165,7 +154,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 
 				newProps["filter"] = bucketKey
 
-				err = rp.processBuckets(bucket.MustMap(), target, series, table, newProps, depth+1)
+				err = rp.processBuckets(bucket.MustMap(), target, queryResult, newProps, depth+1)
 				if err != nil {
 					return err
 				}
@@ -343,52 +332,84 @@ func getAsTime(j *simplejson.Json) (time.Time, error) {
 	return time.UnixMilli(int64(number)).UTC(), nil
 }
 
-func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef *BucketAgg, target *Query, table *tsdb.Table, props map[string]string) error {
+func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef *BucketAgg, target *Query, queryResult *backend.DataResponse, props map[string]string) error {
 	propKeys := make([]string, 0)
 	for k := range props {
 		propKeys = append(propKeys, k)
 	}
 	sort.Strings(propKeys)
+	frames := data.Frames{}
+	var fields []*data.Field
 
-	if len(table.Columns) == 0 {
+	if queryResult.Frames == nil {
 		for _, propKey := range propKeys {
-			table.Columns = append(table.Columns, tsdb.TableColumn{Text: propKey})
+			fields = append(fields, data.NewField(propKey, nil, []*string{}))
 		}
-		table.Columns = append(table.Columns, tsdb.TableColumn{Text: aggDef.Field})
 	}
 
-	addMetricValue := func(values *tsdb.RowValues, metricName string, value null.Float) {
-		found := false
-		for _, c := range table.Columns {
-			if c.Text == metricName {
-				found = true
+	addMetricValue := func(values []interface{}, metricName string, value *float64) {
+		index := -1
+		for i, f := range fields {
+			if f.Name == metricName {
+				index = i
 				break
 			}
 		}
-		if !found {
-			table.Columns = append(table.Columns, tsdb.TableColumn{Text: metricName})
+		var field data.Field
+		if index == -1 {
+			field = *data.NewField(metricName, nil, []*float64{})
+			fields = append(fields, &field)
+		} else {
+			field = *fields[index]
 		}
-		*values = append(*values, value)
+		field.Append(value)
 	}
 
 	for _, v := range esAgg.Get("buckets").MustArray() {
 		bucket := utils.NewJsonFromAny(v)
-		values := make(tsdb.RowValues, 0)
+		var values []interface{}
 
-		for _, propKey := range propKeys {
-			values = append(values, props[propKey])
+		found := false
+		for _, e := range fields {
+			for _, propKey := range propKeys {
+				if e.Name == propKey {
+					e.Append(props[propKey])
+				}
+			}
+			if e.Name == aggDef.Field {
+				found = true
+				if key, err := bucket.Get("key").String(); err == nil {
+					e.Append(&key)
+				} else {
+					f, err := bucket.Get("key").Float64()
+					if err != nil {
+						return err
+					}
+					e.Append(&f)
+				}
+			}
 		}
 
-		if key, err := bucket.Get("key").String(); err == nil {
-			values = append(values, key)
-		} else {
-			values = append(values, castToNullFloat(bucket.Get("key")))
+		if !found {
+			var aggDefField *data.Field
+			if key, err := bucket.Get("key").String(); err == nil {
+				aggDefField = extractDataField(aggDef.Field, &key)
+				aggDefField.Append(&key)
+			} else {
+				f, err := bucket.Get("key").Float64()
+				if err != nil {
+					return err
+				}
+				aggDefField = extractDataField(aggDef.Field, &f)
+				aggDefField.Append(&f)
+			}
+			fields = append(fields, aggDefField)
 		}
 
 		for _, metric := range target.Metrics {
 			switch metric.Type {
 			case countType:
-				addMetricValue(&values, rp.getMetricName(metric.Type), castToNullFloat(bucket.Get("doc_count")))
+				addMetricValue(values, rp.getMetricName(metric.Type), castToFloat(bucket.Get("doc_count")))
 			case extendedStatsType:
 				metaKeys := make([]string, 0)
 				meta := metric.Meta.MustMap()
@@ -402,17 +423,17 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 						continue
 					}
 
-					var value null.Float
+					var value *float64
 					switch statName {
 					case "std_deviation_bounds_upper":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
 					case "std_deviation_bounds_lower":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
 					default:
-						value = castToNullFloat(bucket.GetPath(metric.ID, statName))
+						value = castToFloat(bucket.GetPath(metric.ID, statName))
 					}
 
-					addMetricValue(&values, rp.getMetricName(metric.Type), value)
+					addMetricValue(values, rp.getMetricName(metric.Type), value)
 					break
 				}
 			default:
@@ -433,14 +454,33 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 					}
 				}
 
-				addMetricValue(&values, metricName, castToNullFloat(bucket.GetPath(metric.ID, "value")))
+				addMetricValue(values, metricName, castToFloat(bucket.GetPath(metric.ID, "value")))
 			}
 		}
 
-		table.Rows = append(table.Rows, values)
+		var dataFields []*data.Field
+		dataFields = append(dataFields, fields...)
+
+		frames = data.Frames{
+			&data.Frame{
+				Fields: dataFields,
+			},
+		}
 	}
 
+	queryResult.Frames = frames
 	return nil
+}
+
+func extractDataField(name string, v interface{}) *data.Field {
+	switch v.(type) {
+	case *string:
+		return data.NewField(name, nil, []*string{})
+	case *float64:
+		return data.NewField(name, nil, []*float64{})
+	default:
+		return &data.Field{}
+	}
 }
 
 func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
@@ -462,26 +502,25 @@ func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
 	}
 
 	for _, f := range *frames {
-		if f.Rows() > trimEdges*2 {
-			for i := 0; i < trimEdges; i++ {
-				f.DeleteRow(i)
+		for _, field := range f.Fields {
+			if field.Len() > trimEdges*2 {
+				for i := 0; i < field.Len(); i++ {
+					if i < trimEdges || i > field.Len()-trimEdges {
+						field.Delete(i)
+					}
+				}
 			}
-			for i := f.Rows() - trimEdges; i < f.Rows(); i++ {
-				f.DeleteRow(i)
-			}
-			// f.Points = f.Points[trimEdges : len(f.Points)-trimEdges]
 		}
 	}
 }
 
-func (rp *responseParser) nameSeries(frames *data.Frames, target *Query) {
-	set := make(map[string]string)
+func (rp *responseParser) nameFields(frames *data.Frames, target *Query) {
+	set := make(map[string]struct{})
 	for _, v := range *frames {
-		if len(v.Fields) > 1 {
-			valueField := v.Fields[1]
-			if metricType, exists := valueField.Labels["metric"]; exists {
+		for _, vv := range v.Fields {
+			if metricType, exists := vv.Labels["metric"]; exists {
 				if _, ok := set[metricType]; !ok {
-					set[metricType] = ""
+					set[metricType] = struct{}{}
 				}
 			}
 		}
@@ -495,14 +534,14 @@ func (rp *responseParser) nameSeries(frames *data.Frames, target *Query) {
 			if valueField.Config == nil {
 				valueField.Config = &data.FieldConfig{}
 			}
-			valueField.Config.DisplayNameFromDS = rp.getSeriesName(series, target, metricTypeCount)
+			valueField.Config.DisplayNameFromDS = rp.getFieldName(series, target, metricTypeCount)
 		}
 	}
 }
 
 var aliasPatternRegex = regexp.MustCompile(`\{\{([\s\S]+?)\}\}`)
 
-func (rp *responseParser) getSeriesName(series *data.Frame, target *Query, metricTypeCount int) string {
+func (rp *responseParser) getFieldName(series *data.Frame, target *Query, metricTypeCount int) string {
 	if len(series.Fields) < 2 {
 		return target.Alias
 	}
@@ -628,25 +667,6 @@ func castToFloat(j *simplejson.Json) *float64 {
 	}
 
 	return nil
-}
-
-func castToNullFloat(j *simplejson.Json) null.Float {
-	f, err := j.Float64()
-	if err == nil {
-		return null.FloatFrom(f)
-	}
-
-	if s, err := j.String(); err == nil {
-		if strings.ToLower(s) == "nan" {
-			return null.NewFloat(0, false)
-		}
-
-		if v, err := strconv.ParseFloat(s, 64); err == nil {
-			return null.FloatFromPtr(&v)
-		}
-	}
-
-	return null.NewFloat(0, false)
 }
 
 func findAgg(target *Query, aggID string) (*BucketAgg, error) {

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1144,21 +1144,24 @@ func TestHistogramSimple(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, rowLength)
 
-	fields := queryRes.Frames[0].Fields
-	require.Len(t, fields, 2)
-
-	field1 := fields[0]
-	field2 := fields[1]
-
-	assert.Equal(t, "bytes", field1.Name)
-
+	frames := queryRes.Frames[0]
+	require.Len(t, frames.Fields, 2)
+	require.Equal(t, 3, frames.Fields[0].Len())
+	assert.Equal(t, "bytes", frames.Fields[0].Name)
+	assert.EqualValues(t, 1000, *frames.Fields[0].At(0).(*float64))
+	assert.EqualValues(t, 2000, *frames.Fields[0].At(1).(*float64))
+	assert.EqualValues(t, 1000, *frames.Fields[0].At(2).(*float64))
 	trueValue := true
 	filterableConfig := data.FieldConfig{Filterable: &trueValue}
-
 	// we need to test that the only changed setting is `filterable`
-	require.NotNil(t, field1.Config)
-	assert.Equal(t, filterableConfig, *field1.Config)
-	assert.Equal(t, "Count", field2.Name)
+	require.NotNil(t, frames.Fields[0].Config)
+	assert.Equal(t, filterableConfig, *frames.Fields[0].Config)
+
+	require.Equal(t, 3, frames.Fields[1].Len())
+	assert.Equal(t, "Count", frames.Fields[1].Name)
+	assert.EqualValues(t, 1, *frames.Fields[1].At(0).(*float64))
+	assert.EqualValues(t, 3, *frames.Fields[1].At(1).(*float64))
+	assert.EqualValues(t, 2, *frames.Fields[1].At(2).(*float64))
 	// we need to test that the fieldConfig is "empty"
-	assert.Nil(t, field2.Config)
+	assert.Nil(t, frames.Fields[1].Config)
 }

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1072,6 +1072,60 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 24, *frames.Fields[4].At(0).(*float64))
 		assert.EqualValues(t, 48, *frames.Fields[4].At(1).(*float64))
 	})
+
+	// TODO: raw_document query remains to be implemented https://github.com/grafana/oss-plugin-partnerships/issues/196
+	//t.Run("Raw documents query", func(t *testing.T) {
+	//	targets := map[string]string{
+	//		"A": `{
+	//						"timeField": "@timestamp",
+	//						"metrics": [{ "type": "raw_document", "id": "1" }]
+	//					}`,
+	//	}
+	//	response := `{
+	//			    "responses": [
+	//			      {
+	//			        "hits": {
+	//			          "total": 100,
+	//			          "hits": [
+	//			            {
+	//			              "_id": "1",
+	//			              "_type": "type",
+	//			              "_index": "index",
+	//			              "_source": { "sourceProp": "asd" },
+	//			              "fields": { "fieldProp": "field" }
+	//			            },
+	//			            {
+	//			              "_source": { "sourceProp": "asd2" },
+	//			              "fields": { "fieldProp": "field2" }
+	//			            }
+	//			          ]
+	//			        }
+	//			      }
+	//			    ]
+	//				}`
+	//	rp, err := newResponseParserForTest(targets, response)
+	//	assert.Nil(t, err)
+	//	result, err := rp.getTimeSeries()
+	//	assert.Nil(t, err)
+	//	require.Len(t, result.Responses, 1)
+	//
+	//	queryRes := result.Responses["A"]
+	//	assert.NotNil(t, queryRes)
+	//So(queryRes.Tables, ShouldHaveLength, 1)
+	//
+	//rows := queryRes.Tables[0].Rows
+	//So(rows, ShouldHaveLength, 1)
+	//cols := queryRes.Tables[0].Columns
+	//So(cols, ShouldHaveLength, 3)
+	//
+	//So(cols[0].Text, ShouldEqual, "host")
+	//So(cols[1].Text, ShouldEqual, "Average test")
+	//So(cols[2].Text, ShouldEqual, "Average test2")
+	//
+	//So(rows[0][0].(string), ShouldEqual, "server-1")
+	//So(rows[0][1].(null.Float).Float64, ShouldEqual, 1000)
+	//So(rows[0][2].(null.Float).Float64, ShouldEqual, 3000)
+	//})
 }
 
 func newResponseParserForTest(tsdbQueries map[string]string, responseBody string) (*responseParser, error) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This implements the same changes that were made in Elasticsearch here https://github.com/grafana/grafana/pull/34710 which converts tables to data frames in the function processAggregationDocs (bucketAgg is not "date_histogram").

One of the functions the above PR added also had the following change later applied to it https://github.com/grafana/grafana/pull/64514. It has also been added to this change alongside its test.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/opensearch-datasource/issues/175

**Testing notes**:
I've created a comparison dashboard between current query flow in the frontend and queries which include a server-side expression which force them through the backend. See the first point [here](https://github.com/grafana/oss-plugin-partnerships/issues/195).

For this particular change, however we will get non-numeric data and run into [this issue](https://github.com/grafana/grafana/issues/46429) in the dashboard.

So instead I've compared the data directly in the same time range using the same data source in AWS (see plugin-provisioning) filled with the "sample flight data":

Using the debugger in the backend flow with the changes in this PR:
<img src="https://github.com/grafana/opensearch-datasource/assets/4163034/0d1fd9ec-bf48-4177-9bf6-98b5974037ba" width="600">

Using the frontend flow in v2.6.1 (on Grafana Cloud):
<img src="https://github.com/grafana/opensearch-datasource/assets/4163034/8fb58d39-89d3-4cc7-9466-547b9af353a2" width="600">

The only discrepancy is that the first set of values and last values do not overlap between the two; otherwise the other values are identical. I don't have a good explanation for that. Maybe the time range might be subject to some kind of rounding difference on my local machine vs on Grafana Cloud. 