### PR TITLE
Handle errors caused by empty targets

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -500,6 +500,9 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     );
 
     // Gradually migrate queries to the backend in this condition
+    if (!targetsWithInterpolatedVariables.every(target => target.hasOwnProperty('metric'))) {
+      throw new Error('Some targets are missing the "metric" field.');
+    }
     if (
       request.targets.every(target =>
         target.metrics?.every(metric => metric.type === 'raw_data' || metric.type === 'raw_document')


### PR DESCRIPTION
This code introduced in this change:
https://github.com/grafana/opensearch-datasource/commit/24fcd47ea212f058ecf8227554c2d16a93f60a57 doesn't handle cases in which the `metric` filed in now present in the `target` object. In such cases the conditional will cause a `SIGSEGV: segmentation violation` when trying to access non-existing `target.metric`.

<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
