### PR TITLE
Traces bug on Explore

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -541,7 +541,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
               metric.type === 'raw_document' ||
               (request.app === CoreApp.Explore &&
                 target.queryType === QueryType.Lucene &&
-                target.luceneQueryType !== LuceneQueryType.Traces)
+                target.luceneQueryType === LuceneQueryType.Metric)
           ) ||
           (request.app === CoreApp.Explore &&
             target.queryType === QueryType.PPL &&

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -541,7 +541,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
               metric.type === 'raw_document' ||
               (request.app === CoreApp.Explore &&
                 target.queryType === QueryType.Lucene &&
-                target.luceneQueryType === LuceneQueryType.Metric)
+                target.luceneQueryType !== LuceneQueryType.Traces)
           ) ||
           (request.app === CoreApp.Explore &&
             target.queryType === QueryType.PPL &&

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -548,7 +548,6 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
             (target.format === 'logs' || target.format === 'table'))
       )
     ) {
-      console.log('backend flow', request.targets);
       // @ts-ignore
       const adHocFilters = getTemplateSrv().getAdhocFilters(this.name);
       const queriesWithAdHocAndInterpolatedVariables = targetsWithInterpolatedVariables.map((t) => ({
@@ -567,7 +566,6 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
         })
       );
     }
-    console.log('frontend flow');
 
     // Frontend flow
     const luceneTargets: OpenSearchQuery[] = [];


### PR DESCRIPTION
While working on https://github.com/grafana/opensearch-datasource/issues/287 I noticed that when I am in the explore tab and make a traces request, the request goes through the backend flow, and when I make a request through the Query Editor it goes through the frontend flow. 

But we haven't actually done the work to support the backend flow for traces yet (that's part of what that ticket is about), so if users attempt to make traces queries in Explore mode they are not going to get data back. 

Until this work is done I think we should add a case to keep just the frontend feature flow going.