### PR TITLE
Backend: Use int64 type instead of string for from/to date times

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -151,14 +151,15 @@ var NewClient = func(ctx context.Context, ds *backend.DataSourceInstanceSettings
 	clientLog.Info("Creating new client", "version", version.String(), "timeField", timeField, "indices", strings.Join(indices, ", "), "PPL index", index)
 
 	return &baseClientImpl{
-		ctx:       ctx,
-		ds:        ds,
-		version:   version,
-		flavor:    Flavor(flavor),
-		timeField: timeField,
-		indices:   indices,
-		index:     index,
-		timeRange: timeRange,
+		ctx:          ctx,
+		ds:           ds,
+		version:      version,
+		flavor:       Flavor(flavor),
+		timeField:    timeField,
+		indices:      indices,
+		index:        index,
+		timeRange:    timeRange,
+		debugEnabled: true,
 	}, nil
 }
 

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -151,15 +151,14 @@ var NewClient = func(ctx context.Context, ds *backend.DataSourceInstanceSettings
 	clientLog.Info("Creating new client", "version", version.String(), "timeField", timeField, "indices", strings.Join(indices, ", "), "PPL index", index)
 
 	return &baseClientImpl{
-		ctx:          ctx,
-		ds:           ds,
-		version:      version,
-		flavor:       Flavor(flavor),
-		timeField:    timeField,
-		indices:      indices,
-		index:        index,
-		timeRange:    timeRange,
-		debugEnabled: true,
+		ctx:       ctx,
+		ds:        ds,
+		version:   version,
+		flavor:    Flavor(flavor),
+		timeField: timeField,
+		indices:   indices,
+		index:     index,
+		timeRange: timeRange,
 	}, nil
 }
 

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -144,8 +144,8 @@ func (f *QueryStringFilter) MarshalJSON() ([]byte, error) {
 type RangeFilter struct {
 	Filter
 	Key    string
-	Gte    string
-	Lte    string
+	Gte    int64
+	Lte    int64
 	Format string
 }
 
@@ -270,8 +270,8 @@ type TermsAggregation struct {
 
 // ExtendedBounds represents extended bounds
 type ExtendedBounds struct {
-	Min string `json:"min"`
-	Max string `json:"max"`
+	Min int64 `json:"min"`
+	Max int64 `json:"max"`
 }
 
 // GeoHashGridAggregation represents a geo hash grid aggregation

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -238,7 +238,7 @@ func (b *FilterQueryBuilder) Build() ([]Filter, error) {
 }
 
 // AddDateRangeFilter adds a new time range filter
-func (b *FilterQueryBuilder) AddDateRangeFilter(timeField, lte, gte, format string) *FilterQueryBuilder {
+func (b *FilterQueryBuilder) AddDateRangeFilter(timeField, format string, lte, gte int64) *FilterQueryBuilder {
 	b.filters = append(b.filters, &RangeFilter{
 		Key:    timeField,
 		Lte:    lte,

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -48,7 +48,7 @@ func TestSearchRequest(t *testing.T) {
 				b.Size(200)
 				b.SortDesc(timeField, "boolean")
 				filters := b.Query().Bool().Filter()
-				filters.AddDateRangeFilter(timeField, "$timeTo", "$timeFrom", DateFormatEpochMS)
+				filters.AddDateRangeFilter(timeField, DateFormatEpochMS, 10, 5)
 				filters.AddQueryStringFilter("test", true)
 
 				Convey("When building search request", func() {
@@ -69,8 +69,8 @@ func TestSearchRequest(t *testing.T) {
 					Convey("Should have range filter", func() {
 						f, ok := sr.Query.Bool.Filters[0].(*RangeFilter)
 						So(ok, ShouldBeTrue)
-						So(f.Gte, ShouldEqual, "$timeFrom")
-						So(f.Lte, ShouldEqual, "$timeTo")
+						So(f.Gte, ShouldEqual, 5)
+						So(f.Lte, ShouldEqual, 10)
 						So(f.Format, ShouldEqual, "epoch_millis")
 					})
 
@@ -93,8 +93,8 @@ func TestSearchRequest(t *testing.T) {
 						So(sort.Get("unmapped_type").MustString(), ShouldEqual, "boolean")
 
 						timeRangeFilter := json.GetPath("query", "bool", "filter").GetIndex(0).Get("range").Get(timeField)
-						So(timeRangeFilter.Get("gte").MustString(""), ShouldEqual, "$timeFrom")
-						So(timeRangeFilter.Get("lte").MustString(""), ShouldEqual, "$timeTo")
+						So(timeRangeFilter.Get("gte").MustInt64(), ShouldEqual, 5)
+						So(timeRangeFilter.Get("lte").MustInt64(), ShouldEqual, 10)
 						So(timeRangeFilter.Get("format").MustString(""), ShouldEqual, DateFormatEpochMS)
 
 						queryStringFilter := json.GetPath("query", "bool", "filter").GetIndex(1).Get("query_string")

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -1,7 +1,6 @@
 package opensearch
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -16,9 +15,8 @@ import (
 func TestExecuteTimeSeriesQuery(t *testing.T) {
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
-	fromStr := fmt.Sprintf("%d", from.UnixNano()/int64(time.Millisecond))
-	toStr := fmt.Sprintf("%d", to.UnixNano()/int64(time.Millisecond))
-
+	fromStr := from.UnixNano() / int64(time.Millisecond)
+	toStr := to.UnixNano() / int64(time.Millisecond)
 	Convey("Test execute time series query", t, func() {
 		Convey("With defaults on Elasticsearch 2.0.0", func() {
 			c := newFakeClient(es.Elasticsearch, "2.0.0")

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -15,8 +15,8 @@ import (
 func TestExecuteTimeSeriesQuery(t *testing.T) {
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
-	fromStr := from.UnixNano() / int64(time.Millisecond)
-	toStr := to.UnixNano() / int64(time.Millisecond)
+	fromMs := from.UnixNano() / int64(time.Millisecond)
+	toMs := to.UnixNano() / int64(time.Millisecond)
 	Convey("Test execute time series query", t, func() {
 		Convey("With defaults on Elasticsearch 2.0.0", func() {
 			c := newFakeClient(es.Elasticsearch, "2.0.0")
@@ -29,14 +29,14 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			sr := c.multisearchRequests[0].Requests[0]
 			rangeFilter := sr.Query.Bool.Filters[0].(*es.RangeFilter)
 			So(rangeFilter.Key, ShouldEqual, c.timeField)
-			So(rangeFilter.Lte, ShouldEqual, toStr)
-			So(rangeFilter.Gte, ShouldEqual, fromStr)
+			So(rangeFilter.Lte, ShouldEqual, toMs)
+			So(rangeFilter.Gte, ShouldEqual, fromMs)
 			So(rangeFilter.Format, ShouldEqual, es.DateFormatEpochMS)
 			So(sr.Aggs[0].Key, ShouldEqual, "2")
 			dateHistogramAgg := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
 			So(dateHistogramAgg.Field, ShouldEqual, "@timestamp")
-			So(dateHistogramAgg.ExtendedBounds.Min, ShouldEqual, fromStr)
-			So(dateHistogramAgg.ExtendedBounds.Max, ShouldEqual, toStr)
+			So(dateHistogramAgg.ExtendedBounds.Min, ShouldEqual, fromMs)
+			So(dateHistogramAgg.ExtendedBounds.Max, ShouldEqual, toMs)
 		})
 
 		Convey("With defaults on Elasticsearch 5.0.0", func() {
@@ -50,8 +50,8 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			sr := c.multisearchRequests[0].Requests[0]
 			So(sr.Query.Bool.Filters[0].(*es.RangeFilter).Key, ShouldEqual, c.timeField)
 			So(sr.Aggs[0].Key, ShouldEqual, "2")
-			So(sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Min, ShouldEqual, fromStr)
-			So(sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Max, ShouldEqual, toStr)
+			So(sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Min, ShouldEqual, fromMs)
+			So(sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Max, ShouldEqual, toMs)
 		})
 
 		Convey("With multiple bucket aggs", func() {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This is the equivalent fix that was made in the Elasticsearch data source: https://github.com/grafana/grafana/pull/44027
Thank you for creating such a nice description!

> When doing Data Histogram aggregation `from` and `to` dates are sent as strings. When selected aggregation field has `date` type in Elastic it's automatically converted by Elastic from a string to a number. However, if the aggregation field has a numeric type, such conversion doesn't happen. 
> 
> This automatic type conversion happens inside Elastic because `date` can be represented as [a formatted string or a timestamp in milliseconds or seconds](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html). We always pass both values as timestamps in milliseconds anyway so there's no need to use strings, because it's not needed to be converted. This way fields with non-date type will also work fine for Date Histograms.

> A similar fix was applied some time ago in the Elasticsearch frontend code [#22173](https://github.com/grafana/grafana/pull/22173).


The equivalent documentation about `date` in OpenSearch is this: https://opensearch.org/docs/latest/field-types/supported-field-types/date/

**Which issue(s) this PR fixes**:

Fixes the very specific example in #176, but there will probably still be inconsistent results between alerts(backend) and queries for some time. We aim to resolve that by [migrating the OpenSearch data source to a backend data source](https://github.com/grafana/opensearch-datasource/issues/192). This work is in progress.
