### PR TITLE
Backend Migration: Add data links to responses from the backend

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -56,7 +56,7 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => {
     return {
       getInstanceSettings: () => {
-        return { name: 'elastic25' };
+        return { name: 'OSds' };
       },
     };
   },
@@ -2152,7 +2152,7 @@ describe('OpenSearchDatasource', function (this: any) {
         url: '',
         internal: {
           query: { query: 'query' },
-          datasourceName: 'elastic25',
+          datasourceName: 'OSds',
           datasourceUid: 'dsUid',
         },
       });
@@ -2198,7 +2198,7 @@ describe('enhanceDataFrame', () => {
       url: '',
       internal: {
         query: { query: 'query' },
-        datasourceName: 'elastic25',
+        datasourceName: 'OSds',
         datasourceUid: 'dsUid',
       },
     });

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -2096,7 +2096,7 @@ describe('OpenSearchDatasource', function (this: any) {
     });
   });
   describe('Data links', () => {
-    it('should add links to dataframe for backend flow', async () => {
+    it('should add links to dataframe for logs queries in the backend flow', async () => {
       createDatasource({
         url: OPENSEARCH_MOCK_URL,
         jsonData: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export type DataLinkConfig = {
   field: string;
   url: string;
   datasourceUid?: string;
+  urlDisplayLabel?: string;
 };
 
 export enum QueryType {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,15 +1,5 @@
 import { removeEmpty } from './utils';
 
-jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as unknown as object),
-  getDataSourceSrv: () => {
-    return {
-      getInstanceSettings: () => {
-        return { name: 'elastic25' };
-      },
-    };
-  },
-}));
 describe('removeEmpty', () => {
   it('Should remove all empty', () => {
     const original = {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,15 @@
 import { removeEmpty } from './utils';
 
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  getDataSourceSrv: () => {
+    return {
+      getInstanceSettings: () => {
+        return { name: 'elastic25' };
+      },
+    };
+  },
+}));
 describe('removeEmpty', () => {
   it('Should remove all empty', () => {
     const original = {
@@ -34,3 +44,6 @@ describe('removeEmpty', () => {
     expect(removeEmpty(original)).toStrictEqual(expectedResult);
   });
 });
+
+
+


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Adds response processing for data links in the frontend to mirror ElasticSearch: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/datasource.ts#L671

We could probably do this on the backend as well, but due to this being reported in an escalation, this is quicker.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/9187

**Special notes for your reviewer**:

To test, go to datasource config for the provisioning OpenSearch datasource. Then add a data link with name: host and select a datasource. After this, logs data frames in explore should have links at the bottom of each log entry. 