### PR TITLE
Refactor getTimestamp and sort of property names

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -138,14 +138,15 @@ func processRawDataResponse(res *es.SearchResponse, timeField string, queryRes b
 }
 
 func sortPropNames(propNames map[string]bool, configuredFields es.ConfiguredFields) []string {
-	sortedPropNames := putTimeFieldAtTheFront(propNames, configuredFields)
+	timeField := putTimeFieldAtTheFront(propNames, configuredFields)
 
+	var sortedPropNames []string
 	for k := range propNames {
 		sortedPropNames = append(sortedPropNames, k)
 	}
 	sort.Strings(sortedPropNames)
 
-	return sortedPropNames
+	return append(timeField, sortedPropNames...)
 }
 
 func putTimeFieldAtTheFront(propNames map[string]bool, configuredFields es.ConfiguredFields) []string {

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -138,7 +138,7 @@ func processRawDataResponse(res *es.SearchResponse, timeField string, queryRes b
 }
 
 func sortPropNames(propNames map[string]bool, configuredFields es.ConfiguredFields) []string {
-	timeField := putTimeFieldAtTheFront(propNames, configuredFields)
+	initialSortedPropNames := initializeListWithTimeField(propNames, configuredFields)
 
 	var sortedPropNames []string
 	for k := range propNames {
@@ -146,19 +146,15 @@ func sortPropNames(propNames map[string]bool, configuredFields es.ConfiguredFiel
 	}
 	sort.Strings(sortedPropNames)
 
-	return append(timeField, sortedPropNames...)
+	return append(initialSortedPropNames, sortedPropNames...)
 }
 
-func putTimeFieldAtTheFront(propNames map[string]bool, configuredFields es.ConfiguredFields) []string {
+func initializeListWithTimeField(propNames map[string]bool, configuredFields es.ConfiguredFields) []string {
 	var fields []string
 
-	hasTimeField := false
 	if _, ok := propNames[configuredFields.TimeField]; ok {
-		hasTimeField = true
-		delete(propNames, configuredFields.TimeField)
-	}
-	if hasTimeField {
 		fields = append(fields, configuredFields.TimeField)
+		delete(propNames, configuredFields.TimeField)
 	}
 
 	return fields

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1159,7 +1159,7 @@ func Test_getTimestamp(t *testing.T) {
 
 		require.NotNil(t, actual)
 		assert.True(t, ok)
-		assert.Equal(t, time.Date(2018, time.August, 18, 8, 8, 8, 765000000, time.UTC), *actual)
+		assert.Equal(t, time.Date(2018, time.August, 18, 8, 8, 8, 765000000, time.UTC), actual)
 	})
 
 	t.Run("When fields is absent and source's time field is present, then getTimestamp falls back to _source", func(t *testing.T) {
@@ -1169,9 +1169,8 @@ func Test_getTimestamp(t *testing.T) {
 
 		actual, ok := getTimestamp(hit, "@timestamp")
 
-		require.NotNil(t, actual)
 		assert.True(t, ok)
-		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), *actual)
+		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), actual)
 	})
 
 	t.Run("When fields has its timestamp in an unexpected layout and _source's time field is also present, then getTimestamp falls back to _source", func(t *testing.T) {
@@ -1182,9 +1181,8 @@ func Test_getTimestamp(t *testing.T) {
 
 		actual, ok := getTimestamp(hit, "@timestamp")
 
-		require.NotNil(t, actual)
 		assert.True(t, ok)
-		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), *actual)
+		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), actual)
 	})
 
 	t.Run("When fields's timestamp has an unexpected format, then getTimestamp looks in source", func(t *testing.T) {
@@ -1195,26 +1193,23 @@ func Test_getTimestamp(t *testing.T) {
 
 		actual, ok := getTimestamp(hit, "@timestamp")
 
-		require.NotNil(t, actual)
 		assert.True(t, ok)
-		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), *actual)
+		assert.Equal(t, time.Date(2020, time.January, 01, 10, 10, 10, 765000000, time.UTC), actual)
 	})
 
-	t.Run("When fields is absent and _source's time field has an unexpected format, then getTimestamp returns nil and false", func(t *testing.T) {
+	t.Run("When fields is absent and _source's time field has an unexpected format, then getTimestamp returns false", func(t *testing.T) {
 		hit := map[string]interface{}{
 			"_source": map[string]interface{}{"@timestamp": "unexpected format"},
 		}
 
-		actual, ok := getTimestamp(hit, "@timestamp")
+		_, ok := getTimestamp(hit, "@timestamp")
 
-		assert.Nil(t, actual)
 		assert.False(t, ok)
 	})
 
-	t.Run("When fields is absent and _source's time field is absent, then getTimestamp returns nil and false", func(t *testing.T) {
-		actual, ok := getTimestamp(nil, "@timestamp")
+	t.Run("When fields is absent and _source's time field is absent, then getTimestamp returns false", func(t *testing.T) {
+		_, ok := getTimestamp(nil, "@timestamp")
 
-		assert.Nil(t, actual)
 		assert.False(t, ok)
 	})
 }

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1989,5 +1989,9 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 }
 
 func Test_sortPropNames_puts_timeField_at_the_beginning(t *testing.T) {
-	assert.Equal(t, []string{"testtime", "Average", "_id"}, sortPropNames(map[string]bool{"_id": true, "Average": true, "testtime": true}, client.ConfiguredFields{TimeField: "testtime"}))
+	actual := sortPropNames(
+		map[string]bool{"_id": true, "Average": true, "timestamp": true},
+		client.ConfiguredFields{TimeField: "timestamp"},
+	)
+	assert.Equal(t, []string{"timestamp", "Average", "_id"}, actual)
 }

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1987,3 +1987,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 		assert.JSONEq(t, `{"_id":null,"_index":null,"_type":null,"@timestamp":"1999-01-01T12:12:12.111Z"}`, string(*doc1))
 	})
 }
+
+func Test_sortPropNames_puts_timeField_at_the_beginning(t *testing.T) {
+	assert.Equal(t, []string{"testtime", "Average", "_id"}, sortPropNames(map[string]bool{"_id": true, "Average": true, "testtime": true}, client.ConfiguredFields{TimeField: "testtime"}))
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
* Refactors getTimestamp to return time.Time, not a pointer anymore. This allows it to be included in the generic function to create fields.
* Modifies getTimestamp's behavior a little. If the timestamp string in `fields` is not a valid format (unlikely), it will fall back to check `_source`. Before it would just fail right there. See changes in the test file for the behavior.
* Property names sorting is now extracted out of `processDocsToDataFrameFields`

These functions will be used in the PR for https://github.com/grafana/opensearch-datasource/issues/199, so the intention is to break up the changes to have a more focused review later on.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/199

