### PR TITLE
Refactor client to have configuredFields, refactor raw_data response parsing to resemble raw_document

### DIFF
--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -218,7 +218,7 @@ func createMultisearchForTest(c Client) (*MultiSearchRequest, error) {
 
 func createPPLForTest(c Client) (*PPLRequest, error) {
 	b := c.PPL()
-	b.AddPPLQueryString(c.GetTimeField(), "$timeTo", "$timeFrom", "")
+	b.AddPPLQueryString(c.GetConfiguredFields().TimeField, "$timeTo", "$timeFrom", "")
 	return b.Build()
 }
 

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -44,7 +44,7 @@ func (h *luceneHandler) processQuery(q *Query) error {
 	b := h.ms.Search(interval)
 	b.Size(0)
 	filters := b.Query().Bool().Filter()
-	defaultTimeField := h.client.GetTimeField()
+	defaultTimeField := h.client.GetConfiguredFields().TimeField
 	filters.AddDateRangeFilter(defaultTimeField, es.DateFormatEpochMS, toMs, fromMs)
 
 	if q.RawQuery != "" {
@@ -60,7 +60,7 @@ func (h *luceneHandler) processQuery(q *Query) error {
 
 	switch q.Metrics[0].Type {
 	case rawDocumentType, rawDataType:
-		processDocumentQuery(q, b, h.client.GetTimeField())
+		processDocumentQuery(q, b, defaultTimeField)
 	default:
 		processTimeSeriesQuery(q, b, fromMs, toMs, defaultTimeField)
 	}
@@ -202,7 +202,7 @@ func (h *luceneHandler) executeQueries() (*backend.QueryDataResponse, error) {
 	}
 
 	rp := newResponseParser(res.Responses, h.queries, res.DebugInfo)
-	return rp.getTimeSeries(h.client.GetTimeField())
+	return rp.getTimeSeries(h.client.GetConfiguredFields())
 }
 
 func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo int64, timeField string) es.AggBuilder {

--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -24,7 +24,7 @@ func (h *pplHandler) processQuery(q *Query) error {
 	to := h.req.Queries[0].TimeRange.To.UTC().Format("2006-01-02 15:04:05")
 
 	builder := h.client.PPL()
-	builder.AddPPLQueryString(h.client.GetTimeField(), to, from, q.RawQuery)
+	builder.AddPPLQueryString(h.client.GetConfiguredFields().TimeField, to, from, q.RawQuery)
 	h.builders[q.RefID] = builder
 	return nil
 }

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -82,7 +82,7 @@ func (rp *responseParser) getTimeSeries(configuredFields es.ConfiguredFields) (*
 		case rawDataType:
 			queryRes = processRawDataResponse(res, configuredFields.TimeField, queryRes)
 		case rawDocumentType:
-			queryRes = processRawDocumentResponse(res, timeField, target.RefID, queryRes)
+			queryRes = processRawDocumentResponse(res, target.RefID, queryRes)
 		default:
 			props := make(map[string]string)
 			err := rp.processBuckets(res.Aggregations, target, &queryRes, props, 0)
@@ -100,30 +100,36 @@ func (rp *responseParser) getTimeSeries(configuredFields es.ConfiguredFields) (*
 
 func processRawDataResponse(res *es.SearchResponse, timeField string, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
-	docs := make([]map[string]interface{}, len(res.Hits.Hits))
-
+	documents := make([]map[string]interface{}, len(res.Hits.Hits))
 	for hitIdx, hit := range res.Hits.Hits {
-		var flattenedSource map[string]interface{}
+		doc := map[string]interface{}{
+			"_id":    hit["_id"],
+			"_type":  hit["_type"],
+			"_index": hit["_index"],
+		}
+
 		if hit["_source"] != nil {
-			// On frontend maxDepth wasn't used but as we are processing on backend
-			// let's put a limit to avoid infinite loop. 10 was chosen arbitrarily.
-			flattenedSource = flatten(hit["_source"].(map[string]interface{}), 10)
+			source, ok := hit["_source"].(map[string]interface{})
+			if ok {
+				// On frontend maxDepth wasn't used but as we are processing on backend
+				// let's put a limit to avoid infinite loop. 10 was chosen arbitrarily.
+				for k, v := range flatten(source, 10) {
+					doc[k] = v
+				}
+			}
 		}
 
-		flattenedSource["_id"] = hit["_id"]
-		flattenedSource["_type"] = hit["_type"]
-		flattenedSource["_index"] = hit["_index"]
-		if timestamp, ok := getTimestamp(hit, flattenedSource, timeField); ok {
-			flattenedSource[timeField] = timestamp
+		if timestamp, ok := getTimestamp(hit, doc, timeField); ok {
+			doc[timeField] = timestamp
 		}
 
-		for key := range flattenedSource {
+		for key := range doc {
 			propNames[key] = true
 		}
 
-		docs[hitIdx] = flattenedSource
+		documents[hitIdx] = doc
 	}
-	fields := processDocsToDataFrameFields(docs, propNames)
+	fields := processDocsToDataFrameFields(documents, propNames)
 
 	frames := data.Frames{}
 	frame := data.NewFrame("", fields...)
@@ -133,7 +139,7 @@ func processRawDataResponse(res *es.SearchResponse, timeField string, queryRes b
 	return queryRes
 }
 
-func processRawDocumentResponse(res *es.SearchResponse, timeField, refID string, queryRes backend.DataResponse) backend.DataResponse {
+func processRawDocumentResponse(res *es.SearchResponse, refID string, queryRes backend.DataResponse) backend.DataResponse {
 	documents := make([]map[string]interface{}, len(res.Hits.Hits))
 	for hitIdx, hit := range res.Hits.Hits {
 		doc := map[string]interface{}{

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -45,7 +45,7 @@ var newResponseParser = func(responses []*es.SearchResponse, targets []*Query, d
 	}
 }
 
-func (rp *responseParser) getTimeSeries(timeField string) (*backend.QueryDataResponse, error) {
+func (rp *responseParser) getTimeSeries(configuredFields es.ConfiguredFields) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 
 	if rp.Responses == nil {
@@ -80,7 +80,7 @@ func (rp *responseParser) getTimeSeries(timeField string) (*backend.QueryDataRes
 
 		switch target.Metrics[0].Type {
 		case rawDataType:
-			queryRes = processRawDataResponse(res, timeField, queryRes)
+			queryRes = processRawDataResponse(res, configuredFields.TimeField, queryRes)
 		case rawDocumentType:
 			queryRes = processRawDocumentResponse(res, timeField, target.RefID, queryRes)
 		default:

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -131,11 +131,7 @@ func processRawDataResponse(res *es.SearchResponse, timeField string, queryRes b
 	}
 	fields := processDocsToDataFrameFields(documents, propNames)
 
-	frames := data.Frames{}
-	frame := data.NewFrame("", fields...)
-	frames = append(frames, frame)
-
-	queryRes.Frames = frames
+	queryRes.Frames = data.Frames{data.NewFrame("", fields...)}
 	return queryRes
 }
 

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -45,7 +45,7 @@ func Test_ResponseParser_test(t *testing.T) {
 			}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -96,7 +96,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -158,7 +158,7 @@ func Test_ResponseParser_test(t *testing.T) {
 			}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		responseForA, ok := result.Responses["A"]
 		require.True(t, ok)
@@ -228,7 +228,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -301,7 +301,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -381,7 +381,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -466,7 +466,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -570,7 +570,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -630,7 +630,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -691,7 +691,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -764,7 +764,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -821,7 +821,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -876,7 +876,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -945,7 +945,7 @@ func Test_ResponseParser_test(t *testing.T) {
 				}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1038,7 +1038,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		}`
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		assert.Nil(t, err)
 		require.Len(t, result.Responses, 1)
 		queryRes := result.Responses["A"]
@@ -1243,7 +1243,7 @@ func Test_ProcessRawDataResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1302,7 +1302,7 @@ func Test_ProcessRawDataResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1421,7 +1421,7 @@ func Test_ProcessRawDataResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1484,7 +1484,7 @@ func Test_ProcessRawDataResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 
 		require.NotNil(t, result.Responses["A"])
@@ -1558,7 +1558,7 @@ func TestHistogramSimple(t *testing.T) {
 	}`
 	rp, err := newResponseParserForTest(query, response)
 	assert.NoError(t, err)
-	result, err := rp.getTimeSeries("@timestamp")
+	result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 	assert.NoError(t, err)
 	require.Len(t, result.Responses, 1)
 
@@ -1732,7 +1732,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1825,7 +1825,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1912,7 +1912,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 
@@ -1956,7 +1956,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 
 		rp, err := newResponseParserForTest(targets, response)
 		assert.Nil(t, err)
-		result, err := rp.getTimeSeries("@timestamp")
+		result, err := rp.getTimeSeries(client.ConfiguredFields{TimeField: "@timestamp"})
 		require.NoError(t, err)
 		require.Len(t, result.Responses, 1)
 

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -836,8 +836,8 @@ func (c *fakeClient) GetVersion() *semver.Version {
 	return c.version
 }
 
-func (c *fakeClient) GetTimeField() string {
-	return c.timeField
+func (c *fakeClient) GetConfiguredFields() es.ConfiguredFields {
+	return es.ConfiguredFields{TimeField: c.timeField}
 }
 
 func (c *fakeClient) GetIndex() string {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
* Refactors the client to have types and methods supporting "configured fields" which include the configured timeField and will include the logLevelField for https://github.com/grafana/opensearch-datasource/issues/199. This will minimize the number of lines changed for the upcoming PR.
* Refactors the response parsing in raw_data to resemble the recently-finished raw_document and the similar code in Elasticsearch. There might be some similar code again in https://github.com/grafana/opensearch-datasource/issues/199. Some of this can probably be combined. 

**Which issue(s) this PR fixes**:

Contributes to #https://github.com/grafana/opensearch-datasource/issues/199
