### PR TITLE
Lucene metrics: Remove "size":500 from backend processTimeSeriesQuery

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -132,8 +132,6 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, defaultTimeField
 }
 
 func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, fromMs int64, toMs int64, defaultTimeField string) {
-	metric := q.Metrics[0]
-	b.Size(metric.Settings.Get("size").MustInt(500))
 	aggBuilder := b.Agg()
 
 	// iterate backwards to create aggregations bottom-down

--- a/pkg/opensearch/time_series_query_test.go
+++ b/pkg/opensearch/time_series_query_test.go
@@ -797,6 +797,36 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 	})
 }
 
+func Test_timeSeriesQuery_execute_processTimeSeriesQuery_size_in_search_request(t *testing.T) {
+	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
+	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
+	c := newFakeClient(es.OpenSearch, "2.3.0")
+
+	t.Run("size is 0 by default", func(t *testing.T) {
+		_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "2" }],
+				"metrics": [{"type": "count", "id": "0" }]
+			}`, from, to, 15*time.Second)
+		assert.NoError(t, err)
+		sr := c.multisearchRequests[0].Requests[0]
+
+		assert.Equal(t, 0, sr.Size)
+	})
+
+	t.Run("size from settings is ignored", func(t *testing.T) {
+		_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "2" }],
+				"metrics": [{"type": "count", "id": "0", "settings": {"size": "1337" }}]
+			}`, from, to, 15*time.Second)
+		assert.NoError(t, err)
+		sr := c.multisearchRequests[0].Requests[0]
+
+		assert.Equal(t, 0, sr.Size)
+	})
+}
+
 type fakeClient struct {
 	flavor              es.Flavor
 	version             *semver.Version


### PR DESCRIPTION


<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Query building (to OpenSearch) was compared between the backend and the frontend for the following query:
![Screenshot 2023-09-27 at 17 59 21](https://github.com/grafana/opensearch-datasource/assets/4163034/6dc56d4d-44f5-4af1-b8a2-89e02c370f1e)

One of the differences observed was: `"size":500` in the backend query and `"size":0` in the frontend query. This PR sets the `"size":0` in the backend query.

The `"size":500` was incorrectly introduced in https://github.com/grafana/opensearch-datasource/pull/203/files#diff-44afe4fa7a308b985c56a75c710979bd17870768f6365e65baa40115849846e6R79-R80

(Another argument in support of `"size":0` is that in the Elasticsearch datasource, `"size":0` for the same type of query.)

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/197

**Special notes for your reviewer**:
You can include the changes or cherry-pick this commit to enable backend flow everywhere. https://github.com/grafana/opensearch-datasource/commit/021e747be38330b8906c7c1bbf8beac7bcc3ab60

No difference was observed between this change and the squad's non-regression dashboard https://clouddatasources.grafana.net/goto/2I2f2hWIR?orgId=1
