### PR TITLE
Lucene metrics: Parse MinDocCount as int or string

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -138,6 +138,9 @@ func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, 
 
 	// iterate backwards to create aggregations bottom-down
 	for _, bucketAgg := range q.BucketAggs {
+		bucketAgg.Settings = utils.NewJsonFromAny(
+			bucketAgg.generateSettingsForDSL(),
+		)
 		switch bucketAgg.Type {
 		case dateHistType:
 			aggBuilder = addDateHistogramAgg(aggBuilder, bucketAgg, fromMs, toMs, defaultTimeField)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Query building (to OpenSearch) was compared between the backend and the frontend for the following query:
![Screenshot 2023-09-27 at 17 59 21](https://github.com/grafana/opensearch-datasource/assets/4163034/6dc56d4d-44f5-4af1-b8a2-89e02c370f1e)

One of the differences observed was: `min_doc_count` was missing from the backend query and present in the frontend query. This PR adds this MinDocCount to the query.

The equivalent fix PR in Elasticsearch was this one: https://github.com/grafana/grafana/pull/59713

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/197

**Special notes for your reviewer**:
You can include the changes or cherry-pick this commit to enable backend flow everywhere. https://github.com/grafana/opensearch-datasource/commit/021e747be38330b8906c7c1bbf8beac7bcc3ab60

No difference was observed between this change and the squad's non-regression dashboard https://clouddatasources.grafana.net/goto/2I2f2hWIR?orgId=1
