### PR TITLE
Release 2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.10.2
+
+- Dependencies update
+
 ## 2.10.1
 
 - Backend: Refactor http client so that it is reused

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",


### PR DESCRIPTION
Release for https://github.com/grafana/opensearch-datasource/pull/263

Update dependencies

prismjs -> 1.28.0
simple-git -> 3.19.1