### PR TITLE
Bad: Fix annotation query editor to support new react annotation handling

### DIFF
--- a/src/components/QueryEditor/AnnotationQueryEditor.tsx
+++ b/src/components/QueryEditor/AnnotationQueryEditor.tsx
@@ -35,11 +35,17 @@ export function OpenSearchAnnotationsQueryEditor(props: Props) {
             // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
             // And slate will claim the focus, making it impossible to leave the field.
             onBlur={() => {}}
-            onChange={query =>
+            onChange={query => {
+              const currentTarget = annotation.target ?? { refId : 'annotation_query' };
+              const newTarget = {
+                ...currentTarget,
+                query
+              }
               onAnnotationChange({
                 ...annotation,
-                query,
+                target: newTarget,
               })
+            }
             }
             // We currently only support Lucene Queries in the annotation editor
             placeholder="Lucene Query"

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -186,7 +186,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     const annotation = options.annotation;
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
-    const queryString = annotation.query || '*';
+    const queryString = annotation.query || annotation.target.query;
     const tagsField = annotation.tagsField || 'tags';
     const textField = annotation.textField || null;
 


### PR DESCRIPTION
This PR is to fix the Annotation query editor to support the new json structures for storing the annotation query in the dashboard json.

This PR if to fix the issue - https://github.com/grafana/opensearch-datasource/issues/143

the dashbord json is sticking to the new format of having the query filed nested into the target after the fix
![image](https://github.com/grafana/opensearch-datasource/assets/41931769/177a70ae-c1da-4f4f-97ae-c3f6b1e8ec11)

