### PR TITLE
Bugfix: Forward http headers to enable OAuth for backend queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ## 2.14.3
 
+- Bugfix: Forward http headers to enable OAuth for backend queries [#345](https://github.com/grafana/opensearch-datasource/pull/345)
+
+## 2.14.3
+
 - Update grafana-aws-sdk to 0.22.0 in [#323](https://github.com/grafana/opensearch-datasource/pull/323)
 
 ## 2.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 - Fix: Move "Build a release" in CONTRIBUTING.md out of TLS section in [#324](https://github.com/grafana/opensearch-datasource/pull/324)
 - Backend Migration: Add data links to responses from the backend in [#326](https://github.com/grafana/opensearch-datasource/pull/326)
 
-
 ## 2.14.3
 
 - Update grafana-aws-sdk to 0.22.0 in [#323](https://github.com/grafana/opensearch-datasource/pull/323)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.14.5
+
+- Bugfix: Forward http headers to enable OAuth for backend queries in [#345](https://github.com/grafana/opensearch-datasource/pull/345)
+- Allow to use script in query variable by @loru88 in [#344](https://github.com/grafana/opensearch-datasource/pull/344)
+- Chore: run go mod tidy #338 [#338](https://github.com/grafana/opensearch-datasource/pull/338)
+- Chore: adds basic description and link to github by @sympatheticmoose in [#337](https://github.com/grafana/opensearch-datasource/pull/337)
+
 ## 2.14.4
 
 - Fix: Move "Build a release" in CONTRIBUTING.md out of TLS section in [#324](https://github.com/grafana/opensearch-datasource/pull/324)
 - Backend Migration: Add data links to responses from the backend in [#326](https://github.com/grafana/opensearch-datasource/pull/326)
 
-## 2.14.3
-
-- Bugfix: Forward http headers to enable OAuth for backend queries [#345](https://github.com/grafana/opensearch-datasource/pull/345)
 
 ## 2.14.3
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -104,6 +104,8 @@
     "httptrace",
     "otelhttptrace",
     "testid",
-    "Menges"
+    "Menges",
+    "sympatheticmoose",
+    "loru"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -30,7 +30,8 @@ var (
 
 func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
 	var settings struct {
-		IsServerless bool `json:"serverless"`
+		IsServerless     bool `json:"serverless"`
+		OauthPassThru bool `json:"oauthPassThru"`
 	}
 	err := json.Unmarshal(ds.JSONData, &settings)
 	if err != nil {
@@ -41,6 +42,9 @@ func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstance
 	httpClientOptions, err := ds.HTTPClientOptions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client options: %w", err)
+	}
+	if settings.OauthPassThru {
+		httpClientOptions.ForwardHTTPHeaders = true
 	}
 
 	if httpClientOptions.SigV4 != nil {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

After upgrading to version 2.13.0 of the plugin, query from "Explore view" to OpenSearch stopped working. The user used "Forward OAuth" option in datasource configuration to authenticate to OpenSearch.
This passes on the headers to be used to authenticate down stream. 

From @iwysiu's investigation: 
```
Investigation notes for the person who fixes this:
It looks like (unlike the frontend path) the httpclient.Provider we're using for backend queries doesn't automatically forward oauth tokens. We should set ForwardHTTPHeaders on the http options to true and it should be passed. See the [developer notes](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins#forward-oauth-identity-for-the-logged-in-user)
```
Fixes https://github.com/grafana/opensearch-datasource/issues/330


**Special notes for your reviewer**:

There doesn't seem to be a simple way to unit test this without a refactor to mock out the client, so I decided not to add one.