### PR TITLE
Backend: Fix Lucene logs so it only uses date_histogram

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -84,17 +84,15 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	}
 	b.Size(size)
 
-	// For log query, we add a date histogram aggregation
+	// For log query, we use only date histogram aggregation
 	aggBuilder := b.Agg()
-	q.BucketAggs = append(q.BucketAggs, &BucketAgg{
+	bucketAgg := &BucketAgg{
 		Type:  dateHistType,
 		Field: defaultTimeField,
 		ID:    "1",
 		Settings: utils.NewJsonFromAny(map[string]interface{}{
 			"interval": "auto",
-		}),
-	})
-	bucketAgg := q.BucketAggs[0]
+		})}
 	bucketAgg.Settings = utils.NewJsonFromAny(
 		bucketAgg.generateSettingsForDSL(),
 	)

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -86,17 +86,17 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 
 	// For log query, we use only date histogram aggregation
 	aggBuilder := b.Agg()
-	bucketAgg := &BucketAgg{
+	defaultBucketAgg := &BucketAgg{
 		Type:  dateHistType,
 		Field: defaultTimeField,
 		ID:    "1",
 		Settings: utils.NewJsonFromAny(map[string]interface{}{
 			"interval": "auto",
 		})}
-	bucketAgg.Settings = utils.NewJsonFromAny(
-		bucketAgg.generateSettingsForDSL(),
+	defaultBucketAgg.Settings = utils.NewJsonFromAny(
+		defaultBucketAgg.generateSettingsForDSL(),
 	)
-	_ = addDateHistogramAgg(aggBuilder, bucketAgg, from, to, defaultTimeField)
+	_ = addDateHistogramAgg(aggBuilder, defaultBucketAgg, from, to, defaultTimeField)
 }
 
 func (bucketAgg BucketAgg) generateSettingsForDSL() map[string]interface{} {

--- a/pkg/opensearch/snapshot_tests/lucene_logs_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_logs_test.go
@@ -41,7 +41,7 @@ func Test_logs_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"date_histogram":{"field":"timestamp","interval":"20m","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"script_fields":{},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}},{"_doc":{"order":"desc"}}]}
+{"aggs":{"1":{"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"script_fields":{},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}},{"_doc":{"order":"desc"}}]}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_logs.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_logs.query_input.json
@@ -7,14 +7,13 @@
     "alias": "",
     "bucketAggs": [
       {
-        "field": "timestamp",
+        "field": "agent.keyword",
         "id": "2",
         "settings": {
-          "interval": "20m",
-          "min_doc_count": "0",
-          "trimEdges": "0"
+          "interval": "1000",
+          "min_doc_count": "15"
         },
-        "type": "date_histogram"
+        "type": "histogram"
       }
     ],
     "format": "table",
@@ -29,8 +28,8 @@
     "queryType": "lucene",
     "refId": "A",
     "timeField": "timestamp",
-    "datasourceId": 2397,
-    "intervalMs": 1800000,
-    "maxDataPoints": 858
+    "datasourceId": 4536,
+    "intervalMs": 1200000,
+    "maxDataPoints": 1238
   }
 ]


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
We discovered that [in the frontend](https://github.com/grafana/opensearch-datasource/blob/c4bda8c85a56dc911b42aa8ad3f63079557a9058/src/datasource.ts#L749), Lucene logs queries were built only with `date_histogram` grouping by default time field, no matter what is chosen in the UI.
This fixes the backend to do the same. (This should only affect queries executed in Explore as of [v2.10.0](https://github.com/grafana/opensearch-datasource/releases/tag/v2.10.0).

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/opensearch-datasource/issues/199

