### PR TITLE
Add ad hoc filters before sending Lucene queries to backend

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1291,15 +1291,6 @@ describe('OpenSearchDatasource', function(this: any) {
     });
 
     it('does not send query including types not yet migrated to backend', () => {
-      // TODO: Ask Ida if we need this part? still compiles below
-      // datasourceRequestMock.mockImplementation(options => {
-      //   return Promise.resolve({
-      //     data: {
-      //       responses: [],
-      //     },
-      //   });
-      // });
-
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -1611,15 +1602,15 @@ describe('OpenSearchDatasource', function(this: any) {
     });
 
     describe('with 1 ad hoc filter', () => {
+      const adHocFilters = [{ key: 'test', operator: '=', value: 'test1', condition: '' }];
       it('should correctly add 1 ad hoc filter when query is not empty', () => {
-        const query = ctx.ds.addAdHocFilters('foo:"bar"', [
-          { key: 'test', operator: '=', value: 'test1', condition: '' },
-        ]);
+        const query = ctx.ds.addAdHocFilters('foo:"bar"', adHocFilters);
         expect(query).toBe('foo:"bar" AND test:"test1"');
       });
 
       it('should correctly add 1 ad hoc filter when query is empty', () => {
-        const query = ctx.ds.addAdHocFilters('', [{ key: 'test', operator: '=', value: 'test1', condition: '' }]); // an empty string query is transformed to '*' but this can be refactored to have the same behavior as Elasticsearch
+        // an empty string query is transformed to '*' but this can be refactored to have the same behavior as Elasticsearch
+        const query = ctx.ds.addAdHocFilters('', adHocFilters);
         expect(query).toBe('test:"test1"');
       });
       it('should escape characters in filter keys', () => {
@@ -1631,25 +1622,21 @@ describe('OpenSearchDatasource', function(this: any) {
     });
 
     describe('with multiple ad hoc filters', () => {
+      const adHocFilters = [
+        { key: 'bar', operator: '=', value: 'baz', condition: '' },
+        { key: 'job', operator: '!=', value: 'grafana', condition: '' },
+        { key: 'service', operator: '=~', value: 'service', condition: '' },
+        { key: 'count', operator: '>', value: '1', condition: '' },
+      ];
       it('should correctly add ad hoc filters when query is not empty', () => {
-        const query = ctx.ds.addAdHocFilters('foo:"bar" AND test:"test1"', [
-          { key: 'bar', operator: '=', value: 'baz', condition: '' },
-          { key: 'job', operator: '!=', value: 'grafana', condition: '' },
-          { key: 'service', operator: '=~', value: 'service', condition: '' },
-          { key: 'count', operator: '>', value: '1', condition: '' },
-        ]);
+        const query = ctx.ds.addAdHocFilters('foo:"bar" AND test:"test1"', adHocFilters);
         expect(query).toBe(
           'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1'
         );
       });
 
       it('should correctly add ad hoc filters when query is  empty', () => {
-        const query = ctx.ds.addAdHocFilters('', [
-          { key: 'bar', operator: '=', value: 'baz', condition: '' },
-          { key: 'job', operator: '!=', value: 'grafana', condition: '' },
-          { key: 'service', operator: '=~', value: 'service', condition: '' },
-          { key: 'count', operator: '>', value: '1', condition: '' },
-        ]);
+        const query = ctx.ds.addAdHocFilters('', adHocFilters);
         expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1');
       });
     });

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -44,6 +44,8 @@ jest.mock('./tracking.ts', () => ({
   trackQuery: jest.fn(),
 }));
 
+const getAdHocFiltersMock = jest.fn(() => []);
+
 jest.mock('@grafana/runtime', () => ({
   ...((jest.requireActual('@grafana/runtime') as unknown) as object),
   getBackendSrv: () => {
@@ -64,7 +66,7 @@ jest.mock('@grafana/runtime', () => ({
         return text;
       }
     }),
-    getAdhocFilters: jest.fn(() => []),
+    getAdhocFilters: getAdHocFiltersMock,
   }),
 }));
 
@@ -1233,8 +1235,7 @@ describe('OpenSearchDatasource', function(this: any) {
   });
 
   it('should send ad hoc filtered query to backend', () => {
-    // @ts-ignore
-    getTemplateSrv.getAdhocFilters.mockImplementation([{ key: 'bar', operator: '=', value: 'test' }]);
+    getAdHocFiltersMock.mockImplementation(() => [{ key: 'bar', operator: '=', value: 'test' }]);
     const mockedSuperQuery = jest
       .spyOn(DataSourceWithBackend.prototype, 'query')
       .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -507,24 +507,24 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     ) {
       // @ts-ignore
       const adHocFilters = getTemplateSrv().getAdhocFilters(this.name);
-      const queriesWithAdHocVariables = targetsWithInterpolatedVariables.map(t => ({
+      const queriesWithAdHocAndInterpolatedVariables = targetsWithInterpolatedVariables.map(t => ({
         ...t,
         query: this.addAdHocFilters(t.query, adHocFilters),
       }));
-      const interpolatedRequest = { ...request, targets: queriesWithAdHocVariables };
-      return super.query(interpolatedRequest).pipe(
+      const adHocAndInterpolatedRequest = { ...request, targets: queriesWithAdHocAndInterpolatedVariables };
+      return super.query(adHocAndInterpolatedRequest).pipe(
         tap({
           next: response => {
-            trackQuery(response, targetsWithInterpolatedVariables, interpolatedRequest.app);
+            trackQuery(response, targetsWithInterpolatedVariables, adHocAndInterpolatedRequest.app);
           },
           error: error => {
-            trackQuery({ error, data: [] }, targetsWithInterpolatedVariables, interpolatedRequest.app);
+            trackQuery({ error, data: [] }, targetsWithInterpolatedVariables, adHocAndInterpolatedRequest.app);
           },
         })
       );
     }
 
-    // Queries still run in the frontend
+    // Frontend flow
     const luceneTargets: OpenSearchQuery[] = [];
     const pplTargets: OpenSearchQuery[] = [];
     for (const target of targetsWithInterpolatedVariables) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
For Lucene queries which were recently migrated to the backend, this fixes ad hoc filters on queries which were redirected to the backend as part of this plugin's [migration to a backend data source](https://github.com/grafana/opensearch-datasource/issues/192).

Ad hoc filters were only added [in the frontend while building the query](https://github.com/grafana/opensearch-datasource/blob/ebbfc716282a66592333a5252ae6453e356ebae7/src/datasource.ts#L648), so this code was not reached when [diverting queries to the backend](https://github.com/grafana/opensearch-datasource/blob/main/src/datasource.ts#L459C1-L484). 

Here is a recording of this PR's behavior:

https://github.com/grafana/opensearch-datasource/assets/4163034/44fd9e81-2897-4176-b322-2482abacda27


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/opensearch-datasource/issues/224

**Special notes for your reviewer**:
This PR should revert the behavior to the same as in v2.6.2 and before.
Ad hoc filtering will not return data for nested documents as this is not supported in the Lucene query language. 

Thank you @idastambuk for all your help on this one!
