### PR TITLE
Update trackQuery to track non-dashboard queries

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -3,6 +3,10 @@ import { reportInteraction } from '@grafana/runtime';
 import { LuceneQueryType, OpenSearchQuery, QueryType } from 'types';
 
 export function trackQuery(response: DataQueryResponse, queries: OpenSearchQuery[], app: string): void {
+  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+    return;
+  }
+
   for (const query of queries) {
     try {
       reportInteraction('grafana_opensearch_query_executed', {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,4 +1,4 @@
-import { DataQueryResponse } from '@grafana/data';
+import { CoreApp, DataQueryResponse } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { LuceneQueryType, OpenSearchQuery, QueryType } from 'types';
 


### PR DESCRIPTION
In [Loki](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/tracking.ts#L161) and [Elasticsearch](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/tracking.ts#L119) we track only non-dashboard queries, as dashboards can have 100s of panels and can have refresh interval of `5s` which leads to huge number of tracked queries.

If we are tracking only Explore/Panel View/Others queries, we can get a better insight into what queries are USERS executing and not which ones are run in dashboards on repeat.

So I decided to create this suggestion PR for you to consider. 🙂