### PR TITLE
Backend migration: logs queries should go through frontend in Explore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.14.4
+
+- Backend migration: revert: logs queries should go through frontend in Explore in [#325](https://github.com/grafana/opensearch-datasource/pull/325)
+
 ## 2.14.3
 
 - Update grafana-aws-sdk to 0.22.0 in [#323](https://github.com/grafana/opensearch-datasource/pull/323)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1236,30 +1236,30 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).not.toHaveBeenCalled();
     });
 
-    it('should send logs queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const logsQuery: OpenSearchQuery = {
-        refId: 'A',
-        metrics: [{ type: 'logs', id: '1' }],
-        query: 'foo="bar"',
-        queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [logsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
+    // it('should send logs queries in Explore', () => {
+    //   const mockedSuperQuery = jest
+    //     .spyOn(DataSourceWithBackend.prototype, 'query')
+    //     .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+    //   const logsQuery: OpenSearchQuery = {
+    //     refId: 'A',
+    //     metrics: [{ type: 'logs', id: '1' }],
+    //     query: 'foo="bar"',
+    //     queryType: QueryType.Lucene,
+    //   };
+    //   const request: DataQueryRequest<OpenSearchQuery> = {
+    //     requestId: '',
+    //     interval: '',
+    //     intervalMs: 1,
+    //     scopedVars: {},
+    //     timezone: '',
+    //     app: CoreApp.Explore,
+    //     startTime: 0,
+    //     range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+    //     targets: [logsQuery],
+    //   };
+    //   ctx.ds.query(request);
+    //   expect(mockedSuperQuery).toHaveBeenCalled();
+    // });
 
     it('should send metric max group by terms query in Explore', () => {
       const mockedSuperQuery = jest
@@ -1351,30 +1351,30 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
-    it('should send PPL logs format queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
-        queryType: QueryType.PPL,
-        format: 'logs',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
+    // it('should send PPL logs format queries in Explore', () => {
+    //   const mockedSuperQuery = jest
+    //     .spyOn(DataSourceWithBackend.prototype, 'query')
+    //     .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+    //   const pplLogsQuery: OpenSearchQuery = {
+    //     refId: 'A',
+    //     queryType: QueryType.PPL,
+    //     format: 'logs',
+    //     query: 'source = test-index',
+    //   };
+    //   const request: DataQueryRequest<OpenSearchQuery> = {
+    //     requestId: '',
+    //     interval: '',
+    //     intervalMs: 1,
+    //     scopedVars: {},
+    //     timezone: '',
+    //     app: CoreApp.Explore,
+    //     startTime: 0,
+    //     range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+    //     targets: [pplLogsQuery],
+    //   };
+    //   ctx.ds.query(request);
+    //   expect(mockedSuperQuery).toHaveBeenCalled();
+    // });
 
     it('should send PPL table format queries in Explore', () => {
       const mockedSuperQuery = jest
@@ -1535,6 +1535,31 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).not.toHaveBeenCalled();
       expect(datasourceRequestMock).toHaveBeenCalled();
     });
+    it('should not send logs queries in Explore ot backend', () => {
+      const mockedSuperQuery = jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+      const logsQuery: OpenSearchQuery = {
+        refId: 'A',
+        metrics: [{ type: 'logs', id: '1' }],
+        query: 'foo="bar"',
+        queryType: QueryType.Lucene,
+      };
+      const request: DataQueryRequest<OpenSearchQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 1,
+        scopedVars: {},
+        timezone: '',
+        app: CoreApp.Explore,
+        startTime: 0,
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+        targets: [logsQuery],
+      };
+      ctx.ds.query(request);
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
+    });
 
     it('does not send metric max group by terms in Dashboard to backend', () => {
       const mockedSuperQuery = jest
@@ -1671,6 +1696,31 @@ describe('OpenSearchDatasource', function (this: any) {
         scopedVars: {},
         timezone: '',
         app: CoreApp.Dashboard,
+        startTime: 0,
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+        targets: [pplLogsQuery],
+      };
+      ctx.ds.query(request);
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
+    });
+     it('should send PPL logs format queries in Explore', () => {
+      const mockedSuperQuery = jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
+      const pplLogsQuery: OpenSearchQuery = {
+        refId: 'A',
+        queryType: QueryType.PPL,
+        format: 'logs',
+        query: 'source = test-index',
+      };
+      const request: DataQueryRequest<OpenSearchQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 1,
+        scopedVars: {},
+        timezone: '',
+        app: CoreApp.Explore,
         startTime: 0,
         range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
         targets: [pplLogsQuery],

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -539,11 +539,9 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
             (metric) =>
               metric.type === 'raw_data' ||
               metric.type === 'raw_document' ||
-              (request.app === CoreApp.Explore && target.queryType === QueryType.Lucene)
+              (request.app === CoreApp.Explore && target.queryType === QueryType.Lucene && metric.type !== 'logs')
           ) ||
-          (request.app === CoreApp.Explore &&
-            target.queryType === QueryType.PPL &&
-            (target.format === 'logs' || target.format === 'table')) ||
+          (request.app === CoreApp.Explore && target.queryType === QueryType.PPL && target.format === 'table') ||
           (request.app === CoreApp.Explore &&
             target.luceneQueryType === LuceneQueryType.Traces &&
             getTraceIdFromLuceneQueryString(target.query ?? ''))


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
We received a [bug report ](https://github.com/grafana/support-escalations/issues/9187)that data links don't work in explore. 
This would normally be an easy fix: we would do something [like this in ElasticSearch](https://github.com/grafana/grafana/blob/62c8584443c1163f936d54a7fd94067ec75abe2c/public/app/plugins/datasource/elasticsearch/datasource.ts#L671). However, this doesn't seem to work with plugin sandboxing. Until we figure out how to pass the new response, we should revert logs to go through the frontend again. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
