### PR TITLE
Refactor PPL and Lucene time series response processing to return DataFrames

### DIFF
--- a/src/OpenSearchResponse.ts
+++ b/src/OpenSearchResponse.ts
@@ -424,13 +424,13 @@ export class OpenSearchResponse {
     return result;
   }
 
-  getTimeSeries() {
+  getTimeSeries(): DataQueryResponse {
     if (this.targetType === QueryType.PPL) {
       return this.processPPLResponseToSeries();
     } else if (this.targets.some(target => target.metrics?.some(metric => metric.type === 'raw_data'))) {
       return this.processResponseToDataFrames(false);
     }
-    return this.processResponseToSeries();
+    return this.processLuceneTimeSeries();
   }
 
   getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {
@@ -521,7 +521,7 @@ export class OpenSearchResponse {
     return { data: dataFrame, key: this.targets[0]?.refId };
   }
 
-  processResponseToSeries = () => {
+  processLuceneTimeSeries = (): DataQueryResponse => {
     const seriesList = [];
 
     for (let i = 0; i < this.response.responses.length; i++) {
@@ -557,7 +557,7 @@ export class OpenSearchResponse {
       }
     }
 
-    return { data: seriesList, key: this.targets[0]?.refId };
+    return { data: seriesList.map(item => toDataFrame(item)), key: this.targets[0]?.refId };
   };
 
   processPPLResponseToSeries = () => {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -3,7 +3,6 @@ import {
   CoreApp,
   DataFrame,
   DataQueryRequest,
-  DataQueryResponse,
   DataSourceInstanceSettings,
   DateTime,
   dateTime,
@@ -12,7 +11,6 @@ import {
   MetricFindValue,
   MutableDataFrame,
   TimeRange,
-  TimeSeries,
   toUtc,
 } from '@grafana/data';
 import _ from 'lodash';
@@ -21,7 +19,14 @@ import { PPLFormatType } from './components/QueryEditor/PPLFormatEditor/formats'
 // import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 // @ts-ignore
 import { getBackendSrv } from '@grafana/runtime';
-import { Flavor, LuceneQueryType, OpenSearchOptions, OpenSearchQuery, QueryType } from './types';
+import {
+  Flavor,
+  LuceneQueryType,
+  OpenSearchDataQueryResponse,
+  OpenSearchOptions,
+  OpenSearchQuery,
+  QueryType,
+} from './types';
 import { Filters } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import { matchers } from './dependencies/matchers';
 import { MetricAggregation } from 'components/QueryEditor/MetricAggregationsEditor/aggregations';
@@ -196,7 +201,7 @@ describe('OpenSearchDatasource', function(this: any) {
     });
 
     it('should resolve the alias variable for the alias/target in the result', () => {
-      expect(result.data[0].target).toEqual('resolvedVariable');
+      expect(result.data[0].name).toEqual('resolvedVariable');
     });
 
     it('should json escape lucene query', () => {
@@ -810,9 +815,9 @@ describe('OpenSearchDatasource', function(this: any) {
 
       it('should handle the data source response', async () => {
         const { ds, options } = setup(targets);
-        await expect(ds.query(options)).toEmitValuesWith((received: DataQueryResponse[]) => {
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
           const result = received[0];
-          const dataFrame = result.data[0] as DataFrame;
+          const dataFrame = result.data[0];
           expect(dataFrame.length).toBe(2);
           expect(dataFrame.refId).toBe('A');
           const fieldCache = new FieldCache(dataFrame);
@@ -874,7 +879,7 @@ describe('OpenSearchDatasource', function(this: any) {
 
       it('should handle the data source response', async () => {
         const { ds, options } = setup(targets);
-        await expect(ds.query(options)).toEmitValuesWith((received: DataQueryResponse[]) => {
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
           const result = received[0];
           const dataFrame = result.data[0] as DataFrame;
           expect(dataFrame.length).toBe(2);
@@ -936,12 +941,12 @@ describe('OpenSearchDatasource', function(this: any) {
 
       it('should handle the data source response', async () => {
         const { ds, options } = setup(targets);
-        await expect(ds.query(options)).toEmitValuesWith((received: DataQueryResponse[]) => {
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
           const result = received[0];
-          const timeSeries = result.data[0] as TimeSeries;
-          expect(timeSeries.datapoints.length).toBe(1);
+          const timeSeries = result.data[0];
+          expect(timeSeries.length).toBe(1);
           expect(timeSeries.refId).toBe('C');
-          expect(timeSeries.target).toEqual('count(response)');
+          expect(timeSeries.name).toEqual('count(response)');
         });
       });
     });
@@ -986,7 +991,7 @@ describe('OpenSearchDatasource', function(this: any) {
 
       it('should handle the data source responses', async () => {
         const { ds, options } = setup(targets);
-        await expect(ds.query(options)).toEmitValuesWith((received: DataQueryResponse[]) => {
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
           expect(received.length).toBe(2);
           expect(received).toEqual(
             expect.arrayContaining([
@@ -1046,7 +1051,7 @@ describe('OpenSearchDatasource', function(this: any) {
 
       it('should handle the data source responses', async () => {
         const { ds, options } = setup(targets);
-        await expect(ds.query(options)).toEmitValuesWith((received: DataQueryResponse[]) => {
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
           expect(received.length).toBe(2);
           expect(received).toEqual(
             expect.arrayContaining([

--- a/src/specs/OpenSearchResponse.test.ts
+++ b/src/specs/OpenSearchResponse.test.ts
@@ -1,12 +1,37 @@
-import { DataFrameView, FieldCache, KeyValue, MutableDataFrame, toUtc } from '@grafana/data';
+import {
+  DataFrame,
+  DataFrameView,
+  Field,
+  FieldCache,
+  FieldType,
+  KeyValue,
+  MutableDataFrame,
+  toUtc,
+} from '@grafana/data';
 import { OpenSearchResponse } from '../OpenSearchResponse';
 import flatten from '../dependencies/flatten';
 import { OpenSearchQuery, QueryType } from '../types';
 
+function getTimeField(frame: DataFrame): Field {
+  const field = frame.fields[0];
+  if (field.type !== FieldType.time) {
+    throw new Error('first field should be the time-field');
+  }
+  return field;
+}
+
+function getValueField(frame: DataFrame): Field {
+  const field = frame.fields[1];
+  if (field.type !== FieldType.number) {
+    throw new Error('second field should be the number-field');
+  }
+  return field;
+}
+
 describe('OpenSearchResponse', () => {
   let targets: OpenSearchQuery[];
   let response: any;
-  let result: any;
+  let result: { data: DataFrame[] };
 
   describe('refId matching', () => {
     // We default to the old table structure to ensure backward compatibility,
@@ -293,16 +318,19 @@ describe('OpenSearchResponse', () => {
     });
 
     it('should return 1 series', () => {
+      const frame1 = result.data[0];
       expect(result.data.length).toBe(1);
-      expect(result.data[0].target).toBe('Count');
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].datapoints[0][0]).toBe(10);
-      expect(result.data[0].datapoints[0][1]).toBe(1000);
+      expect(frame1.name).toBe('Count');
+      expect(frame1.fields.length).toBe(2);
+      expect(getTimeField(frame1).values.get(0)).toBe(1000);
+      expect(getValueField(frame1).values.get(0)).toBe(10);
+      expect(getTimeField(frame1).values.get(1)).toBe(2000);
+      expect(getValueField(frame1).values.get(1)).toBe(15);
     });
   });
 
   describe('simple query count & avg aggregation', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -343,18 +371,19 @@ describe('OpenSearchResponse', () => {
 
     it('should return 2 series', () => {
       expect(result.data.length).toBe(2);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].datapoints[0][0]).toBe(10);
-      expect(result.data[0].datapoints[0][1]).toBe(1000);
+      const frame1 = result.data[0];
+      const frame2 = result.data[1];
+      expect(frame1.length).toBe(2);
+      expect(getValueField(frame1).values.get(0)).toBe(10);
+      expect(getTimeField(frame1).values.get(0)).toBe(1000);
 
-      expect(result.data[1].target).toBe('Average value');
-      expect(result.data[1].datapoints[0][0]).toBe(88);
-      expect(result.data[1].datapoints[1][0]).toBe(99);
+      expect(frame2.name).toBe('Average value');
+      expect(getValueField(frame2).values.toArray()).toStrictEqual([88, 99]);
     });
   });
 
   describe('single group by query one metric', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -405,14 +434,23 @@ describe('OpenSearchResponse', () => {
 
     it('should return 2 series', () => {
       expect(result.data.length).toBe(2);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('server1');
-      expect(result.data[1].target).toBe('server2');
+
+      const frame1 = result.data[0];
+      expect(frame1.name).toBe('server1');
+      expect(frame1.fields.length).toBe(2);
+      expect(getTimeField(frame1).values.toArray()).toStrictEqual([1000, 2000]);
+      expect(getValueField(frame1).values.toArray()).toStrictEqual([1, 3]);
+
+      const frame2 = result.data[1];
+      expect(frame2.name).toBe('server2');
+      expect(frame2.fields.length).toBe(2);
+      expect(getTimeField(frame2).values.toArray()).toStrictEqual([1000, 2000]);
+      expect(getValueField(frame2).values.toArray()).toStrictEqual([2, 8]);
     });
   });
 
   describe('single group by query two metrics', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -466,16 +504,16 @@ describe('OpenSearchResponse', () => {
 
     it('should return 2 series', () => {
       expect(result.data.length).toBe(4);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('server1 Count');
-      expect(result.data[1].target).toBe('server1 Average @value');
-      expect(result.data[2].target).toBe('server2 Count');
-      expect(result.data[3].target).toBe('server2 Average @value');
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].name).toBe('server1 Count');
+      expect(result.data[1].name).toBe('server1 Average @value');
+      expect(result.data[2].name).toBe('server2 Count');
+      expect(result.data[3].name).toBe('server2 Average @value');
     });
   });
 
   describe('with percentiles ', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -513,17 +551,21 @@ describe('OpenSearchResponse', () => {
 
     it('should return 2 series', () => {
       expect(result.data.length).toBe(2);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('p75 @value');
-      expect(result.data[1].target).toBe('p90 @value');
-      expect(result.data[0].datapoints[0][0]).toBe(3.3);
-      expect(result.data[0].datapoints[0][1]).toBe(1000);
-      expect(result.data[1].datapoints[1][0]).toBe(4.5);
+      expect(result.data[0].name).toBe('p75 @value');
+      expect(result.data[1].name).toBe('p90 @value');
+
+      const frame1 = result.data[0];
+      expect(getTimeField(frame1).values.toArray()).toStrictEqual([1000, 2000]);
+      expect(getValueField(frame1).values.toArray()).toStrictEqual([3.3, 2.3]);
+
+      const frame2 = result.data[1];
+      expect(getTimeField(frame2).values.toArray()).toStrictEqual([1000, 2000]);
+      expect(getValueField(frame2).values.toArray()).toStrictEqual([5.5, 4.5]);
     });
   });
 
   describe('with extended_stats', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -593,17 +635,17 @@ describe('OpenSearchResponse', () => {
 
     it('should return 4 series', () => {
       expect(result.data.length).toBe(4);
-      expect(result.data[0].datapoints.length).toBe(1);
-      expect(result.data[0].target).toBe('server1 Max @value');
-      expect(result.data[1].target).toBe('server1 Std Dev Upper @value');
+      expect(result.data[0].length).toBe(1);
+      expect(result.data[0].name).toBe('server1 Max @value');
+      expect(result.data[1].name).toBe('server1 Std Dev Upper @value');
 
-      expect(result.data[0].datapoints[0][0]).toBe(10.2);
-      expect(result.data[1].datapoints[0][0]).toBe(3);
+      expect(getValueField(result.data[0]).values.get(0)).toBe(10.2);
+      expect(getValueField(result.data[1]).values.get(0)).toBe(3);
     });
   });
 
   describe('single group by with alias pattern', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -665,15 +707,15 @@ describe('OpenSearchResponse', () => {
 
     it('should return 2 series', () => {
       expect(result.data.length).toBe(3);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('server1 Count and {{not_exist}} server1');
-      expect(result.data[1].target).toBe('server2 Count and {{not_exist}} server2');
-      expect(result.data[2].target).toBe('0 Count and {{not_exist}} 0');
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].name).toBe('server1 Count and {{not_exist}} server1');
+      expect(result.data[1].name).toBe('server2 Count and {{not_exist}} server2');
+      expect(result.data[2].name).toBe('0 Count and {{not_exist}} 0');
     });
   });
 
   describe('histogram response', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -702,14 +744,19 @@ describe('OpenSearchResponse', () => {
       result = new OpenSearchResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table with byte and count', () => {
-      expect(result.data[0].rows.length).toBe(3);
-      expect(result.data[0].columns).toEqual([{ text: 'bytes', filterable: true }, { text: 'Count' }]);
+    it('should return dataframe with byte and count', () => {
+      expect(result.data[0].length).toBe(3);
+      const { fields } = result.data[0];
+      expect(fields.length).toBe(2);
+      expect(fields[0].name).toBe('bytes');
+      expect(fields[0].config).toStrictEqual({ filterable: true });
+      expect(fields[1].name).toBe('Count');
+      expect(fields[1].config).toStrictEqual({});
     });
   });
 
   describe('with two filters agg', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -764,10 +811,9 @@ describe('OpenSearchResponse', () => {
     });
 
     it('should return 2 series', () => {
-      expect(result.data.length).toBe(2);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('@metric:cpu');
-      expect(result.data[1].target).toBe('@metric:logins.count');
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].name).toBe('@metric:cpu');
+      expect(result.data[1].name).toBe('@metric:logins.count');
     });
   });
 
@@ -824,7 +870,7 @@ describe('OpenSearchResponse', () => {
 
     it('should remove first and last value', () => {
       expect(result.data.length).toBe(2);
-      expect(result.data[0].datapoints.length).toBe(1);
+      expect(result.data[0].length).toBe(1);
     });
   });
 
@@ -867,21 +913,21 @@ describe('OpenSearchResponse', () => {
       result = new OpenSearchResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table', () => {
-      expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][0]).toBe('server-1');
-      expect(result.data[0].rows[0][1]).toBe(1000);
-      expect(result.data[0].rows[0][2]).toBe(369);
+    it('should return data frame', () => {
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].fields.length).toBe(3);
+      const field1 = result.data[0].fields[0];
+      const field2 = result.data[0].fields[1];
+      const field3 = result.data[0].fields[2];
 
-      expect(result.data[0].rows[1][0]).toBe('server-2');
-      expect(result.data[0].rows[1][1]).toBe(2000);
+      expect(field1.values.toArray()).toStrictEqual(['server-1', 'server-2']);
+      expect(field2.values.toArray()).toStrictEqual([1000, 2000]);
+      expect(field3.values.toArray()).toStrictEqual([369, 200]);
     });
   });
 
   describe('No group by time with percentiles ', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -917,19 +963,19 @@ describe('OpenSearchResponse', () => {
       result = new OpenSearchResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table', () => {
+    it('should return data frame', () => {
       expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].columns[0].text).toBe('id');
-      expect(result.data[0].columns[1].text).toBe('p75 value');
-      expect(result.data[0].columns[2].text).toBe('p90 value');
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][0]).toBe('id1');
-      expect(result.data[0].rows[0][1]).toBe(3.3);
-      expect(result.data[0].rows[0][2]).toBe(5.5);
-      expect(result.data[0].rows[1][0]).toBe('id2');
-      expect(result.data[0].rows[1][1]).toBe(2.3);
-      expect(result.data[0].rows[1][2]).toBe(4.5);
+      expect(result.data[0].length).toBe(2);
+      const field1 = result.data[0].fields[0];
+      const field2 = result.data[0].fields[1];
+      const field3 = result.data[0].fields[2];
+      expect(field1.name).toBe('id');
+      expect(field2.name).toBe('p75 value');
+      expect(field3.name).toBe('p90 value');
+
+      expect(field1.values.toArray()).toStrictEqual(['id1', 'id2']);
+      expect(field2.values.toArray()).toStrictEqual([3.3, 2.3]);
+      expect(field3.values.toArray()).toStrictEqual([5.5, 4.5]);
     });
   });
 
@@ -969,9 +1015,11 @@ describe('OpenSearchResponse', () => {
     });
 
     it('should include field in metric name', () => {
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].rows[0][1]).toBe(1000);
-      expect(result.data[0].rows[0][2]).toBe(3000);
+      expect(result.data[0].length).toBe(1);
+      expect(result.data[0].fields.length).toBe(3);
+      expect(result.data[0].fields[0].values.toArray()).toStrictEqual(['server-1']);
+      expect(result.data[0].fields[1].values.toArray()).toStrictEqual([1000]);
+      expect(result.data[0].fields[2].values.toArray()).toStrictEqual([3000]);
     });
   });
 
@@ -1010,18 +1058,21 @@ describe('OpenSearchResponse', () => {
       result = new OpenSearchResponse(targets, response).getTimeSeries();
     });
 
-    it('should return docs', () => {
-      expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('docs');
-      expect(result.data[0].total).toBe(100);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].datapoints[0].sourceProp).toBe('asd');
-      expect(result.data[0].datapoints[0].fieldProp).toBe('field');
+    it('should return raw_document formatted data', () => {
+      const frame = result.data[0];
+      const { fields } = frame;
+      expect(fields.length).toBe(1);
+      const field = fields[0];
+      expect(field.type === FieldType.other);
+      const values = field.values.toArray();
+      expect(values.length).toBe(2);
+      expect(values[0].sourceProp).toBe('asd');
+      expect(values[0].fieldProp).toBe('field');
     });
   });
 
   describe('with bucket_script ', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -1074,21 +1125,21 @@ describe('OpenSearchResponse', () => {
     });
     it('should return 3 series', () => {
       expect(result.data.length).toBe(3);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].target).toBe('Sum @value');
-      expect(result.data[1].target).toBe('Max @value');
-      expect(result.data[2].target).toBe('Sum @value * Max @value');
-      expect(result.data[0].datapoints[0][0]).toBe(2);
-      expect(result.data[1].datapoints[0][0]).toBe(3);
-      expect(result.data[2].datapoints[0][0]).toBe(6);
-      expect(result.data[0].datapoints[1][0]).toBe(3);
-      expect(result.data[1].datapoints[1][0]).toBe(4);
-      expect(result.data[2].datapoints[1][0]).toBe(12);
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].name).toBe('Sum @value');
+      expect(result.data[1].name).toBe('Max @value');
+      expect(result.data[2].name).toBe('Sum @value * Max @value');
+      expect(getValueField(result.data[0]).values.get(0)).toBe(2);
+      expect(getValueField(result.data[1]).values.get(0)).toBe(3);
+      expect(getValueField(result.data[2]).values.get(0)).toBe(6);
+      expect(getValueField(result.data[0]).values.get(1)).toBe(3);
+      expect(getValueField(result.data[1]).values.get(1)).toBe(4);
+      expect(getValueField(result.data[2]).values.get(1)).toBe(12);
     });
   });
 
   describe('terms with bucket_script and two scripts', () => {
-    let result: any;
+    let result: { data: DataFrame[] };
 
     beforeEach(() => {
       targets = [
@@ -1152,16 +1203,15 @@ describe('OpenSearchResponse', () => {
     });
 
     it('should return 2 rows with 5 columns', () => {
-      expect(result.data[0].columns.length).toBe(5);
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][1]).toBe(2);
-      expect(result.data[0].rows[0][2]).toBe(3);
-      expect(result.data[0].rows[0][3]).toBe(6);
-      expect(result.data[0].rows[0][4]).toBe(24);
-      expect(result.data[0].rows[1][1]).toBe(3);
-      expect(result.data[0].rows[1][2]).toBe(4);
-      expect(result.data[0].rows[1][3]).toBe(12);
-      expect(result.data[0].rows[1][4]).toBe(48);
+      const frame = result.data[0];
+      expect(frame.length).toBe(2);
+      const { fields } = frame;
+      expect(fields.length).toBe(5);
+      expect(fields[0].values.toArray()).toStrictEqual([1000, 2000]);
+      expect(fields[1].values.toArray()).toStrictEqual([2, 3]);
+      expect(fields[2].values.toArray()).toStrictEqual([3, 4]);
+      expect(fields[3].values.toArray()).toStrictEqual([6, 12]);
+      expect(fields[4].values.toArray()).toStrictEqual([24, 48]);
     });
   });
 

--- a/src/specs/OpenSearchResponse.test.ts
+++ b/src/specs/OpenSearchResponse.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { OpenSearchResponse } from '../OpenSearchResponse';
 import flatten from '../dependencies/flatten';
-import { OpenSearchQuery, QueryType } from '../types';
+import { OpenSearchDataQueryResponse, OpenSearchQuery, QueryType } from '../types';
 
 function getTimeField(frame: DataFrame): Field {
   const field = frame.fields[0];
@@ -31,7 +31,7 @@ function getValueField(frame: DataFrame): Field {
 describe('OpenSearchResponse', () => {
   let targets: OpenSearchQuery[];
   let response: any;
-  let result: { data: DataFrame[] };
+  let result: OpenSearchDataQueryResponse;
 
   describe('refId matching', () => {
     // We default to the old table structure to ensure backward compatibility,
@@ -273,7 +273,6 @@ describe('OpenSearchResponse', () => {
         expect(result.data[0].refId).toBe(countQuery.target.refId);
 
         expect(result.data[1].refId).toBe(countGroupByHistogramQuery.target.refId);
-
         expect(result.data[2].refId).toBe(rawDocumentQuery.target.refId);
 
         expect(result.data[3].refId).toBe(percentilesQuery.target.refId);
@@ -330,7 +329,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('simple query count & avg aggregation', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -383,7 +382,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('single group by query one metric', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -450,7 +449,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('single group by query two metrics', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -513,7 +512,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('with percentiles ', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -565,7 +564,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('with extended_stats', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -645,7 +644,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('single group by with alias pattern', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -715,7 +714,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('histogram response', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -756,7 +755,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('with two filters agg', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -927,7 +926,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('No group by time with percentiles ', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -1072,7 +1071,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('with bucket_script ', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -1139,7 +1138,7 @@ describe('OpenSearchResponse', () => {
   });
 
   describe('terms with bucket_script and two scripts', () => {
-    let result: { data: DataFrame[] };
+    let result: OpenSearchDataQueryResponse;
 
     beforeEach(() => {
       targets = [
@@ -1520,12 +1519,12 @@ describe('OpenSearchResponse', () => {
         { name: 'timeName', type: 'timestamp' },
       ],
     };
-    it('should return series', () => {
+    it('should return data frames', () => {
       const result = new OpenSearchResponse(targets, response, targetType).getTimeSeries();
       expect(result.data.length).toBe(1);
-      expect(result.data[0].datapoints.length).toBe(3);
-      expect(result.data[0].datapoints[0][0]).toBe(5);
-      expect(result.data[0].datapoints[0][1]).toBe(1604191142000);
+      const frame = result.data[0];
+      expect(getTimeField(frame).values.toArray()).toStrictEqual([1604191142000, 1604201181000, 1604201683000]);
+      expect(getValueField(frame).values.toArray()).toStrictEqual([5, 1, 4]);
     });
 
     const response2 = {
@@ -1539,12 +1538,12 @@ describe('OpenSearchResponse', () => {
         { name: 'test', type: 'int' },
       ],
     };
-    it('should return series', () => {
+    it('should return data frames', () => {
       const result = new OpenSearchResponse(targets, response2, targetType).getTimeSeries();
       expect(result.data.length).toBe(1);
-      expect(result.data[0].datapoints.length).toBe(3);
-      expect(result.data[0].datapoints[0][0]).toBe(5);
-      expect(result.data[0].datapoints[0][1]).toBe(1604214000000);
+      const frame = result.data[0];
+      expect(getTimeField(frame).values.toArray()).toStrictEqual([1604214000000, 1604300400000, 1604386800000]);
+      expect(getValueField(frame).values.toArray()).toStrictEqual([5, 1, 4]);
     });
 
     const response3 = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataFrame, DataQuery, DataQueryResponse, DataSourceJsonData } from '@grafana/data';
 import {
   BucketAggregation,
   BucketAggregationType,
@@ -208,3 +208,7 @@ export interface OpenSearchSpan {
     [key: string]: any;
   };
 }
+
+export type OpenSearchDataQueryResponse = Omit<DataQueryResponse, 'data'> & {
+  data: DataFrame[];
+};


### PR DESCRIPTION
Datasource query() method in OpenSearch returns LegacyResponseData **for time series queries**, but DataFrames for all other types. 
When LegacyResponseData is returned, Grafana-data eventually calls [toDataFrame](https://github.com/grafana/grafana/blob/12dc56ad0cb5b6b982007d1498346fb03be05f41/packages/grafana-data/src/dataframe/processDataFrame.ts#L309) method in order for viz panels to be able to handle the data. 

This is just doing that already in OpenSearch for time series queries and adjusting tests accordingly. 
The motivation behind doing this now and here is that we will soon start to [migrate response handling logic to the backend](https://github.com/grafana/oss-plugin-partnerships/issues/194) and it will be useful to compare output in DataFrames between FE and Backend, both in tests and runtime. 


**How to test:** 
After @fridgepoet's comment, Im attaching an exported dashboard - it works with the OpenSearch DS config from plugin provisioning. 
For Lucene changes:
- queries use the OpenSearch (not serverless) datasource from plugin-provisioning
- there is a Lucene metrics row (edit). Run them without, then with the new changes. The queries should be identical.

For PPL changes:
- queries use the OpenSearch Serverless datasource from plugin-provisioning. **NB**: You might have to change the time field from release_date (as it is in plugin-provisioning) to "timestamp" in order for the queries to work. See [here](https://github.com/grafana/opensearch-datasource/pull/188#issuecomment-1578187488) 
- there is a PPL time series row in the dashboard Run them without, then with the new changes. The panels should look identical.


Fixes https://github.com/grafana/opensearch-datasource/issues/185

More info: ElasticSearch went through the same process when migrating the DS to BE, the PR is [here
](https://github.com/grafana/grafana/pull/58636)


[OpenSearch FE & BE non regression-1685963225258.json.zip](https://github.com/grafana/opensearch-datasource/files/11651914/OpenSearch.FE.BE.non.regression-1685963225258.json.zip)