### PR TITLE
Add node graph toggle

### DIFF
--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
@@ -1,4 +1,4 @@
-import { Segment, InlineSegmentGroup } from '@grafana/ui';
+import { Segment, InlineSegmentGroup, InlineField, InlineSwitch } from '@grafana/ui';
 import { useNextId } from 'hooks/useNextId';
 import React from 'react';
 import { LuceneQueryType, OpenSearchQuery } from 'types';
@@ -6,6 +6,7 @@ import { BucketAggregationsEditor } from '../BucketAggregationsEditor';
 import { MetricAggregationsEditor } from '../MetricAggregationsEditor';
 import { QueryEditorRow } from '../QueryEditorRow';
 import { segmentStyles } from '../styles';
+import { config } from '@grafana/runtime';
 
 type LuceneQueryEditorProps = {
   query: OpenSearchQuery;
@@ -42,6 +43,20 @@ export const LuceneQueryEditor = (props: LuceneQueryEditorProps) => {
             }}
             value={toOption(luceneQueryType)}
           />
+          {luceneQueryType === LuceneQueryType.Traces && (config.featureToggles as any)['openSearchNodeGraph'] && (
+            <InlineField label="Node Graph">
+              <InlineSwitch
+                value={props.query.nodeGraph || false}
+                onChange={(event) => {
+                  const newVal = event.currentTarget.checked;
+                  props.onChange({
+                    ...props.query,
+                    nodeGraph: newVal,
+                  });
+                }}
+              />
+            </InlineField>
+          )}
         </InlineSegmentGroup>
       </QueryEditorRow>
       {luceneQueryType === LuceneQueryType.Metric && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface OpenSearchQuery extends DataQuery {
   queryType?: QueryType;
   format?: PPLFormatType;
   luceneQueryType?: LuceneQueryType;
+  nodeGraph?: boolean;
 }
 
 export type DataLinkConfig = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a node graph toggle to the query editor, doesn't do much yet except send over the boolean to the backend. 
<img width="636" alt="Screenshot 2024-03-18 at 3 28 57 PM" src="https://github.com/grafana/opensearch-datasource/assets/6620164/0031a03d-b06e-4595-8303-ce07e79c51b7">


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/opensearch-datasource/issues/334

**Special notes for your reviewer**:
I've done this behind a feature toggle, but did not put the feature toggle into main grafana. We could add it to main grafana if we wanted to but I am not sure it's worth it in this case, it just gives us better typing and things like that. I think it might be enough to just sort of ad-hoc add it as I've done here so that we're able to work on this in multiple prs and merge/release before the full feature is done. 
