### PR TITLE
Get filter values with correct time range

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -964,7 +964,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
   }
 
   getTagValues(options: any) {
-    return this.getTerms({ field: options.key, query: '*' });
+    return this.getTerms({ field: options.key, query: '*' }, options.timeRange);
   }
 
   targetContainsTemplate(target: any) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Depends on https://github.com/grafana/grafana/pull/74952 or something similar that actually passes the timeRange to getTagValues to work. (If timeRange isn't passed then nothing changes)
This passes the timeRange of the getTagValue query along to getTerms, so we'll get values in the correct range instead of the default last 6 hours

**Which issue(s) this PR fixes**:

Fixes #213

**Special notes for your reviewer**:
This has to be run with a version of main grafana with the above pr merged for the timeRange field to actually be passed in