### PR TITLE
Default to timeField if no field is specified in date histogram aggregation

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -44,7 +44,8 @@ func (h *luceneHandler) processQuery(q *Query) error {
 	b := h.ms.Search(interval)
 	b.Size(0)
 	filters := b.Query().Bool().Filter()
-	filters.AddDateRangeFilter(h.client.GetTimeField(), es.DateFormatEpochMS, toMs, fromMs)
+	defaultTimeField := h.client.GetTimeField()
+	filters.AddDateRangeFilter(defaultTimeField, es.DateFormatEpochMS, toMs, fromMs)
 
 	if q.RawQuery != "" {
 		filters.AddQueryStringFilter(q.RawQuery, true)
@@ -59,9 +60,9 @@ func (h *luceneHandler) processQuery(q *Query) error {
 
 	switch {
 	case q.Metrics[0].Type == rawDataType:
-		processRawDataQuery(q, b, h.client.GetTimeField())
+		processRawDataQuery(q, b, defaultTimeField)
 	default:
-		processTimeSeriesQuery(q, b, fromMs, toMs)
+		processTimeSeriesQuery(q, b, fromMs, toMs, defaultTimeField)
 	}
 
 	return nil
@@ -83,7 +84,7 @@ func processRawDataQuery(q *Query, b *es.SearchRequestBuilder, defaultTimeField 
 	b.Size(size)
 }
 
-func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, toMs int64) {
+func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, toMs int64, defaultTimeField string) {
 	metric := q.Metrics[0]
 	b.Size(metric.Settings.Get("size").MustInt(500))
 	aggBuilder := b.Agg()
@@ -92,7 +93,7 @@ func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, 
 	for _, bucketAgg := range q.BucketAggs {
 		switch bucketAgg.Type {
 		case dateHistType:
-			aggBuilder = addDateHistogramAgg(aggBuilder, bucketAgg, fromMs, toMs)
+			aggBuilder = addDateHistogramAgg(aggBuilder, bucketAgg, fromMs, toMs, defaultTimeField)
 		case histogramType:
 			aggBuilder = addHistogramAgg(aggBuilder, bucketAgg)
 		case filtersType:
@@ -204,8 +205,13 @@ func (h *luceneHandler) executeQueries() (*backend.QueryDataResponse, error) {
 	return rp.getTimeSeries(h.client.GetTimeField())
 }
 
-func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo int64) es.AggBuilder {
-	aggBuilder.DateHistogram(bucketAgg.ID, bucketAgg.Field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
+func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo int64, timeField string) es.AggBuilder {
+	// If no field is specified, use the time field
+	field := bucketAgg.Field
+	if field == "" {
+		field = timeField
+	}
+	aggBuilder.DateHistogram(bucketAgg.ID, field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
 		a.Interval = bucketAgg.Settings.Get("interval").MustString("auto")
 		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
 		a.ExtendedBounds = &es.ExtendedBounds{Min: timeFrom, Max: timeTo}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Based on https://github.com/grafana/grafana/pull/60238

In a date_histogram aggregation, the aggregation input a user enters or chooses in the UI is taken into account. Otherwise if none is present, it defaults to the default timeField. 

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/199
Original issue it fixed would be the equivalent of https://github.com/grafana/grafana/issues/8260