### PR TITLE
PPL: Execute Explore PPL Table format queries through the backend

### DIFF
--- a/pkg/opensearch/ppl_response_parser.go
+++ b/pkg/opensearch/ppl_response_parser.go
@@ -127,8 +127,10 @@ func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, co
 	if frame.Meta == nil {
 		frame.Meta = &data.FrameMeta{}
 	}
-	if isLogsQuery {
-		frame.Meta.PreferredVisualization = data.VisTypeLogs
+
+	frame.Meta.PreferredVisualization = data.VisTypeLogs
+	if !isLogsQuery {
+		frame.Meta.PreferredVisualization = data.VisTypeTable
 	}
 
 	queryRes.Frames = append(queryRes.Frames, frame)

--- a/pkg/opensearch/ppl_response_parser.go
+++ b/pkg/opensearch/ppl_response_parser.go
@@ -105,6 +105,7 @@ func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, co
 
 		doc = flatten(doc, maxFlattenDepth)
 		for key := range doc {
+			// Do not add _source field (besides logs) as we are showing each _source field in table instead
 			if !isLogsQuery && key == "_source" {
 				continue
 			}
@@ -116,11 +117,7 @@ func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, co
 		docs[rowIdx] = doc
 	}
 
-	fieldsToGoInFront := []string{}
-	if isLogsQuery {
-		fieldsToGoInFront = append(fieldsToGoInFront, configuredFields.TimeField, configuredFields.LogMessageField)
-	}
-	sortedPropNames := sortPropNames(propNames, fieldsToGoInFront)
+	sortedPropNames := sortPropNames(propNames, []string{configuredFields.TimeField, configuredFields.LogMessageField})
 	fields := processDocsToDataFrameFields(docs, sortedPropNames)
 
 	frame := data.NewFrame("", fields...)

--- a/pkg/opensearch/ppl_response_parser.go
+++ b/pkg/opensearch/ppl_response_parser.go
@@ -71,7 +71,7 @@ func (rp *pplResponseParser) parseLogs(queryRes *backend.DataResponse, configure
 	return rp.parsePPLResponse(queryRes, configuredFields, true)
 }
 
-// parsePPLResponse parses reponses for the logs and table format
+// parsePPLResponse parses responses for the logs and table format
 func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, configuredFields es.ConfiguredFields, isLogsQuery bool) (*backend.DataResponse, error) {
 	propNames := make(map[string]bool)
 	docs := make([]map[string]interface{}, len(rp.Response.Datarows))

--- a/pkg/opensearch/ppl_response_parser.go
+++ b/pkg/opensearch/ppl_response_parser.go
@@ -105,7 +105,8 @@ func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, co
 
 		doc = flatten(doc, maxFlattenDepth)
 		for key := range doc {
-			// Do not add _source field (besides logs) as we are showing each _source field in table instead
+			// Do not add _source field for the table format as the _source field contains the original
+			// payload and table already uses the fields as the column names
 			if !isLogsQuery && key == "_source" {
 				continue
 			}

--- a/pkg/opensearch/ppl_response_parser_test.go
+++ b/pkg/opensearch/ppl_response_parser_test.go
@@ -713,7 +713,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 		assert.Equal(t, "foo", actualValue)
 		assert.Equal(t, "value", queryRes.Frames[0].Fields[1].Name)
 	})
-	t.Run("should not set preferred visualization", func(t *testing.T) {
+	t.Run("should set preferred visualization to table", func(t *testing.T) {
 		targets := map[string]string{
 			"A": `{
 						"format": "table"
@@ -734,7 +734,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 		assert.NoError(t, err)
 		queryRes, err := rp.parseResponse(es.ConfiguredFields{}, tableType)
 		assert.NoError(t, err)
-		assert.Equal(t, "", string(queryRes.Frames[0].Meta.PreferredVisualization))
+		assert.Equal(t, data.VisTypeTable, string(queryRes.Frames[0].Meta.PreferredVisualization))
 	})
 
 	t.Run("should not add timefield, level, or logMessageField to the fields", func(t *testing.T) {})

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -29,6 +29,7 @@ const (
 	termsType       = "terms"
 	geohashGridType = "geohash_grid"
 	logsType        = "logs"
+	tableType       = "table"
 	rawDataType     = "raw_data"
 	rawDocumentType = "raw_document"
 	descending      = "desc"

--- a/pkg/opensearch/snapshot_tests/ppl_table_test.go
+++ b/pkg/opensearch/snapshot_tests/ppl_table_test.go
@@ -1,0 +1,70 @@
+package snapshot_tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ppl_table_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/ppl_table.query_input.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest :=
+		`{"query":"search source=opensearch_dashboards_sample_data_flights | where` + " `timestamp` " + `>= timestamp('2022-11-14 10:40:37') and` + " `timestamp` " + `<= timestamp('2022-11-14 10:43:45') | where AvgTicketPrice > 1150 | where FlightDelay = true "}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+
+func Test_ppl_table_response(t *testing.T) {
+	responseFromOpenSearch, err := os.ReadFile("testdata/ppl_table.response_from_opensearch.json")
+	require.NoError(t, err)
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/ppl_table.query_input.json")
+	require.NoError(t, err)
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			Transport: &queryDataTestRoundTripper{body: responseFromOpenSearch, statusCode: 200, requestCallback: func(req *http.Request) error { return nil }},
+		},
+	}
+
+	result, err := openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	responseForRefIdA, ok := result.Responses["A"]
+	assert.True(t, ok)
+	experimental.CheckGoldenJSONResponse(t, "testdata", "ppl_table.expected_result_generated_snapshot.golden", &responseForRefIdA, false)
+}

--- a/pkg/opensearch/snapshot_tests/testdata/ppl_table.expected_result_generated_snapshot.golden.jsonc
+++ b/pkg/opensearch/snapshot_tests/testdata/ppl_table.expected_result_generated_snapshot.golden.jsonc
@@ -1,0 +1,746 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 29 Fields by 11 Rows
+//  +----------------------+-----------------+--------------------------------+------------------------------------------------------+---------------------+--------------------+-------------------+------------------------+------------------------+------------------+-------------------+--------------------------+---------------------+-------------------+----------------------+-----------------------+-----------------+----------------------+---------------------+------------------------------------------------+-----------------------+----------------------+---------------------+--------------------------+--------------------------+--------------------+---------------------+------------------+-------------------------------+
+//  | Name: AvgTicketPrice | Name: Cancelled | Name: Carrier                  | Name: Dest                                           | Name: DestAirportID | Name: DestCityName | Name: DestCountry | Name: DestLocation.lat | Name: DestLocation.lon | Name: DestRegion | Name: DestWeather | Name: DistanceKilometers | Name: DistanceMiles | Name: FlightDelay | Name: FlightDelayMin | Name: FlightDelayType | Name: FlightNum | Name: FlightTimeHour | Name: FlightTimeMin | Name: Origin                                   | Name: OriginAirportID | Name: OriginCityName | Name: OriginCountry | Name: OriginLocation.lat | Name: OriginLocation.lon | Name: OriginRegion | Name: OriginWeather | Name: dayOfWeek  | Name: timestamp               |
+//  | Labels:              | Labels:         | Labels:                        | Labels:                                              | Labels:             | Labels:            | Labels:           | Labels:                | Labels:                | Labels:          | Labels:           | Labels:                  | Labels:             | Labels:           | Labels:              | Labels:               | Labels:         | Labels:              | Labels:             | Labels:                                        | Labels:               | Labels:              | Labels:             | Labels:                  | Labels:                  | Labels:            | Labels:             | Labels:          | Labels:                       |
+//  | Type: []*float64     | Type: []*bool   | Type: []*string                | Type: []*string                                      | Type: []*string     | Type: []*string    | Type: []*string   | Type: []*float64       | Type: []*float64       | Type: []*string  | Type: []*string   | Type: []*float64         | Type: []*float64    | Type: []*bool     | Type: []*float64     | Type: []*string       | Type: []*string | Type: []*string      | Type: []*float64    | Type: []*string                                | Type: []*string       | Type: []*string      | Type: []*string     | Type: []*float64         | Type: []*float64         | Type: []*string    | Type: []*string     | Type: []*float64 | Type: []*time.Time            |
+//  +----------------------+-----------------+--------------------------------+------------------------------------------------------+---------------------+--------------------+-------------------+------------------------+------------------------+------------------+-------------------+--------------------------+---------------------+-------------------+----------------------+-----------------------+-----------------+----------------------+---------------------+------------------------------------------------+-----------------------+----------------------+---------------------+--------------------------+--------------------------+--------------------+---------------------+------------------+-------------------------------+
+//  | 1159.6538            | false           | OpenSearch Dashboards Airlines | Shanghai Pudong International Airport                | PVG                 | Shanghai           | CN                | 31.14340019            | 121.8050003            | SE-BD            | Sunny             | 12150.084                | 7549.712            | true              | 240                  | NAS Delay             | HST1ZY8         | 19.5770305010858     | 1174.6218           | Richmond International Airport                 | RIC                   | Richmond             | US                  | 37.50519943              | -77.31970215             | US-VA              | Thunder & Lightning | 6                | 2023-04-02 04:01:54 +0000 UTC |
+//  | 1165.8376            | true            | OpenSearch-Air                 | Melbourne International Airport                      | MEL                 | Melbourne          | AU                | -37.673302             | 144.843002             | SE-BD            | Hail              | 15985.107                | 9932.686            | true              | 315                  | Late Aircraft Delay   | 82GSS08         | 20.05102578320481    | 1203.0615           | Leonardo da Vinci___Fiumicino Airport          | RM11                  | Rome                 | IT                  | 41.8002778               | 12.2388889               | IT-62              | Sunny               | 6                | 2023-04-02 06:58:19 +0000 UTC |
+//  | 1174.4707            | false           | OpenSearch Dashboards Airlines | OR Tambo International Airport                       | JNB                 | Johannesburg       | ZA                | -26.1392               | 28.246                 | SE-BD            | Damaging Wind     | 14605.987                | 9075.739            | true              | 300                  | Security Delay        | IJ9R0OA         | 17.171655767118615   | 1030.2993           | Licenciado Benito Juarez International Airport | AICM                  | Mexico City          | MX                  | 19.4363                  | -99.072098               | MX-DIF             | Sunny               | 5                | 2023-03-18 07:10:15 +0000 UTC |
+//  | 1182.732             | false           | OpenSearch-Air                 | Sydney Kingsford Smith International Airport         | SYD                 | Sydney             | AU                | -33.94609833           | 151.177002             | SE-BD            | Rain              | 14599.797                | 9071.893            | true              | 75                   | NAS Delay             | 6L4ATTB         | 13.416497170683765   | 804.9898            | Olenya Air Base                                | XLMO                  | Olenegorsk           | RU                  | 68.15180206              | 33.46390152              | RU-MUR             | Sunny               | 6                | 2023-03-19 12:00:41 +0000 UTC |
+//  | 1180.7833            | false           | Logstash Airways               | Rochester International Airport                      | RST                 | Rochester          | US                | 43.90829849            | -92.5                  | US-MN            | Rain              | 11588.737                | 7200.9077           | true              | 45                   | Carrier Delay         | NEW23WT         | 12.821601293947955   | 769.2961            | Chengdu Shuangliu International Airport        | CTU                   | Chengdu              | CN                  | 30.57850075              | 103.9469986              | SE-BD              | Rain                | 6                | 2023-03-19 09:40:58 +0000 UTC |
+//  | 1176.6382            | true            | Logstash Airways               | Comodoro Arturo Merino Benitez International Airport | SCL                 | Santiago           | CL                | -33.39300156           | -70.78579712           | SE-BD            | Rain              | 11958.329                | 7430.5615           | true              | 165                  | Carrier Delay         | 2IMKCI2         | 16.986106496512363   | 1019.1664           | Bologna Guglielmo Marconi Airport              | BO08                  | Bologna              | IT                  | 44.5354                  | 11.2887                  | IT-45              | Heavy Fog           | 5                | 2023-03-04 04:59:34 +0000 UTC |
+//  | 1181.4222            | false           | BeatsWest                      | Mariscal Sucre International Airport                 | UIO                 | Quito              | EC                | -0.129166667           | -78.3575               | EC-P             | Sunny             | 14331.022                | 8904.884            | true              | 45                   | Carrier Delay         | 8L18ARF         | 12.123827012488386   | 727.4296            | Dubai International Airport                    | DXB                   | Dubai                | AE                  | 25.25279999              | 55.36439896              | SE-BD              | Clear               | 5                | 2023-03-11 05:39:17 +0000 UTC |
+//  | 1170.5417            | false           | OpenSearch-Air                 | Jorge Chavez International Airport                   | LIM                 | Lima               | PE                | -12.0219               | -77.114304             | SE-BD            | Clear             | 15879.832                | 9867.27             | true              | 45                   | Late Aircraft Delay   | RWH362V         | 14.679676933133779   | 880.78064           | Itami Airport                                  | ITM                   | Osaka                | JP                  | 34.78549957              | 135.4380035              | SE-BD              | Cloudy              | 5                | 2023-03-11 05:14:32 +0000 UTC |
+//  | 1159.7863            | false           | Logstash Airways               | Mariscal Sucre International Airport                 | UIO                 | Quito              | EC                | -0.129166667           | -78.3575               | EC-P             | Clear             | 14297.614                | 8884.125            | true              | 75                   | NAS Delay             | KMGWBI2         | 16.143347890204613   | 968.6009            | Abu Dhabi International Airport                | AUH                   | Abu Dhabi            | AE                  | 24.43300056              | 54.65110016              | SE-BD              | Rain                | 5                | 2023-04-01 03:21:14 +0000 UTC |
+//  | ...                  | ...             | ...                            | ...                                                  | ...                 | ...                | ...               | ...                    | ...                    | ...              | ...               | ...                      | ...                 | ...               | ...                  | ...                   | ...             | ...                  | ...                 | ...                                            | ...                   | ...                  | ...                 | ...                      | ...                      | ...                | ...                 | ...              | ...                           |
+//  +----------------------+-----------------+--------------------------------+------------------------------------------------------+---------------------+--------------------+-------------------+------------------------+------------------------+------------------+-------------------+--------------------------+---------------------+-------------------+----------------------+-----------------------+-----------------+----------------------+---------------------+------------------------------------------------+-----------------------+----------------------+---------------------+--------------------------+--------------------------+--------------------+---------------------+------------------+-------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "AvgTicketPrice",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "Cancelled",
+            "type": "boolean",
+            "typeInfo": {
+              "frame": "bool",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "Carrier",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "Dest",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestAirportID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestCityName",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestCountry",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestLocation.lat",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestLocation.lon",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestRegion",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DestWeather",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DistanceKilometers",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "DistanceMiles",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightDelay",
+            "type": "boolean",
+            "typeInfo": {
+              "frame": "bool",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightDelayMin",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightDelayType",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightNum",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightTimeHour",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "FlightTimeMin",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "Origin",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginAirportID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginCityName",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginCountry",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginLocation.lat",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginLocation.lon",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginRegion",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "OriginWeather",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "dayOfWeek",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            },
+            "config": {
+              "filterable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1159.6538,
+            1165.8376,
+            1174.4707,
+            1182.732,
+            1180.7833,
+            1176.6382,
+            1181.4222,
+            1170.5417,
+            1159.7863,
+            1163.2606,
+            1153.3503
+          ],
+          [
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+            true
+          ],
+          [
+            "OpenSearch Dashboards Airlines",
+            "OpenSearch-Air",
+            "OpenSearch Dashboards Airlines",
+            "OpenSearch-Air",
+            "Logstash Airways",
+            "Logstash Airways",
+            "BeatsWest",
+            "OpenSearch-Air",
+            "Logstash Airways",
+            "OpenSearch-Air",
+            "OpenSearch Dashboards Airlines"
+          ],
+          [
+            "Shanghai Pudong International Airport",
+            "Melbourne International Airport",
+            "OR Tambo International Airport",
+            "Sydney Kingsford Smith International Airport",
+            "Rochester International Airport",
+            "Comodoro Arturo Merino Benitez International Airport",
+            "Mariscal Sucre International Airport",
+            "Jorge Chavez International Airport",
+            "Mariscal Sucre International Airport",
+            "OR Tambo International Airport",
+            "Piedmont Triad International Airport"
+          ],
+          [
+            "PVG",
+            "MEL",
+            "JNB",
+            "SYD",
+            "RST",
+            "SCL",
+            "UIO",
+            "LIM",
+            "UIO",
+            "JNB",
+            "GSO"
+          ],
+          [
+            "Shanghai",
+            "Melbourne",
+            "Johannesburg",
+            "Sydney",
+            "Rochester",
+            "Santiago",
+            "Quito",
+            "Lima",
+            "Quito",
+            "Johannesburg",
+            "Greensboro"
+          ],
+          [
+            "CN",
+            "AU",
+            "ZA",
+            "AU",
+            "US",
+            "CL",
+            "EC",
+            "PE",
+            "EC",
+            "ZA",
+            "US"
+          ],
+          [
+            31.14340019,
+            -37.673302,
+            -26.1392,
+            -33.94609833,
+            43.90829849,
+            -33.39300156,
+            -0.129166667,
+            -12.0219,
+            -0.129166667,
+            -26.1392,
+            36.09780121
+          ],
+          [
+            121.8050003,
+            144.843002,
+            28.246,
+            151.177002,
+            -92.5,
+            -70.78579712,
+            -78.3575,
+            -77.114304,
+            -78.3575,
+            28.246,
+            -79.93730164
+          ],
+          [
+            "SE-BD",
+            "SE-BD",
+            "SE-BD",
+            "SE-BD",
+            "US-MN",
+            "SE-BD",
+            "EC-P",
+            "SE-BD",
+            "EC-P",
+            "SE-BD",
+            "US-NC"
+          ],
+          [
+            "Sunny",
+            "Hail",
+            "Damaging Wind",
+            "Rain",
+            "Rain",
+            "Rain",
+            "Sunny",
+            "Clear",
+            "Clear",
+            "Thunder \u0026 Lightning",
+            "Clear"
+          ],
+          [
+            12150.084,
+            15985.107,
+            14605.987,
+            14599.797,
+            11588.737,
+            11958.329,
+            14331.022,
+            15879.832,
+            14297.614,
+            11664.482,
+            11825.472
+          ],
+          [
+            7549.712,
+            9932.686,
+            9075.739,
+            9071.893,
+            7200.9077,
+            7430.5615,
+            8904.884,
+            9867.27,
+            8884.125,
+            7247.973,
+            7348.0073
+          ],
+          [
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true
+          ],
+          [
+            240,
+            315,
+            300,
+            75,
+            45,
+            165,
+            45,
+            45,
+            75,
+            180,
+            15
+          ],
+          [
+            "NAS Delay",
+            "Late Aircraft Delay",
+            "Security Delay",
+            "NAS Delay",
+            "Carrier Delay",
+            "Carrier Delay",
+            "Carrier Delay",
+            "Late Aircraft Delay",
+            "NAS Delay",
+            "NAS Delay",
+            "NAS Delay"
+          ],
+          [
+            "HST1ZY8",
+            "82GSS08",
+            "IJ9R0OA",
+            "6L4ATTB",
+            "NEW23WT",
+            "2IMKCI2",
+            "8L18ARF",
+            "RWH362V",
+            "KMGWBI2",
+            "IT4M6U6",
+            "6RL7TVQ"
+          ],
+          [
+            "19.5770305010858",
+            "20.05102578320481",
+            "17.171655767118615",
+            "13.416497170683765",
+            "12.821601293947955",
+            "16.986106496512363",
+            "12.123827012488386",
+            "14.679676933133779",
+            "16.143347890204613",
+            "15.15050213039852",
+            "13.389412498564672"
+          ],
+          [
+            1174.6218,
+            1203.0615,
+            1030.2993,
+            804.9898,
+            769.2961,
+            1019.1664,
+            727.4296,
+            880.78064,
+            968.6009,
+            909.03015,
+            803.36475
+          ],
+          [
+            "Richmond International Airport",
+            "Leonardo da Vinci___Fiumicino Airport",
+            "Licenciado Benito Juarez International Airport",
+            "Olenya Air Base",
+            "Chengdu Shuangliu International Airport",
+            "Bologna Guglielmo Marconi Airport",
+            "Dubai International Airport",
+            "Itami Airport",
+            "Abu Dhabi International Airport",
+            "Mariscal Sucre International Airport",
+            "Jeju International Airport"
+          ],
+          [
+            "RIC",
+            "RM11",
+            "AICM",
+            "XLMO",
+            "CTU",
+            "BO08",
+            "DXB",
+            "ITM",
+            "AUH",
+            "UIO",
+            "CJU"
+          ],
+          [
+            "Richmond",
+            "Rome",
+            "Mexico City",
+            "Olenegorsk",
+            "Chengdu",
+            "Bologna",
+            "Dubai",
+            "Osaka",
+            "Abu Dhabi",
+            "Quito",
+            "Jeju City"
+          ],
+          [
+            "US",
+            "IT",
+            "MX",
+            "RU",
+            "CN",
+            "IT",
+            "AE",
+            "JP",
+            "AE",
+            "EC",
+            "KR"
+          ],
+          [
+            37.50519943,
+            41.8002778,
+            19.4363,
+            68.15180206,
+            30.57850075,
+            44.5354,
+            25.25279999,
+            34.78549957,
+            24.43300056,
+            -0.129166667,
+            33.51129913
+          ],
+          [
+            -77.31970215,
+            12.2388889,
+            -99.072098,
+            33.46390152,
+            103.9469986,
+            11.2887,
+            55.36439896,
+            135.4380035,
+            54.65110016,
+            -78.3575,
+            126.4929962
+          ],
+          [
+            "US-VA",
+            "IT-62",
+            "MX-DIF",
+            "RU-MUR",
+            "SE-BD",
+            "IT-45",
+            "SE-BD",
+            "SE-BD",
+            "SE-BD",
+            "SE-BD",
+            "SE-BD"
+          ],
+          [
+            "Thunder \u0026 Lightning",
+            "Sunny",
+            "Sunny",
+            "Sunny",
+            "Rain",
+            "Heavy Fog",
+            "Clear",
+            "Cloudy",
+            "Rain",
+            "Cloudy",
+            "Thunder \u0026 Lightning"
+          ],
+          [
+            6,
+            6,
+            5,
+            6,
+            6,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5
+          ],
+          [
+            1680408114000,
+            1680418699000,
+            1679123415000,
+            1679227241000,
+            1679218858000,
+            1677905974000,
+            1678513157000,
+            1678511672000,
+            1680319274000,
+            1680954057000,
+            1680922486000
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/opensearch/snapshot_tests/testdata/ppl_table.expected_result_generated_snapshot.golden.jsonc
+++ b/pkg/opensearch/snapshot_tests/testdata/ppl_table.expected_result_generated_snapshot.golden.jsonc
@@ -4,7 +4,8 @@
 //      "typeVersion": [
 //          0,
 //          0
-//      ]
+//      ],
+//      "preferredVisualisationType": "table"
 //  }
 //  Name: 
 //  Dimensions: 29 Fields by 11 Rows
@@ -36,7 +37,8 @@
           "typeVersion": [
             0,
             0
-          ]
+          ],
+          "preferredVisualisationType": "table"
         },
         "fields": [
           {

--- a/pkg/opensearch/snapshot_tests/testdata/ppl_table.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/ppl_table.query_input.json
@@ -1,0 +1,33 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "b12b6921-d5bd-44e8-98c7-defbdbef73dd"
+    },
+    "format": "table",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "count"
+      }
+    ],
+    "query": "search source=opensearch_dashboards_sample_data_flights | where AvgTicketPrice > 1150 | where FlightDelay = true ",
+    "queryType": "PPL",
+    "refId": "A",
+    "timeField": "timestamp",
+    "datasourceId": 276,
+    "intervalMs": 43200000,
+    "maxDataPoints": 1125
+  }
+]

--- a/pkg/opensearch/snapshot_tests/testdata/ppl_table.response_from_opensearch.json
+++ b/pkg/opensearch/snapshot_tests/testdata/ppl_table.response_from_opensearch.json
@@ -1,0 +1,501 @@
+{
+  "schema": [
+    {
+      "name": "FlightNum",
+      "type": "string"
+    },
+    {
+      "name": "Origin",
+      "type": "string"
+    },
+    {
+      "name": "OriginLocation",
+      "type": "geo_point"
+    },
+    {
+      "name": "DestLocation",
+      "type": "geo_point"
+    },
+    {
+      "name": "FlightDelay",
+      "type": "boolean"
+    },
+    {
+      "name": "DistanceMiles",
+      "type": "float"
+    },
+    {
+      "name": "FlightTimeMin",
+      "type": "float"
+    },
+    {
+      "name": "OriginWeather",
+      "type": "string"
+    },
+    {
+      "name": "dayOfWeek",
+      "type": "integer"
+    },
+    {
+      "name": "AvgTicketPrice",
+      "type": "float"
+    },
+    {
+      "name": "Carrier",
+      "type": "string"
+    },
+    {
+      "name": "FlightDelayMin",
+      "type": "integer"
+    },
+    {
+      "name": "OriginRegion",
+      "type": "string"
+    },
+    {
+      "name": "DestAirportID",
+      "type": "string"
+    },
+    {
+      "name": "FlightDelayType",
+      "type": "string"
+    },
+    {
+      "name": "timestamp",
+      "type": "timestamp"
+    },
+    {
+      "name": "Dest",
+      "type": "string"
+    },
+    {
+      "name": "FlightTimeHour",
+      "type": "string"
+    },
+    {
+      "name": "Cancelled",
+      "type": "boolean"
+    },
+    {
+      "name": "DistanceKilometers",
+      "type": "float"
+    },
+    {
+      "name": "OriginCityName",
+      "type": "string"
+    },
+    {
+      "name": "DestWeather",
+      "type": "string"
+    },
+    {
+      "name": "OriginCountry",
+      "type": "string"
+    },
+    {
+      "name": "DestCountry",
+      "type": "string"
+    },
+    {
+      "name": "DestRegion",
+      "type": "string"
+    },
+    {
+      "name": "DestCityName",
+      "type": "string"
+    },
+    {
+      "name": "OriginAirportID",
+      "type": "string"
+    }
+  ],
+  "datarows": [
+    [
+      "HST1ZY8",
+      "Richmond International Airport",
+      {
+        "lat": 37.50519943,
+        "lon": -77.31970215
+      },
+      {
+        "lat": 31.14340019,
+        "lon": 121.8050003
+      },
+      true,
+      7549.712,
+      1174.6218,
+      "Thunder & Lightning",
+      6,
+      1159.6538,
+      "OpenSearch Dashboards Airlines",
+      240,
+      "US-VA",
+      "PVG",
+      "NAS Delay",
+      "2023-04-02 04:01:54",
+      "Shanghai Pudong International Airport",
+      "19.5770305010858",
+      false,
+      12150.084,
+      "Richmond",
+      "Sunny",
+      "US",
+      "CN",
+      "SE-BD",
+      "Shanghai",
+      "RIC"
+    ],
+    [
+      "82GSS08",
+      "Leonardo da Vinci___Fiumicino Airport",
+      {
+        "lat": 41.8002778,
+        "lon": 12.2388889
+      },
+      {
+        "lat": -37.673302,
+        "lon": 144.843002
+      },
+      true,
+      9932.686,
+      1203.0615,
+      "Sunny",
+      6,
+      1165.8376,
+      "OpenSearch-Air",
+      315,
+      "IT-62",
+      "MEL",
+      "Late Aircraft Delay",
+      "2023-04-02 06:58:19",
+      "Melbourne International Airport",
+      "20.05102578320481",
+      true,
+      15985.107,
+      "Rome",
+      "Hail",
+      "IT",
+      "AU",
+      "SE-BD",
+      "Melbourne",
+      "RM11"
+    ],
+    [
+      "IJ9R0OA",
+      "Licenciado Benito Juarez International Airport",
+      {
+        "lat": 19.4363,
+        "lon": -99.072098
+      },
+      {
+        "lat": -26.1392,
+        "lon": 28.246
+      },
+      true,
+      9075.739,
+      1030.2993,
+      "Sunny",
+      5,
+      1174.4707,
+      "OpenSearch Dashboards Airlines",
+      300,
+      "MX-DIF",
+      "JNB",
+      "Security Delay",
+      "2023-03-18 07:10:15",
+      "OR Tambo International Airport",
+      "17.171655767118615",
+      false,
+      14605.987,
+      "Mexico City",
+      "Damaging Wind",
+      "MX",
+      "ZA",
+      "SE-BD",
+      "Johannesburg",
+      "AICM"
+    ],
+    [
+      "6L4ATTB",
+      "Olenya Air Base",
+      {
+        "lat": 68.15180206,
+        "lon": 33.46390152
+      },
+      {
+        "lat": -33.94609833,
+        "lon": 151.177002
+      },
+      true,
+      9071.893,
+      804.9898,
+      "Sunny",
+      6,
+      1182.732,
+      "OpenSearch-Air",
+      75,
+      "RU-MUR",
+      "SYD",
+      "NAS Delay",
+      "2023-03-19 12:00:41",
+      "Sydney Kingsford Smith International Airport",
+      "13.416497170683765",
+      false,
+      14599.797,
+      "Olenegorsk",
+      "Rain",
+      "RU",
+      "AU",
+      "SE-BD",
+      "Sydney",
+      "XLMO"
+    ],
+    [
+      "NEW23WT",
+      "Chengdu Shuangliu International Airport",
+      {
+        "lat": 30.57850075,
+        "lon": 103.9469986
+      },
+      {
+        "lat": 43.90829849,
+        "lon": -92.5
+      },
+      true,
+      7200.9077,
+      769.2961,
+      "Rain",
+      6,
+      1180.7833,
+      "Logstash Airways",
+      45,
+      "SE-BD",
+      "RST",
+      "Carrier Delay",
+      "2023-03-19 09:40:58",
+      "Rochester International Airport",
+      "12.821601293947955",
+      false,
+      11588.737,
+      "Chengdu",
+      "Rain",
+      "CN",
+      "US",
+      "US-MN",
+      "Rochester",
+      "CTU"
+    ],
+    [
+      "2IMKCI2",
+      "Bologna Guglielmo Marconi Airport",
+      {
+        "lat": 44.5354,
+        "lon": 11.2887
+      },
+      {
+        "lat": -33.39300156,
+        "lon": -70.78579712
+      },
+      true,
+      7430.5615,
+      1019.1664,
+      "Heavy Fog",
+      5,
+      1176.6382,
+      "Logstash Airways",
+      165,
+      "IT-45",
+      "SCL",
+      "Carrier Delay",
+      "2023-03-04 04:59:34",
+      "Comodoro Arturo Merino Benitez International Airport",
+      "16.986106496512363",
+      true,
+      11958.329,
+      "Bologna",
+      "Rain",
+      "IT",
+      "CL",
+      "SE-BD",
+      "Santiago",
+      "BO08"
+    ],
+    [
+      "8L18ARF",
+      "Dubai International Airport",
+      {
+        "lat": 25.25279999,
+        "lon": 55.36439896
+      },
+      {
+        "lat": -0.129166667,
+        "lon": -78.3575
+      },
+      true,
+      8904.884,
+      727.4296,
+      "Clear",
+      5,
+      1181.4222,
+      "BeatsWest",
+      45,
+      "SE-BD",
+      "UIO",
+      "Carrier Delay",
+      "2023-03-11 05:39:17",
+      "Mariscal Sucre International Airport",
+      "12.123827012488386",
+      false,
+      14331.022,
+      "Dubai",
+      "Sunny",
+      "AE",
+      "EC",
+      "EC-P",
+      "Quito",
+      "DXB"
+    ],
+    [
+      "RWH362V",
+      "Itami Airport",
+      {
+        "lat": 34.78549957,
+        "lon": 135.4380035
+      },
+      {
+        "lat": -12.0219,
+        "lon": -77.114304
+      },
+      true,
+      9867.27,
+      880.78064,
+      "Cloudy",
+      5,
+      1170.5417,
+      "OpenSearch-Air",
+      45,
+      "SE-BD",
+      "LIM",
+      "Late Aircraft Delay",
+      "2023-03-11 05:14:32",
+      "Jorge Chavez International Airport",
+      "14.679676933133779",
+      false,
+      15879.832,
+      "Osaka",
+      "Clear",
+      "JP",
+      "PE",
+      "SE-BD",
+      "Lima",
+      "ITM"
+    ],
+    [
+      "KMGWBI2",
+      "Abu Dhabi International Airport",
+      {
+        "lat": 24.43300056,
+        "lon": 54.65110016
+      },
+      {
+        "lat": -0.129166667,
+        "lon": -78.3575
+      },
+      true,
+      8884.125,
+      968.6009,
+      "Rain",
+      5,
+      1159.7863,
+      "Logstash Airways",
+      75,
+      "SE-BD",
+      "UIO",
+      "NAS Delay",
+      "2023-04-01 03:21:14",
+      "Mariscal Sucre International Airport",
+      "16.143347890204613",
+      false,
+      14297.614,
+      "Abu Dhabi",
+      "Clear",
+      "AE",
+      "EC",
+      "EC-P",
+      "Quito",
+      "AUH"
+    ],
+    [
+      "IT4M6U6",
+      "Mariscal Sucre International Airport",
+      {
+        "lat": -0.129166667,
+        "lon": -78.3575
+      },
+      {
+        "lat": -26.1392,
+        "lon": 28.246
+      },
+      true,
+      7247.973,
+      909.03015,
+      "Cloudy",
+      5,
+      1163.2606,
+      "OpenSearch-Air",
+      180,
+      "SE-BD",
+      "JNB",
+      "NAS Delay",
+      "2023-04-08 11:40:57",
+      "OR Tambo International Airport",
+      "15.15050213039852",
+      true,
+      11664.482,
+      "Quito",
+      "Thunder & Lightning",
+      "EC",
+      "ZA",
+      "SE-BD",
+      "Johannesburg",
+      "UIO"
+    ],
+    [
+      "6RL7TVQ",
+      "Jeju International Airport",
+      {
+        "lat": 33.51129913,
+        "lon": 126.4929962
+      },
+      {
+        "lat": 36.09780121,
+        "lon": -79.93730164
+      },
+      true,
+      7348.0073,
+      803.36475,
+      "Thunder & Lightning",
+      5,
+      1153.3503,
+      "OpenSearch Dashboards Airlines",
+      15,
+      "SE-BD",
+      "GSO",
+      "NAS Delay",
+      "2023-04-08 02:54:46",
+      "Piedmont Triad International Airport",
+      "13.389412498564672",
+      true,
+      11825.472,
+      "Jeju City",
+      "Clear",
+      "KR",
+      "US",
+      "US-NC",
+      "Greensboro",
+      "CJU"
+    ]
+  ],
+  "total": 11,
+  "size": 11
+}

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1320,6 +1320,31 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
+    it('should send PPL table format queries in Explore', () => {
+      const mockedSuperQuery = jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+      const pplLogsQuery: OpenSearchQuery = {
+        refId: 'A',
+        queryType: QueryType.PPL,
+        format: 'table',
+        query: 'source = test-index',
+      };
+      const request: DataQueryRequest<OpenSearchQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 1,
+        scopedVars: {},
+        timezone: '',
+        app: CoreApp.Explore,
+        startTime: 0,
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+        targets: [pplLogsQuery],
+      };
+      ctx.ds.query(request);
+      expect(mockedSuperQuery).toHaveBeenCalled();
+    });
+
     it('should send interpolated query to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
@@ -1555,6 +1580,32 @@ describe('OpenSearchDatasource', function (this: any) {
         refId: 'A',
         queryType: QueryType.PPL,
         format: 'logs',
+        query: 'source = test-index',
+      };
+      const request: DataQueryRequest<OpenSearchQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 1,
+        scopedVars: {},
+        timezone: '',
+        app: CoreApp.Dashboard,
+        startTime: 0,
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+        targets: [pplLogsQuery],
+      };
+      ctx.ds.query(request);
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
+    });
+
+    it('does not send PPL table format queries in Dashboard to backend', () => {
+      const mockedSuperQuery = jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+      const pplLogsQuery: OpenSearchQuery = {
+        refId: 'A',
+        queryType: QueryType.PPL,
+        format: 'table',
         query: 'source = test-index',
       };
       const request: DataQueryRequest<OpenSearchQuery> = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -545,7 +545,9 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
               metric.type === 'raw_document' ||
               (request.app === CoreApp.Explore && target.queryType === QueryType.Lucene)
           ) ||
-          (request.app === CoreApp.Explore && target.queryType === QueryType.PPL && target.format === 'logs')
+          (request.app === CoreApp.Explore &&
+            target.queryType === QueryType.PPL &&
+            (target.format === 'logs' || target.format === 'table'))
       )
     ) {
       // @ts-ignore


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

This make PPL queries with the `table` format run in `Explore` execute on the backend.

You can use a PPL query from the "PPL Table" section [here](https://clouddatasources.grafana.net/goto/vMOq6OmIg?orgId=1) to test it with the external dev.

**Which issue(s) this PR fixes**:

Fixes #201 

**Special notes for your reviewer**:
Similar to https://github.com/grafana/opensearch-datasource/pull/259 , in order to test the ad-hoc filters you have to enable ppl queries to be sent from the dashboard to the backend (remove the check for `CoreApp.Explore` in `datasource.ts` at line 548)

Also: my query in `ppl_table.query_input.json` isn't actually the query that produces the response I'm using (i narrowed it down a bit to be smaller) since it seemed like that was allowed. If they should match I can make them.
