### PR TITLE
Reuse http Client in the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2.10.0
+## 2.10.1
 
+- Backend: Refactor http client so that it is reused
+
+## 2.10.0
 
 - [Explore] Migrate Lucene log queries to the backend by @fridgepoet in https://github.com/grafana/opensearch-datasource/pull/228
   - The Lucene Logs query type has been refactored to execute through the backend in the **Explore view only**. Existing Lucene Logs queries in Dashboards are unchanged and execute through the frontend. Please report any anomalies observed in Explore by [reporting an issue](https://github.com/grafana/opensearch-datasource/issues/new?assignees=&labels=datasource%2FOpenSearch%2Ctype%2Fbug&projects=&template=bug_report.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -22,14 +22,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 var (
 	clientLog = log.New()
 )
 
-var newDatasourceHttpClient = func(ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
+func NewDatasourceHttpClient(ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
 	var settings struct {
 		IsServerless bool `json:"serverless"`
 	}
@@ -541,18 +540,13 @@ func (c *baseClientImpl) executePPLQueryRequest(method, uriPath string, body []b
 		req.SetBasicAuth(c.ds.User, password)
 	}
 
-	httpClient, err := newDatasourceHttpClient(c.ds)
-	if err != nil {
-		return nil, err
-	}
-
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start)
 		clientLog.Debug("Executed request", "took", elapsed)
 	}()
 	//nolint:bodyclose
-	resp, err := ctxhttp.Do(c.ctx, httpClient, req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -262,17 +262,6 @@ func httpClientScenario(t *testing.T, desc string, ds *backend.DataSourceInstanc
 		So(c, ShouldNotBeNil)
 		sc.client = c
 
-		currentNewDatasourceHttpClient := newDatasourceHttpClient
-
-		newDatasourceHttpClient = func(ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
-			return ts.Client(), nil
-		}
-
-		defer func() {
-			ts.Close()
-			newDatasourceHttpClient = currentNewDatasourceHttpClient
-		}()
-
 		fn(sc)
 	})
 }
@@ -324,8 +313,8 @@ func Test_TLS_config_included_in_client_passed_from_decrypted_json_data(t *testi
 	clientCertPEM, clientKeyPEM, err := generateCertificate(t, "client.localhost", ca, caPrivKey)
 	require.NoError(t, err)
 
-	// verify that newDatasourceHttpClient, when provided the client's JSON data from the config editor, is able to authenticate with the test server mutually
-	client, err := newDatasourceHttpClient(&backend.DataSourceInstanceSettings{
+	// verify that NewDatasourceHttpClient, when provided the client's JSON data from the config editor, is able to authenticate with the test server mutually
+	client, err := NewDatasourceHttpClient(&backend.DataSourceInstanceSettings{
 		JSONData: jsonEncoding.RawMessage(`{"tlsAuth":true, "tlsAuthWithCACert":true}`),
 		DecryptedSecureJSONData: map[string]string{
 			"tlsCACert":     caPEM.String(),
@@ -463,7 +452,7 @@ func Test_newDatasourceHttpClient_includes_sigV4_information(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := newDatasourceHttpClient(&backend.DataSourceInstanceSettings{
+	client, err := NewDatasourceHttpClient(&backend.DataSourceInstanceSettings{
 		JSONData: jsonEncoding.RawMessage(`{
 		   "flavor":"opensearch",
 		   "sigV4Auth":true,
@@ -491,7 +480,7 @@ func Test_newDatasourceHttpClient_sets_aoss_as_service_name_for_serverless(t *te
 	}))
 	defer server.Close()
 
-	client, err := newDatasourceHttpClient(&backend.DataSourceInstanceSettings{
+	client, err := NewDatasourceHttpClient(&backend.DataSourceInstanceSettings{
 		JSONData: jsonEncoding.RawMessage(`{
 		   "flavor":"opensearch",
 		   "sigV4Auth":true,

--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -37,8 +37,7 @@ func TestClient(t *testing.T) {
 				ds := &backend.DataSourceInstanceSettings{
 					JSONData: utils.NewRawJsonFromAny(make(map[string]interface{})),
 				}
-
-				_, err := NewClient(context.Background(), ds, nil)
+				_, err := NewClient(context.Background(), ds, &http.Client{}, nil)
 				So(err, ShouldNotBeNil)
 			})
 
@@ -49,7 +48,7 @@ func TestClient(t *testing.T) {
 					}),
 				}
 
-				_, err := NewClient(context.Background(), ds, nil)
+				_, err := NewClient(context.Background(), ds, &http.Client{}, nil)
 				So(err, ShouldNotBeNil)
 			})
 
@@ -61,7 +60,7 @@ func TestClient(t *testing.T) {
 					}),
 				}
 
-				_, err := NewClient(context.Background(), ds, nil)
+				_, err := NewClient(context.Background(), ds, &http.Client{}, nil)
 				So(err, ShouldNotBeNil)
 			})
 		})
@@ -258,7 +257,7 @@ func httpClientScenario(t *testing.T, desc string, ds *backend.DataSourceInstanc
 		to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
 		timeRange := &backend.TimeRange{From: from, To: to}
 
-		c, err := NewClient(context.Background(), ds, timeRange)
+		c, err := NewClient(context.Background(), ds, &http.Client{}, timeRange)
 		So(err, ShouldBeNil)
 		So(c, ShouldNotBeNil)
 		sc.client = c

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
@@ -33,12 +32,7 @@ type OpenSearchDatasource struct {
 func NewOpenSearchDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	log.DefaultLogger.Debug("Initializing new data source instance")
 
-	httpClientProvider := httpclient.NewProvider()
-	httpClientOpts, err := settings.HTTPClientOptions()
-	if err != nil {
-		return nil, fmt.Errorf("error getting http options: %w", err)
-	}
-	httpClient, err := httpClientProvider.New(httpClientOpts)
+	httpClient, err := client.NewDatasourceHttpClient(&settings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Similar to the fix in Elasticsearch: https://github.com/grafana/grafana/pull/55172

The http.Client was initialized with every [Lucene](https://github.com/grafana/opensearch-datasource/blob/b2812efd4b20bafbccf0fa3378b96fb57f2f0b43/pkg/opensearch/client/client.go#L323) and [PPL query execution](https://github.com/grafana/opensearch-datasource/blob/b2812efd4b20bafbccf0fa3378b96fb57f2f0b43/pkg/opensearch/client/client.go#L546).

This PR is a refactor so that the http.Client is initialized at a higher level. This Client is passed to the entry point of query execution so that it can be reused. 

**Which issue(s) this PR fixes**:

Fixes #https://github.com/grafana/opensearch-datasource/issues/250

**Special notes for your reviewer**:
The following types of queries were tested for non-regression: Lucene raw_data and raw_document queries are executed in the backend. Lucene logs queries are executed on the backend in Explore.
An AWS Serverless instance was also tested with SigV4 authentication. 