### PR TITLE
Change query sort to respect sort order

### DIFF
--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -42,7 +42,7 @@ type SearchRequest struct {
 	Index       string
 	Interval    tsdb.Interval
 	Size        int
-	Sort        map[string]interface{}
+	Sort        []map[string]interface{}
 	Query       *Query
 	Aggs        AggArray
 	CustomProps map[string]interface{}

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -42,7 +42,7 @@ type SearchRequest struct {
 	Index       string
 	Interval    tsdb.Interval
 	Size        int
-	Sort        []map[string]interface{}
+	Sort        []map[string]map[string]string
 	Query       *Query
 	Aggs        AggArray
 	CustomProps map[string]interface{}

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -14,7 +14,7 @@ type SearchRequestBuilder struct {
 	interval     tsdb.Interval
 	index        string
 	size         int
-	sort         []map[string]interface{}
+	sort         []map[string]map[string]string
 	queryBuilder *QueryBuilder
 	aggBuilders  []AggBuilder
 	customProps  map[string]interface{}
@@ -26,7 +26,7 @@ func NewSearchRequestBuilder(flavor Flavor, version *semver.Version, interval ts
 		flavor:      flavor,
 		version:     version,
 		interval:    interval,
-		sort:        make([]map[string]interface{}, 0),
+		sort:        make([]map[string]map[string]string, 0),
 		customProps: make(map[string]interface{}),
 		aggBuilders: make([]AggBuilder, 0),
 	}
@@ -87,7 +87,7 @@ func (b *SearchRequestBuilder) Sort(order, field, unmappedType string) *SearchRe
 		props["unmapped_type"] = unmappedType
 	}
 
-	b.sort = append(b.sort, map[string]interface{}{field: props})
+	b.sort = append(b.sort, map[string]map[string]string{field: props})
 
 	return b
 }

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -14,7 +14,7 @@ type SearchRequestBuilder struct {
 	interval     tsdb.Interval
 	index        string
 	size         int
-	sort         map[string]interface{}
+	sort         []map[string]interface{}
 	queryBuilder *QueryBuilder
 	aggBuilders  []AggBuilder
 	customProps  map[string]interface{}
@@ -26,7 +26,7 @@ func NewSearchRequestBuilder(flavor Flavor, version *semver.Version, interval ts
 		flavor:      flavor,
 		version:     version,
 		interval:    interval,
-		sort:        make(map[string]interface{}),
+		sort:        make([]map[string]interface{}, 0),
 		customProps: make(map[string]interface{}),
 		aggBuilders: make([]AggBuilder, 0),
 	}
@@ -87,7 +87,7 @@ func (b *SearchRequestBuilder) Sort(order, field, unmappedType string) *SearchRe
 		props["unmapped_type"] = unmappedType
 	}
 
-	b.sort[field] = props
+	b.sort = append(b.sort, map[string]interface{}{field: props})
 
 	return b
 }

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -61,7 +61,7 @@ func TestSearchRequest(t *testing.T) {
 
 					Convey("Should have correct sorting", func() {
 						So(sr.Sort, ShouldHaveLength, 1)
-						sort, ok := sr.Sort[0][timeField].(map[string]string)
+						sort, ok := sr.Sort[0][timeField]
 						So(ok, ShouldBeTrue)
 						So(sort["order"], ShouldEqual, "desc")
 						So(sort["unmapped_type"], ShouldEqual, "boolean")

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -60,7 +60,7 @@ func TestSearchRequest(t *testing.T) {
 					})
 
 					Convey("Should have correct sorting", func() {
-						sort, ok := sr.Sort[timeField].(map[string]string)
+						sort, ok := sr.Sort[0][timeField].(map[string]string)
 						So(ok, ShouldBeTrue)
 						So(sort["order"], ShouldEqual, "desc")
 						So(sort["unmapped_type"], ShouldEqual, "boolean")
@@ -88,9 +88,8 @@ func TestSearchRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(json.Get("size").MustInt(0), ShouldEqual, 200)
 
-						sort := json.GetPath("sort", timeField)
-						So(sort.Get("order").MustString(), ShouldEqual, "desc")
-						So(sort.Get("unmapped_type").MustString(), ShouldEqual, "boolean")
+						sort := json.Get("sort").MustArray()[0]
+						So(sort, ShouldResemble, map[string]interface{}{timeField: map[string]interface{}{"order": "desc", "unmapped_type": "boolean"}})
 
 						timeRangeFilter := json.GetPath("query", "bool", "filter").GetIndex(0).Get("range").Get(timeField)
 						So(timeRangeFilter.Get("gte").MustInt64(), ShouldEqual, 5)

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -60,6 +60,7 @@ func TestSearchRequest(t *testing.T) {
 					})
 
 					Convey("Should have correct sorting", func() {
+						So(sr.Sort, ShouldHaveLength, 1)
 						sort, ok := sr.Sort[0][timeField].(map[string]string)
 						So(ok, ShouldBeTrue)
 						So(sort["order"], ShouldEqual, "desc")
@@ -88,8 +89,9 @@ func TestSearchRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(json.Get("size").MustInt(0), ShouldEqual, 200)
 
-						sort := json.Get("sort").MustArray()[0]
-						So(sort, ShouldResemble, map[string]interface{}{timeField: map[string]interface{}{"order": "desc", "unmapped_type": "boolean"}})
+						sort := json.Get("sort").MustArray()
+						So(sort, ShouldHaveLength, 1)
+						So(sort[0], ShouldResemble, map[string]interface{}{timeField: map[string]interface{}{"order": "desc", "unmapped_type": "boolean"}})
 
 						timeRangeFilter := json.GetPath("query", "bool", "filter").GetIndex(0).Get("range").Get(timeField)
 						So(timeRangeFilter.Get("gte").MustInt64(), ShouldEqual, 5)

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -36,8 +36,8 @@ func Test_raw_data(t *testing.T) {
 		assert.Equal(t, es.DateFormatEpochMS, rangeFilter.Format)
 
 		assert.Equal(t, 1337, sr.Size)
-		assert.Equal(t, map[string]string{"order": "desc", "unmapped_type": "boolean"}, sr.Sort["@timestamp"])
-		assert.Equal(t, map[string]string{"order": "desc"}, sr.Sort["_doc"])
+		assert.Equal(t, map[string]interface{}{"@timestamp": map[string]string{"order": "desc", "unmapped_type": "boolean"}}, sr.Sort[0])
+		assert.Equal(t, map[string]interface{}{"_doc": map[string]string{"order": "desc"}}, sr.Sort[1])
 	})
 }
 

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -36,8 +36,8 @@ func Test_raw_data(t *testing.T) {
 		assert.Equal(t, es.DateFormatEpochMS, rangeFilter.Format)
 
 		assert.Equal(t, 1337, sr.Size)
-		assert.Equal(t, map[string]interface{}{"@timestamp": map[string]string{"order": "desc", "unmapped_type": "boolean"}}, sr.Sort[0])
-		assert.Equal(t, map[string]interface{}{"_doc": map[string]string{"order": "desc"}}, sr.Sort[1])
+		assert.Equal(t, map[string]map[string]string{"@timestamp": {"order": "desc", "unmapped_type": "boolean"}}, sr.Sort[0])
+		assert.Equal(t, map[string]map[string]string{"_doc": {"order": "desc"}}, sr.Sort[1])
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Sort is an array, not just a map. 
This PR changes it to an array, which will reflect the order of priority defined in the code. 
The `map[string]interface{}` can also be more precisely typed as `map[string]map[string]string{}`. 

See https://opensearch.org/docs/latest/search-plugins/searching-data/sort/ for documentation on the array and examples.
>The sort parameter is an array, so you can specify multiple field values in the order of their priority.


Sort is only currently used in raw_data (and soon-to-be-implemented-in-the-backend raw_document) queries.

Similar to what was identified in Elasticsearch: https://github.com/grafana/grafana/blob/b39c8aec6c36a9557b147f628496af591cf1583e/pkg/tsdb/elasticsearch/client/search_request.go#L19C1-L19C1

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/196

