### PR TITLE
Fix: convert ad-hoc timestamp filters to UTC for PPL queries

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
+// force timezone to UTC to allow tests to work regardless of local timezone
+// generally used by snapshots, but can affect specific tests
+process.env.TZ = 'UTC';
+
 const path = require('path');
 
 // This file is needed because it is used by vscode and other tools that

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -458,7 +458,9 @@ export class QueryBuilder {
 
     for (i = 0; i < adhocFilters.length; i++) {
       if (dateMath.isValid(adhocFilters[i].value)) {
-        const validTime = dateTime(adhocFilters[i].value).format('YYYY-MM-DD HH:mm:ss.SSSSSS');
+        const validTime = dateTime(adhocFilters[i].value)
+          .utc()
+          .format('YYYY-MM-DD HH:mm:ss.SSSSSS');
         value = `timestamp('${validTime}')`;
       } else if (typeof adhocFilters[i].value === 'string') {
         value = `'${adhocFilters[i].value}'`;


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where ad-hoc timestamp filters did not work correctly due to the ad-hoc timestamp filter not being translated to a UTC timestamp.

**Which issue(s) this PR fixes**:

Fixes #212 

**Special notes for your reviewer**:

Testing instructions are in the original issue's description.

There is an existing test case already in `src/specs/QueryBuilder.test.ts`. It's named `"should return the query with datetime adhoc filter and time range filter"`. No changes required for the actual test case, only update to the jest config to set a predictable timezone was required.