### PR TITLE
Fix: raw_data query size is a string, not an int

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -72,7 +72,12 @@ func processRawDataQuery(q *Query, b *es.SearchRequestBuilder, defaultTimeField 
 	b.SortDesc(defaultTimeField, "boolean")
 	b.SortDesc("_doc", "")
 	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
-	b.Size(metric.Settings.Get("size").MustInt(500))
+	sizeString := metric.Settings.Get("size").MustString()
+	size, err := strconv.Atoi(sizeString)
+	if err != nil {
+		size = 500
+	}
+	b.Size(size)
 }
 
 func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, toMs int64) {

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -24,7 +24,7 @@ func Test_raw_data(t *testing.T) {
 		_, err := executeTsdbQuery(c, `{
 				"timeField": "@timestamp",
 				"bucketAggs": [],
-				"metrics": [{ "id": "1", "type": "raw_data", "settings": {"size": 1337 }	}]
+				"metrics": [{ "id": "1", "type": "raw_data", "settings": {"size": "1337" }	}]
 			}`, from, to, 15*time.Second)
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This fixes the backend parsing of the size for a raw_data query.
It is a string, not an int. 

Currently the behavior defaults to a Size of 500, effectively ignoring whatever the user inputs.
With the changes in the PR, the Size is now taken into account.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/196

**Special notes for your reviewer**:
