### PR TITLE
Lucene metrics: Fix replacement of _term to _key in terms order

### DIFF
--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -124,7 +124,7 @@ func (b *SearchRequestBuilder) Query() *QueryBuilder {
 
 // Agg initiate and returns a new aggregation builder
 func (b *SearchRequestBuilder) Agg() AggBuilder {
-	aggBuilder := newAggBuilder(b.version)
+	aggBuilder := newAggBuilder(b.version, b.flavor)
 	b.aggBuilders = append(b.aggBuilders, aggBuilder)
 	return aggBuilder
 }
@@ -287,16 +287,16 @@ type AggBuilder interface {
 }
 
 type aggBuilderImpl struct {
-	AggBuilder
 	aggDefs []*aggDef
 	flavor  Flavor
 	version *semver.Version
 }
 
-func newAggBuilder(version *semver.Version) *aggBuilderImpl {
+func newAggBuilder(version *semver.Version, flavor Flavor) AggBuilder {
 	return &aggBuilderImpl{
 		aggDefs: make([]*aggDef, 0),
 		version: version,
+		flavor:  flavor,
 	}
 }
 
@@ -334,7 +334,7 @@ func (b *aggBuilderImpl) Histogram(key, field string, fn func(a *HistogramAgg, b
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version)
+		builder := newAggBuilder(b.version, b.flavor)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -354,7 +354,7 @@ func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogr
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version)
+		builder := newAggBuilder(b.version, b.flavor)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -377,7 +377,7 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version)
+		builder := newAggBuilder(b.version, b.flavor)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -403,7 +403,7 @@ func (b *aggBuilderImpl) Filters(key string, fn func(a *FiltersAggregation, b Ag
 		Aggregation: innerAgg,
 	})
 	if fn != nil {
-		builder := newAggBuilder(b.version)
+		builder := newAggBuilder(b.version, b.flavor)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -424,7 +424,7 @@ func (b *aggBuilderImpl) GeoHashGrid(key, field string, fn func(a *GeoHashGridAg
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version)
+		builder := newAggBuilder(b.version, b.flavor)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Query building (to OpenSearch) was compared between the backend and the frontend for the following query:
![Screenshot 2023-09-27 at 17 59 21](https://github.com/grafana/opensearch-datasource/assets/4163034/6dc56d4d-44f5-4af1-b8a2-89e02c370f1e)

One of the differences observed was: `"order":{
          "_term":"desc"
        },` in the backend query and `"order":{
          "_key":"desc"
        }` in the frontend query. `_term` was deprecated in Elasticsearch 6.0 and replaced with `_key`. Although this logic was included in an [earlier PR](https://github.com/grafana/opensearch-datasource/pull/5/files#diff-f57eb533f459265bc8c9e1b89d3834a2afcbf36708ca373e643389c7a1c84573R372), I believe that there might have been a omission passing along `opensearch`/`elasticsearch` (flavor) while creating the `aggBuilderImpl` [here](https://github.com/grafana/opensearch-datasource/pull/5/files#diff-f57eb533f459265bc8c9e1b89d3834a2afcbf36708ca373e643389c7a1c84573R286). The `flavor` is then an empty string and thus does not enter [this condition](https://github.com/grafana/opensearch-datasource/blob/9ca086eff14419f1dec8dec424942975aa4fb56c/pkg/opensearch/client/search_request.go#L385) where `_term` is replaced by `_key`.

This PR passes `flavor` along any time `aggBuilderImpl` is created.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/197

**Special notes for your reviewer**:
You can include the changes or cherry-pick this commit to enable backend flow everywhere. https://github.com/grafana/opensearch-datasource/commit/021e747be38330b8906c7c1bbf8beac7bcc3ab60

No difference was observed between this change and the squad's non-regression dashboard https://clouddatasources.grafana.net/goto/2I2f2hWIR?orgId=1
