### PR TITLE
Fix: data links not working in explore for Trace List queries

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -298,6 +298,7 @@ func processTraceListResponse(res *es.SearchResponse, dsUID string, dsName strin
 	traceIdColumn.Config = &data.FieldConfig{
 		Links: []data.DataLink{
 			{
+				Title: "Trace: ${__value.raw}",
 				Internal: &data.InternalDataLink{
 					Query: map[string]interface{}{
 						"query":           "traceId: ${__value.raw}",

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.expected_result_generated_snapshot.golden.jsonc
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.expected_result_generated_snapshot.golden.jsonc
@@ -38,6 +38,7 @@
             "config": {
               "links": [
                 {
+                  "title": "Trace: ${__value.raw}",
                   "internal": {
                     "query": {
                       "luceneQueryType": "Traces",

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -566,7 +566,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
           },
         }),
         map((response) => {
-          return enhanceDataFramesWithDataLinks(response, this.dataLinks);
+          return enhanceDataFramesWithDataLinks(response, this.dataLinks, this.uid, this.name, this.type);
         })
       );
     }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { removeEmpty } from './utils';
+import { removeEmpty, enhanceDataFramesWithDataLinks } from './utils';
 
 describe('removeEmpty', () => {
   it('Should remove all empty', () => {
@@ -32,5 +32,69 @@ describe('removeEmpty', () => {
     };
 
     expect(removeEmpty(original)).toStrictEqual(expectedResult);
+  });
+});
+
+describe('enhanceDataFramesWithDataLinks', () => {
+  it('should set an internal data link config for Trace List queries where the Trace Id field does not have an internal config set', () => {
+    const dataQueryResponse = {
+      data: [
+        {
+          name: 'Trace List',
+          fields: [
+            {
+              name: 'Trace Id',
+              config: {
+                links: [{ title: 'Trace: ${__value.raw}' }],
+              },
+            },
+            {
+              name: 'Another Field',
+              config: {
+                links: [{ title: 'Trace: ${__value.raw}' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const dsUid = 'dsUid';
+    const dsName = 'dsName';
+    const dsType = 'dsType';
+    const enhancedDataFrames = enhanceDataFramesWithDataLinks(dataQueryResponse, [], dsUid, dsName, dsType);
+    const traceIdFieldLinkConfig = enhancedDataFrames.data[0].fields[0].config.links?.[0];
+    expect(traceIdFieldLinkConfig?.internal).toBeDefined();
+  });
+
+  it('should not set an internal data link config for non Trace List queries with a Trace Id field', () => {
+    const dataQueryResponse = {
+      data: [
+        {
+          name: 'Not a Trace List Query',
+          fields: [
+            {
+              name: 'Trace Id',
+              config: {
+                links: [{ title: 'Trace: ${__value.raw}' }],
+              },
+            },
+            {
+              name: 'Another Field',
+              config: {
+                links: [{ title: 'Trace: ${__value.raw}' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const dsUid = 'dsUid';
+    const dsName = 'dsName';
+    const dsType = 'dsType';
+    const enhancedDataFrames = enhanceDataFramesWithDataLinks(dataQueryResponse, [], dsUid, dsName, dsType);
+    const traceIdFieldLinkConfig = enhancedDataFrames.data[0].fields[0].config.links?.[0];
+    expect(traceIdFieldLinkConfig?.internal).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Internal data link configs (data links that link to another data source) were added to the backend in 9.5.0. When Trace queries were added to OpenSearch, it added internal data links in the frontend. When we moved the Trace queries to run on the backend, the data links stopped working in pre 9.5.0 versions of Grafana since the backend response didn't have the internal data link config anymore. This PR adds the logic to populate the internal link config only for Trace List queries and only for the Trace Id field, it should leave all other data link configs untouched.

**Which issue(s) this PR fixes**:

Fixes #348

**Special notes for your reviewer**:

For testing, see the contributing doc for instructions on how to set up traces for OpenSearch.