### PR TITLE
[BUG] Support time field with nanoseconds

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	TimeFormat = "2006-01-02T15:04:05.000000Z"
+	TimeFormat = "2006-01-02T15:04:05.999999999Z"
 )
 
 func NewJsonFromAny(data interface{}) *simplejson.Json {
@@ -86,7 +86,7 @@ func SpanHasError(spanEvents []interface{}) bool {
 		attributes, ok := eventMap["attributes"].(map[string]interface{})
 		if !ok {
 			log.DefaultLogger.Debug("event attribute is not a map")
-			continue;
+			continue
 		}
 		if attributes["error"] != nil {
 			return true

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -13,6 +13,11 @@ func Test_TimeFieldToMilliseconds(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1631804645000), timestamp)
 	})
+	t.Run("if field is string with nanoseconds, return timestamp in milliseconds", func(t *testing.T) {
+		timestamp, err := TimeFieldToMilliseconds("2021-09-16T15:04:05.000000000Z")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1631804645000), timestamp)
+	})
 	t.Run("if field is invalid time string, return error", func(t *testing.T) {
 		_, err := TimeFieldToMilliseconds("invalid time")
 		require.Error(t, err)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
The time field for traces can have nanosecond precision. If nanoseconds were used, the following error was shown:
![image](https://github.com/grafana/opensearch-datasource/assets/15248220/35cbc8f9-b9a2-4bd9-9a5b-3982c67f4e7c)
This PR fixes this issue by adapting the timeformat to allow for arbitrary subsecond precision up to nanoseconds. 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

It would be great if this change could be released as a patch release, since I can't use the plugin without this change. Thanks