### PR TITLE
Traces: Direct all trace queries to the BE and rename Node graph to Service map

### DIFF
--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -2659,3 +2659,249 @@ func TestProcessTraceListResponse(t *testing.T) {
 	assert.Equal(t, "Last Updated", lastUpdated.Name)
 	assert.Equal(t, "time.Time", lastUpdated.Type().ItemTypeString())
 }
+
+
+func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
+	targets := map[string]string{
+		"A": `{
+			"timeField": "@timestamp",
+			"metrics": [{ "type": "count", "id": "1" }],
+			"query": "traceId:test",
+			"luceneQueryType": "Traces"
+			}`,
+		"B": `{
+			"timeField": "@timestamp",
+			"metrics": [{ "type": "count", "id": "1" }],
+			"query": "traceId:test123",
+			"luceneQueryType": "Traces"
+			}`,
+	}
+
+	response := `
+	{
+		"responses": [
+			{
+				"hits": {
+					"hits": [
+						{
+							"_source": {
+								"traceId": "000000000000000047ed3a25a7dba0cd",
+								"droppedLinksCount": 0,
+								"kind": "SPAN_KIND_SERVER",
+								"droppedEventsCount": 0,
+								"traceGroupFields": {
+									"endTime": "2023-10-18T07:58:38.689468Z",
+									"durationInNanos": 870879000,
+									"statusCode": 0
+								},
+								"traceGroup": "HTTP GET /dispatch",
+								"serviceName": "frontend",
+								"parentSpanId": "",
+								"spanId": "47ed3a25a7dba0cd",
+								"traceState": "",
+								"name": "HTTP GET /dispatch",
+								"startTime": "2023-10-18T07:58:37.818589Z",
+								"links": [],
+								"endTime": "2023-10-18T07:58:38.689468Z",
+								"droppedAttributesCount": 0,
+								"durationInNanos": 870879000,
+								"events": [],
+								"span.attributes.sampler@param": true,
+								"span.attributes.http@method": "GET",
+								"resource.attributes.client-uuid": "1ba5d5eb37e7c2a1",
+								"status.code": 0
+							}
+						}
+						]
+					}
+				},
+				{
+					"hits": {
+						"hits": [
+							{
+								"_source": {
+									"traceId": "000000000000000047ed3a25a7dba0cd",
+									"droppedLinksCount": 0,
+									"kind": "SPAN_KIND_SERVER",
+									"droppedEventsCount": 0,
+									"traceGroupFields": {
+										"endTime": "2023-10-18T07:58:38.689468Z",
+										"durationInNanos": 870879000,
+										"statusCode": 0
+									},
+									"traceGroup": "HTTP GET /dispatch",
+									"serviceName": "frontend",
+									"parentSpanId": "",
+									"spanId": "47ed3a25a7dba0cd",
+									"traceState": "",
+									"name": "HTTP GET /dispatch",
+									"startTime": "2023-10-18T07:58:37.818589Z",
+									"links": [],
+									"endTime": "2023-10-18T07:58:38.689468Z",
+									"droppedAttributesCount": 0,
+									"durationInNanos": 870879000,
+									"events": [],
+									"span.attributes.sampler@param": true,
+									"resource.attributes.client-uuid": "1ba5d5eb37e7c2a1",
+									"status.code": 0
+								}
+							}
+							]
+						}
+					}
+			
+	]	
+	}
+	`
+
+	rp, err := newResponseParserForTest(targets, response, nil, client.ConfiguredFields{TimeField: "@timestamp"}, &backend.DataSourceInstanceSettings{UID: "123", Name: "DatasourceInstanceName"})
+	assert.Nil(t, err)
+
+	result, err := rp.parseResponse()
+	require.NoError(t, err)
+	require.Len(t, result.Responses, 2)
+
+	// 1st query
+	queryResTraceSpans1 := result.Responses["B"]
+	require.NotNil(t, queryResTraceSpans1)
+
+	dataframes := queryResTraceSpans1.Frames
+	require.Len(t, dataframes, 1)
+
+	frame := dataframes[0]
+
+	assert.Len(t, frame.Fields, 24)
+
+	// 2nd query
+	queryResTraceSpans2 := result.Responses["B"]
+	require.NotNil(t, queryResTraceSpans2)
+
+	dataframes = queryResTraceSpans2.Frames
+	require.Len(t, dataframes, 1)
+
+	frame = dataframes[0]
+
+	assert.Len(t, frame.Fields, 24)
+
+}
+
+func TestProcessTraceListAndTraceSpansResponse(t *testing.T) {
+	targets := map[string]string{
+		"A": `{
+			"timeField": "@timestamp",
+			"metrics": [{ "type": "count", "id": "1" }],
+			"luceneQueryType": "Traces"
+			}`,
+		"B": `{
+			"timeField": "@timestamp",
+			"metrics": [{ "type": "count", "id": "1" }],
+			"query": "traceId:test",
+			"luceneQueryType": "Traces"
+			}`,
+	}
+
+	response := `
+	{
+		"responses": [{
+			"aggregations": {
+				"traces": {
+					"buckets": [{
+						"doc_count": 50,
+						"key": "000000000000000001c01e08995dd2e2",
+						"last_updated": {
+							"value": 1700074430928,
+							"value_as_string": "2023-11-15T18:53:50.928Z"
+						},
+						"latency": {
+							"value": 656.43
+						},
+						"trace_group": {
+							"buckets":[{
+								"doc_count":50,
+								"key": "HTTP GET /dispatch"
+							}]
+						},
+						"error_count": {
+							"doc_count":0
+						}
+					}]
+				}
+			
+		}
+},
+			{
+				"hits": {
+					"total": {
+						"value": 51,
+						"relation": "eq"
+					},
+					"max_score": 3.4040546,
+					"hits": [
+						{
+							"_source": {
+								"traceId": "000000000000000047ed3a25a7dba0cd",
+								"droppedLinksCount": 0,
+								"kind": "SPAN_KIND_SERVER",
+								"droppedEventsCount": 0,
+								"traceGroupFields": {
+									"endTime": "2023-10-18T07:58:38.689468Z",
+									"durationInNanos": 870879000,
+									"statusCode": 0
+								},
+								"traceGroup": "HTTP GET /dispatch",
+								"serviceName": "frontend",
+								"parentSpanId": "",
+								"spanId": "47ed3a25a7dba0cd",
+								"traceState": "",
+								"name": "HTTP GET /dispatch",
+								"startTime": "2023-10-18T07:58:37.818589Z",
+								"links": [],
+								"endTime": "2023-10-18T07:58:38.689468Z",
+								"droppedAttributesCount": 0,
+								"durationInNanos": 870879000,
+								"events": [],
+								"span.attributes.sampler@param": true,
+								"span.attributes.http@method": "GET",
+								"resource.attributes.client-uuid": "1ba5d5eb37e7c2a1",
+								"status.code": 0
+							}
+						}
+						]
+					}
+				}
+			
+	]	
+	}
+	`
+
+	rp, err := newResponseParserForTest(targets, response, nil, client.ConfiguredFields{TimeField: "@timestamp"}, &backend.DataSourceInstanceSettings{UID: "123", Name: "DatasourceInstanceName"})
+	assert.Nil(t, err)
+
+	result, err := rp.parseResponse()
+	require.NoError(t, err)
+	require.Len(t, result.Responses, 2)
+
+	// trace list
+	queryResTraceList := result.Responses["A"]
+	require.NotNil(t, queryResTraceList)
+
+	dataframes := queryResTraceList.Frames
+	require.Len(t, dataframes, 1)
+
+	frame := dataframes[0]
+
+	traceId := frame.Fields[0]
+	assert.Equal(t, "000000000000000001c01e08995dd2e2", traceId.At(0))
+
+	// trace spans
+	queryResTraceSpans := result.Responses["B"]
+	require.NotNil(t, queryResTraceSpans)
+
+	dataframes = queryResTraceSpans.Frames
+	require.Len(t, dataframes, 1)
+
+	frame = dataframes[0]
+
+	assert.Len(t, frame.Fields, 24)
+
+}

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -2660,7 +2660,6 @@ func TestProcessTraceListResponse(t *testing.T) {
 	assert.Equal(t, "time.Time", lastUpdated.Type().ItemTypeString())
 }
 
-
 func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 	targets := map[string]string{
 		"A": `{
@@ -2699,7 +2698,7 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 								"parentSpanId": "",
 								"spanId": "47ed3a25a7dba0cd",
 								"traceState": "",
-								"name": "HTTP GET /dispatch",
+								"name": "test domain A",
 								"startTime": "2023-10-18T07:58:37.818589Z",
 								"links": [],
 								"endTime": "2023-10-18T07:58:38.689468Z",
@@ -2734,7 +2733,7 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 									"parentSpanId": "",
 									"spanId": "47ed3a25a7dba0cd",
 									"traceState": "",
-									"name": "HTTP GET /dispatch",
+									"name": "test domain B",
 									"startTime": "2023-10-18T07:58:37.818589Z",
 									"links": [],
 									"endTime": "2023-10-18T07:58:38.689468Z",
@@ -2762,7 +2761,7 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 	require.Len(t, result.Responses, 2)
 
 	// 1st query
-	queryResTraceSpans1 := result.Responses["B"]
+	queryResTraceSpans1 := result.Responses["A"]
 	require.NotNil(t, queryResTraceSpans1)
 
 	dataframes := queryResTraceSpans1.Frames
@@ -2771,7 +2770,8 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 	frame := dataframes[0]
 
 	assert.Len(t, frame.Fields, 24)
-
+	assert.Equal(t, getFrameValue("operationName", 0, frame.Fields), "test domain A")
+	
 	// 2nd query
 	queryResTraceSpans2 := result.Responses["B"]
 	require.NotNil(t, queryResTraceSpans2)
@@ -2780,6 +2780,7 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 	require.Len(t, dataframes, 1)
 
 	frame = dataframes[0]
+	assert.Equal(t, getFrameValue("operationName", 0, frame.Fields), "test domain B")
 
 	assert.Len(t, frame.Fields, 24)
 
@@ -2904,4 +2905,14 @@ func TestProcessTraceListAndTraceSpansResponse(t *testing.T) {
 
 	assert.Len(t, frame.Fields, 24)
 
+}
+
+
+func getFrameValue(name string, index int, fields []*data.Field) string {
+	for _, field := range fields {
+		if field.Name == name {
+			return *field.At(index).(*string)
+		}
+	}
+	return ""
 }

--- a/pkg/opensearch/snapshot_tests/lucene_trace_list_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_trace_list_test.go
@@ -46,6 +46,40 @@ func Test_trace_list_request(t *testing.T) {
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
 
+func Test_trace_list_request_with_multiple_list_queries(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_trace_list.query_input_multiple.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"traces":{"aggs":{"error_count":{"filter":{"term":{"traceGroupFields.statusCode":"2"}}},"last_updated":{"max":{"field":"traceGroupFields.endTime"}},"latency":{"max":{"script":{"source":"\n                if (doc.containsKey('traceGroupFields.durationInNanos') \u0026\u0026 !doc['traceGroupFields.durationInNanos'].empty) {\n                  return Math.round(doc['traceGroupFields.durationInNanos'].value / 10000) / 100.0\n                }\n                return 0\n                ","lang":"painless"}}},"trace_group":{"terms":{"field":"traceGroup","size":1}}},"terms":{"field":"traceId","size":100,"order":{"_key":"asc"}}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"some query"}}]}},"size":10}
+{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"traces":{"aggs":{"error_count":{"filter":{"term":{"traceGroupFields.statusCode":"2"}}},"last_updated":{"max":{"field":"traceGroupFields.endTime"}},"latency":{"max":{"script":{"source":"\n                if (doc.containsKey('traceGroupFields.durationInNanos') \u0026\u0026 !doc['traceGroupFields.durationInNanos'].empty) {\n                  return Math.round(doc['traceGroupFields.durationInNanos'].value / 10000) / 100.0\n                }\n                return 0\n                ","lang":"painless"}}},"trace_group":{"terms":{"field":"traceGroup","size":1}}},"terms":{"field":"traceId","size":100,"order":{"_key":"asc"}}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"some query"}}]}},"size":10}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+
 func Test_trace_list_response(t *testing.T) {
 	responseFromOpenSearch, err := os.ReadFile("testdata/lucene_trace_list.response_from_opensearch.json")
 	require.NoError(t, err)
@@ -68,3 +102,30 @@ func Test_trace_list_response(t *testing.T) {
 	assert.True(t, ok)
 	experimental.CheckGoldenJSONResponse(t, "testdata", "lucene_trace_list.expected_result_generated_snapshot.golden", &responseForRefIdA, false)
 }
+
+func Test_trace_list_response_with_multiple_list_queries(t *testing.T) {
+	responseFromOpenSearch, err := os.ReadFile("testdata/lucene_trace_list.response_from_opensearch_multiple.json")
+	require.NoError(t, err)
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_trace_list.query_input_multiple.json")
+	require.NoError(t, err)
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			Transport: &queryDataTestRoundTripper{body: responseFromOpenSearch, statusCode: 200, requestCallback: func(req *http.Request) error { return nil }},
+		},
+	}
+
+	result, err := openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	responseForRefIdA, ok := result.Responses["A"]
+	assert.True(t, ok)
+	responseForRefIdB, ok := result.Responses["B"]
+	assert.True(t, ok)
+	experimental.CheckGoldenJSONResponse(t, "testdata", "lucene_trace_list.expected_result_generated_snapshot.golden", &responseForRefIdA, false)
+	experimental.CheckGoldenJSONResponse(t, "testdata", "lucene_trace_list.expected_result_generated_snapshot.golden", &responseForRefIdB, false)
+}
+

--- a/pkg/opensearch/snapshot_tests/lucene_trace_spans_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_trace_spans_test.go
@@ -43,5 +43,73 @@ func Test_trace_spans_request(t *testing.T) {
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
+
+func Test_trace_spans_request_with_multiple_spans_queries(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_trace_spans.query_input_multiple.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
+{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test123"}}]}},"size":1000}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+
+func Test_trace_spans_request_with_trace_list_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_trace_list_and_spans.query_input.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
+{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"traces":{"aggs":{"error_count":{"filter":{"term":{"traceGroupFields.statusCode":"2"}}},"last_updated":{"max":{"field":"traceGroupFields.endTime"}},"latency":{"max":{"script":{"source":"\n                if (doc.containsKey('traceGroupFields.durationInNanos') \u0026\u0026 !doc['traceGroupFields.durationInNanos'].empty) {\n                  return Math.round(doc['traceGroupFields.durationInNanos'].value / 10000) / 100.0\n                }\n                return 0\n                ","lang":"painless"}}},"trace_group":{"terms":{"field":"traceGroup","size":1}}},"terms":{"field":"traceId","size":100,"order":{"_key":"asc"}}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"some query"}}]}},"size":10}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
 // Couldn't get the snapshot test for the trace span responses to work because the response processing uses maps, so the result has slightly different order every time. 
 // Added a test for the response in response_processing.test.go instead

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.query_input_multiple.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.query_input_multiple.json
@@ -1,0 +1,66 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "a2a05fd1-c06c-4008-b469-720fea03add2"
+    },
+    "format": "table",
+    "luceneQueryType": "Traces",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "count"
+      }
+    ],
+    "query": "some query",
+    "queryType": "lucene",
+    "refId": "A",
+    "timeField": "@timestamp",
+    "datasourceId": 2020,
+    "intervalMs": 10000,
+    "maxDataPoints": 1124
+  },
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "a2a05fd1-c06c-4008-b469-720fea03add2"
+    },
+    "format": "table",
+    "luceneQueryType": "Traces",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "count"
+      }
+    ],
+    "query": "some query",
+    "queryType": "lucene",
+    "refId": "B",
+    "timeField": "@timestamp",
+    "datasourceId": 2020,
+    "intervalMs": 10000,
+    "maxDataPoints": 1124
+  }
+]

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.response_from_opensearch_multiple.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.response_from_opensearch_multiple.json
@@ -1,0 +1,1425 @@
+{
+  "took": 94,
+  "responses": [
+    {
+      "took": 93,
+      "timed_out": false,
+      "_shards": { "total": 7, "successful": 7, "skipped": 0, "failed": 0 },
+      "hits": {
+        "total": { "value": 262, "relation": "eq" },
+        "max_score": 2.0,
+        "hits": [
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "57603fd19d265431",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "000000000000000057603fd19d265431",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:41.225343Z",
+                "durationInNanos": 1025000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "57603fd19d265431",
+              "traceState": "",
+              "name": "HTTP GET /",
+              "startTime": "2023-11-21T19:39:41.224318Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:41.225343Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 1025000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "3a2735bf3ecf9fbe",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000003a2735bf3ecf9fbe",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:41.248198Z",
+                "durationInNanos": 2920000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "3a2735bf3ecf9fbe",
+              "traceState": "",
+              "name": "HTTP GET /",
+              "startTime": "2023-11-21T19:39:41.245278Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:41.248198Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 2920000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/jquery-3.1.1.min.js",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "6486522b83a8a0b1",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000006486522b83a8a0b1",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.139154Z",
+                "durationInNanos": 42000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /config",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "6486522b83a8a0b1",
+              "traceState": "",
+              "name": "HTTP GET /config",
+              "startTime": "2023-11-21T19:39:46.139112Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.139154Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 42000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/config?nonse=0.4969536744975127",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "63a3f64f32254597",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "000000000000000063a3f64f32254597",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:43.828816Z",
+                "durationInNanos": 138000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /config",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "63a3f64f32254597",
+              "traceState": "",
+              "name": "HTTP GET /config",
+              "startTime": "2023-11-21T19:39:43.828678Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:43.828816Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 138000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/config?nonse=0.9432233421993381",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "1c826277770e267d",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "1c826277770e267d",
+              "traceState": "",
+              "name": "HTTP GET /dispatch",
+              "startTime": "2023-11-21T19:39:46.139118Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.811037Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 671919000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.139165Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/dispatch?customer=392&nonse=0.665090655428118"
+                  },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Getting customer",
+                  "time": "2023-11-21T19:39:46.139299Z",
+                  "attributes": { "level": "info", "customer_id": "392" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found customer",
+                  "time": "2023-11-21T19:39:46.421125Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "baggage",
+                  "time": "2023-11-21T19:39:46.421195Z",
+                  "attributes": { "value": "Trom Chocolatier", "key": "customer" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding nearest drivers",
+                  "time": "2023-11-21T19:39:46.421212Z",
+                  "attributes": { "level": "info", "location": "577,322" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found drivers",
+                  "time": "2023-11-21T19:39:46.614743Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615402Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "238,861" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615830Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "431,751" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615877Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "953,948" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.665114Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "787,985" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.666635Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "494,185" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.666743Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "530,981" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.707929Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "809,976" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.714134Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "277,491" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.737995Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "716,562" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.763875Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "823,141" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found routes",
+                  "time": "2023-11-21T19:39:46.810996Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Dispatch successful",
+                  "time": "2023-11-21T19:39:46.811027Z",
+                  "attributes": { "eta": "2m0s", "driver": "T718601C", "level": "info" },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/dispatch?customer=392&nonse=0.665090655428118",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "0492f886688bb597",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_UNSPECIFIED",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "frontend",
+              "parentSpanId": "1c826277770e267d",
+              "spanId": "0492f886688bb597",
+              "traceState": "",
+              "name": "HTTP GET: /route",
+              "startTime": "2023-11-21T19:39:46.616007Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.666741Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 50734000,
+              "events": [],
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "17b647e1da52861a",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_CLIENT",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "redis",
+              "parentSpanId": "7fed956b4cf2be50",
+              "spanId": "17b647e1da52861a",
+              "traceState": "",
+              "name": "GetDriver",
+              "startTime": "2023-11-21T19:39:46.528458Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.561093Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 32635000,
+              "events": [
+                {
+                  "name": "redis timeout",
+                  "time": "2023-11-21T19:39:46.561046Z",
+                  "attributes": { "driver_id": "T780536C", "level": "error", "error": "redis timeout" },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "resource.attributes.client-uuid": "2f4706c5818f30d0",
+              "resource.attributes.ip": "172.18.0.5",
+              "span.attributes.param@driverID": "T780536C",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "redis",
+              "status.code": 2
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "73a1d7f5c55c28bd",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "route",
+              "parentSpanId": "201326eb351d1e2c",
+              "spanId": "73a1d7f5c55c28bd",
+              "traceState": "",
+              "name": "HTTP GET /route",
+              "startTime": "2023-11-21T19:39:46.665397Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.707759Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 42362000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.665414Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/route?dropoff=577%2C322&pickup=787%2C985"
+                  },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/route?dropoff=577%2C322&pickup=787%2C985",
+              "resource.attributes.client-uuid": "7d83c287c3398922",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "route",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "339f1f478babdef0",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_CLIENT",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "redis",
+              "parentSpanId": "7fed956b4cf2be50",
+              "spanId": "339f1f478babdef0",
+              "traceState": "",
+              "name": "GetDriver",
+              "startTime": "2023-11-21T19:39:46.497379Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.506207Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 8828000,
+              "events": [],
+              "resource.attributes.client-uuid": "2f4706c5818f30d0",
+              "resource.attributes.ip": "172.18.0.5",
+              "span.attributes.param@driverID": "T790599C",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "redis",
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "16188420e0231318",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "route",
+              "parentSpanId": "33db03d29de15345",
+              "spanId": "16188420e0231318",
+              "traceState": "",
+              "name": "HTTP GET /route",
+              "startTime": "2023-11-21T19:39:46.666936Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.737865Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 70929000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.666949Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/route?dropoff=577%2C322&pickup=494%2C185"
+                  },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/route?dropoff=577%2C322&pickup=494%2C185",
+              "resource.attributes.client-uuid": "7d83c287c3398922",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "route",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0
+            }
+          }
+        ]
+      },
+      "aggregations": {
+        "traces": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "00000000000000001c826277770e267d",
+              "doc_count": 50,
+              "last_updated": { "value": 1.700595586811e12, "value_as_string": "2023-11-21T19:39:46.811Z" },
+              "latency": { "value": 671.91 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 50 }]
+              }
+            },
+            {
+              "key": "0000000000000000252c7c74849b6fe7",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700595588782e12, "value_as_string": "2023-11-21T19:39:48.782Z" },
+              "latency": { "value": 760.23 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            },
+            {
+              "key": "0000000000000000260d9137e9aea627",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700596099622e12, "value_as_string": "2023-11-21T19:48:19.622Z" },
+              "latency": { "value": 735.64 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            },
+            {
+              "key": "00000000000000003a2735bf3ecf9fbe",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595581248e12, "value_as_string": "2023-11-21T19:39:41.248Z" },
+              "latency": { "value": 2.92 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000046f0ef81931b97f9",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596097544e12, "value_as_string": "2023-11-21T19:48:17.544Z" },
+              "latency": { "value": 0.63 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000057603fd19d265431",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595581225e12, "value_as_string": "2023-11-21T19:39:41.225Z" },
+              "latency": { "value": 1.02 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000057a6dd673748973d",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595590157e12, "value_as_string": "2023-11-21T19:39:50.157Z" },
+              "latency": { "value": 0.02 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000005bb75b8cd50e57ca",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596097482e12, "value_as_string": "2023-11-21T19:48:17.482Z" },
+              "latency": { "value": 0.81 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000063a3f64f32254597",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595583828e12, "value_as_string": "2023-11-21T19:39:43.828Z" },
+              "latency": { "value": 0.13 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000006486522b83a8a0b1",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595586139e12, "value_as_string": "2023-11-21T19:39:46.139Z" },
+              "latency": { "value": 0.04 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000071beb0b4e7e64589",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595588022e12, "value_as_string": "2023-11-21T19:39:48.022Z" },
+              "latency": { "value": 0.03 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000074921202d333f490",
+              "doc_count": 50,
+              "last_updated": { "value": 1.700595590836e12, "value_as_string": "2023-11-21T19:39:50.836Z" },
+              "latency": { "value": 679.0 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 50 }]
+              }
+            },
+            {
+              "key": "00000000000000007df1103ab1f31768",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596098886e12, "value_as_string": "2023-11-21T19:48:18.886Z" },
+              "latency": { "value": 0.16 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000007ec612d7ab1c325f",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700595584556e12, "value_as_string": "2023-11-21T19:39:44.556Z" },
+              "latency": { "value": 727.8 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    },
+    {
+      "took": 93,
+      "timed_out": false,
+      "_shards": { "total": 7, "successful": 7, "skipped": 0, "failed": 0 },
+      "hits": {
+        "total": { "value": 262, "relation": "eq" },
+        "max_score": 2.0,
+        "hits": [
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "57603fd19d265431",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "000000000000000057603fd19d265431",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:41.225343Z",
+                "durationInNanos": 1025000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "57603fd19d265431",
+              "traceState": "",
+              "name": "HTTP GET /",
+              "startTime": "2023-11-21T19:39:41.224318Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:41.225343Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 1025000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "3a2735bf3ecf9fbe",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000003a2735bf3ecf9fbe",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:41.248198Z",
+                "durationInNanos": 2920000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "3a2735bf3ecf9fbe",
+              "traceState": "",
+              "name": "HTTP GET /",
+              "startTime": "2023-11-21T19:39:41.245278Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:41.248198Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 2920000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/jquery-3.1.1.min.js",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "6486522b83a8a0b1",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000006486522b83a8a0b1",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.139154Z",
+                "durationInNanos": 42000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /config",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "6486522b83a8a0b1",
+              "traceState": "",
+              "name": "HTTP GET /config",
+              "startTime": "2023-11-21T19:39:46.139112Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.139154Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 42000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/config?nonse=0.4969536744975127",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "63a3f64f32254597",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "000000000000000063a3f64f32254597",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:43.828816Z",
+                "durationInNanos": 138000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /config",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "63a3f64f32254597",
+              "traceState": "",
+              "name": "HTTP GET /config",
+              "startTime": "2023-11-21T19:39:43.828678Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:43.828816Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 138000,
+              "events": [],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/config?nonse=0.9432233421993381",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "1c826277770e267d",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "frontend",
+              "parentSpanId": "",
+              "spanId": "1c826277770e267d",
+              "traceState": "",
+              "name": "HTTP GET /dispatch",
+              "startTime": "2023-11-21T19:39:46.139118Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.811037Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 671919000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.139165Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/dispatch?customer=392&nonse=0.665090655428118"
+                  },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Getting customer",
+                  "time": "2023-11-21T19:39:46.139299Z",
+                  "attributes": { "level": "info", "customer_id": "392" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found customer",
+                  "time": "2023-11-21T19:39:46.421125Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "baggage",
+                  "time": "2023-11-21T19:39:46.421195Z",
+                  "attributes": { "value": "Trom Chocolatier", "key": "customer" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding nearest drivers",
+                  "time": "2023-11-21T19:39:46.421212Z",
+                  "attributes": { "level": "info", "location": "577,322" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found drivers",
+                  "time": "2023-11-21T19:39:46.614743Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615402Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "238,861" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615830Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "431,751" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.615877Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "953,948" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.665114Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "787,985" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.666635Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "494,185" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.666743Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "530,981" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.707929Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "809,976" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.714134Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "277,491" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.737995Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "716,562" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Finding route",
+                  "time": "2023-11-21T19:39:46.763875Z",
+                  "attributes": { "level": "info", "dropoff": "577,322", "pickup": "823,141" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Found routes",
+                  "time": "2023-11-21T19:39:46.810996Z",
+                  "attributes": { "level": "info" },
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "name": "Dispatch successful",
+                  "time": "2023-11-21T19:39:46.811027Z",
+                  "attributes": { "eta": "2m0s", "driver": "T718601C", "level": "info" },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.sampler@param": true,
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/dispatch?customer=392&nonse=0.665090655428118",
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0,
+              "span.attributes.sampler@type": "const"
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "0492f886688bb597",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_UNSPECIFIED",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "frontend",
+              "parentSpanId": "1c826277770e267d",
+              "spanId": "0492f886688bb597",
+              "traceState": "",
+              "name": "HTTP GET: /route",
+              "startTime": "2023-11-21T19:39:46.616007Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.666741Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 50734000,
+              "events": [],
+              "resource.attributes.client-uuid": "446876afaa199f40",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "frontend",
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "17b647e1da52861a",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_CLIENT",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "redis",
+              "parentSpanId": "7fed956b4cf2be50",
+              "spanId": "17b647e1da52861a",
+              "traceState": "",
+              "name": "GetDriver",
+              "startTime": "2023-11-21T19:39:46.528458Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.561093Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 32635000,
+              "events": [
+                {
+                  "name": "redis timeout",
+                  "time": "2023-11-21T19:39:46.561046Z",
+                  "attributes": { "driver_id": "T780536C", "level": "error", "error": "redis timeout" },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "resource.attributes.client-uuid": "2f4706c5818f30d0",
+              "resource.attributes.ip": "172.18.0.5",
+              "span.attributes.param@driverID": "T780536C",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "redis",
+              "status.code": 2
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "73a1d7f5c55c28bd",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "route",
+              "parentSpanId": "201326eb351d1e2c",
+              "spanId": "73a1d7f5c55c28bd",
+              "traceState": "",
+              "name": "HTTP GET /route",
+              "startTime": "2023-11-21T19:39:46.665397Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.707759Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 42362000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.665414Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/route?dropoff=577%2C322&pickup=787%2C985"
+                  },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/route?dropoff=577%2C322&pickup=787%2C985",
+              "resource.attributes.client-uuid": "7d83c287c3398922",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "route",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "339f1f478babdef0",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_CLIENT",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "redis",
+              "parentSpanId": "7fed956b4cf2be50",
+              "spanId": "339f1f478babdef0",
+              "traceState": "",
+              "name": "GetDriver",
+              "startTime": "2023-11-21T19:39:46.497379Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.506207Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 8828000,
+              "events": [],
+              "resource.attributes.client-uuid": "2f4706c5818f30d0",
+              "resource.attributes.ip": "172.18.0.5",
+              "span.attributes.param@driverID": "T790599C",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "redis",
+              "status.code": 0
+            }
+          },
+          {
+            "_index": "otel-v1-apm-span-000001",
+            "_id": "16188420e0231318",
+            "_score": 2.0,
+            "_source": {
+              "traceId": "00000000000000001c826277770e267d",
+              "droppedLinksCount": 0,
+              "kind": "SPAN_KIND_SERVER",
+              "droppedEventsCount": 0,
+              "traceGroupFields": {
+                "endTime": "2023-11-21T19:39:46.811037Z",
+                "durationInNanos": 671919000,
+                "statusCode": 0
+              },
+              "traceGroup": "HTTP GET /dispatch",
+              "serviceName": "route",
+              "parentSpanId": "33db03d29de15345",
+              "spanId": "16188420e0231318",
+              "traceState": "",
+              "name": "HTTP GET /route",
+              "startTime": "2023-11-21T19:39:46.666936Z",
+              "links": [],
+              "endTime": "2023-11-21T19:39:46.737865Z",
+              "droppedAttributesCount": 0,
+              "durationInNanos": 70929000,
+              "events": [
+                {
+                  "name": "HTTP request received",
+                  "time": "2023-11-21T19:39:46.666949Z",
+                  "attributes": {
+                    "method": "GET",
+                    "level": "info",
+                    "url": "/route?dropoff=577%2C322&pickup=494%2C185"
+                  },
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "span.attributes.http@method": "GET",
+              "span.attributes.http@url": "/route?dropoff=577%2C322&pickup=494%2C185",
+              "resource.attributes.client-uuid": "7d83c287c3398922",
+              "resource.attributes.ip": "172.18.0.5",
+              "resource.attributes.host@name": "e0693ce0a2d1",
+              "resource.attributes.opencensus@exporterversion": "Jaeger-Go-2.30.0",
+              "resource.attributes.service@name": "route",
+              "span.attributes.component": "net/http",
+              "span.attributes.http@status_code": 200,
+              "status.code": 0
+            }
+          }
+        ]
+      },
+      "aggregations": {
+        "traces": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "00000000000000001c826277770e267d",
+              "doc_count": 50,
+              "last_updated": { "value": 1.700595586811e12, "value_as_string": "2023-11-21T19:39:46.811Z" },
+              "latency": { "value": 671.91 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 50 }]
+              }
+            },
+            {
+              "key": "0000000000000000252c7c74849b6fe7",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700595588782e12, "value_as_string": "2023-11-21T19:39:48.782Z" },
+              "latency": { "value": 760.23 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            },
+            {
+              "key": "0000000000000000260d9137e9aea627",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700596099622e12, "value_as_string": "2023-11-21T19:48:19.622Z" },
+              "latency": { "value": 735.64 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            },
+            {
+              "key": "00000000000000003a2735bf3ecf9fbe",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595581248e12, "value_as_string": "2023-11-21T19:39:41.248Z" },
+              "latency": { "value": 2.92 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000046f0ef81931b97f9",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596097544e12, "value_as_string": "2023-11-21T19:48:17.544Z" },
+              "latency": { "value": 0.63 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000057603fd19d265431",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595581225e12, "value_as_string": "2023-11-21T19:39:41.225Z" },
+              "latency": { "value": 1.02 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000057a6dd673748973d",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595590157e12, "value_as_string": "2023-11-21T19:39:50.157Z" },
+              "latency": { "value": 0.02 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000005bb75b8cd50e57ca",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596097482e12, "value_as_string": "2023-11-21T19:48:17.482Z" },
+              "latency": { "value": 0.81 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000063a3f64f32254597",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595583828e12, "value_as_string": "2023-11-21T19:39:43.828Z" },
+              "latency": { "value": 0.13 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000006486522b83a8a0b1",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595586139e12, "value_as_string": "2023-11-21T19:39:46.139Z" },
+              "latency": { "value": 0.04 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000071beb0b4e7e64589",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700595588022e12, "value_as_string": "2023-11-21T19:39:48.022Z" },
+              "latency": { "value": 0.03 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "000000000000000074921202d333f490",
+              "doc_count": 50,
+              "last_updated": { "value": 1.700595590836e12, "value_as_string": "2023-11-21T19:39:50.836Z" },
+              "latency": { "value": 679.0 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 50 }]
+              }
+            },
+            {
+              "key": "00000000000000007df1103ab1f31768",
+              "doc_count": 1,
+              "last_updated": { "value": 1.700596098886e12, "value_as_string": "2023-11-21T19:48:18.886Z" },
+              "latency": { "value": 0.16 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /config", "doc_count": 1 }]
+              }
+            },
+            {
+              "key": "00000000000000007ec612d7ab1c325f",
+              "doc_count": 51,
+              "last_updated": { "value": 1.700595584556e12, "value_as_string": "2023-11-21T19:39:44.556Z" },
+              "latency": { "value": 727.8 },
+              "error_count": { "doc_count": 0 },
+              "trace_group": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [{ "key": "HTTP GET /dispatch", "doc_count": 51 }]
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    }
+  ]
+}

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list_and_spans.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list_and_spans.query_input.json
@@ -1,0 +1,49 @@
+[
+  {
+    "refId": "A",
+    "datasource": { "type": "grafana-opensearch-datasource", "uid": "aca30e11-e305-46d1-b378-9b29b690bacb" },
+    "query": "traceId:test",
+    "queryType": "lucene",
+    "alias": "",
+    "metrics": [{ "type": "count", "id": "1" }],
+    "bucketAggs": [{ "type": "date_histogram", "id": "2", "settings": { "interval": "auto" }, "field": "@timestamp" }],
+    "format": "table",
+    "timeField": "@timestamp",
+    "luceneQueryType": "Traces",
+    "datasourceId": 13510,
+    "intervalMs": 20000,
+    "maxDataPoints": 1150
+  },
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "a2a05fd1-c06c-4008-b469-720fea03add2"
+    },
+    "format": "table",
+    "luceneQueryType": "Traces",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "count"
+      }
+    ],
+    "query": "some query",
+    "queryType": "lucene",
+    "refId": "B",
+    "timeField": "@timestamp",
+    "datasourceId": 2020,
+    "intervalMs": 10000,
+    "maxDataPoints": 1124
+  }
+]

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_spans.query_input_multiple.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_spans.query_input_multiple.json
@@ -1,0 +1,32 @@
+[
+  {
+    "refId": "A",
+    "datasource": { "type": "grafana-opensearch-datasource", "uid": "aca30e11-e305-46d1-b378-9b29b690bacb" },
+    "query": "traceId:test",
+    "queryType": "lucene",
+    "alias": "",
+    "metrics": [{ "type": "count", "id": "1" }],
+    "bucketAggs": [{ "type": "date_histogram", "id": "2", "settings": { "interval": "auto" }, "field": "@timestamp" }],
+    "format": "table",
+    "timeField": "@timestamp",
+    "luceneQueryType": "Traces",
+    "datasourceId": 13510,
+    "intervalMs": 20000,
+    "maxDataPoints": 1150
+  },
+  {
+    "refId": "B",
+    "datasource": { "type": "grafana-opensearch-datasource", "uid": "aca30e11-e305-46d1-b378-9b29b690bacb" },
+    "query": "traceId:test123",
+    "queryType": "lucene",
+    "alias": "",
+    "metrics": [{ "type": "count", "id": "1" }],
+    "bucketAggs": [{ "type": "date_histogram", "id": "2", "settings": { "interval": "auto" }, "field": "@timestamp" }],
+    "format": "table",
+    "timeField": "@timestamp",
+    "luceneQueryType": "Traces",
+    "datasourceId": 13510,
+    "intervalMs": 20000,
+    "maxDataPoints": 1150
+  }
+]

--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
@@ -99,7 +99,7 @@ describe('LuceneQueryEditor', () => {
     expect(mockOnChange.mock.calls[0][0].luceneQueryType).toBe('Traces');
   });
 
-  it('renders the node graph switch when traces is selected', async () => {
+  it('renders the service map switch when traces is selected', async () => {
     jest.mock('@grafana/runtime', () => ({
       ...jest.requireActual('@grafana/runtime'),
       config: {
@@ -120,7 +120,7 @@ describe('LuceneQueryEditor', () => {
       </OpenSearchProvider>
     );
 
-    expect(screen.queryByText('Node Graph')).toBeInTheDocument();
+    expect(screen.queryByText('Service Map')).toBeInTheDocument();
     jest.clearAllMocks();
   });
 });

--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
@@ -44,14 +44,14 @@ export const LuceneQueryEditor = (props: LuceneQueryEditorProps) => {
             value={toOption(luceneQueryType)}
           />
           {luceneQueryType === LuceneQueryType.Traces && (config.featureToggles as any)['openSearchNodeGraph'] && (
-            <InlineField label="Node Graph">
+            <InlineField label="Service Map" tooltip={"Request and display service map data for trace(s)"}>
               <InlineSwitch
-                value={props.query.nodeGraph || false}
+                value={props.query.serviceMap || false}
                 onChange={(event) => {
                   const newVal = event.currentTarget.checked;
                   props.onChange({
                     ...props.query,
-                    nodeGraph: newVal,
+                    serviceMap: newVal,
                   });
                 }}
               />

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1223,7 +1223,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
-    it('should not send trace list queries', () => {
+    it('should send trace list queries', () => {
       const rawDataQuery: OpenSearchQuery = {
         refId: 'A',
         queryType: QueryType.Lucene,
@@ -1242,7 +1242,7 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [rawDataQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
     it('should send logs queries in Explore', () => {
@@ -1855,24 +1855,6 @@ describe('OpenSearchDatasource', function (this: any) {
         } as MetricAggregation,
       ],
     });
-
-    it('can handle multiple trace list queries', async () => {
-      const mockResponses = {
-        responses: [emptyTraceListResponse.data.responses[0], emptyTraceListResponse.data.responses[0]],
-      };
-      datasourceRequestMock.mockImplementation((options) => {
-        return Promise.resolve({
-          data: mockResponses,
-        });
-      });
-      const result = await lastValueFrom(
-        ctx.ds.query({
-          ...createOpenSearchQuery([traceListTarget('traceList1'), traceListTarget('traceList2')]),
-        })
-      );
-      expect(result.data[0].refId).toEqual('traceList1');
-      expect(result.data[1].refId).toEqual('traceList2');
-    });
     it('can handle multiple metrics queries', async () => {
       const mockResponses = {
         responses: [emptyMetricsResponse.data.responses[0], emptyMetricsResponse.data.responses[0]],
@@ -1889,31 +1871,6 @@ describe('OpenSearchDatasource', function (this: any) {
       );
       expect(result.data[0].refId).toEqual('metrics1');
       expect(result.data[1].refId).toEqual('metrics2');
-    });
-
-    it('can handle a trace list and a trace details query', async () => {
-      datasourceRequestMock.mockImplementation((options) => {
-        if (options.data.includes('traceList')) {
-          return Promise.resolve(emptyTraceListResponse);
-        } else {
-          return Promise.resolve(emptyTraceDetailsResponse);
-        }
-      });
-      const resultTraceList = await firstValueFrom(
-        ctx.ds.query({
-          ...createOpenSearchQuery([traceListTarget('traceList'), traceTarget]),
-        })
-      );
-
-      expect(resultTraceList.data[0].refId).toEqual('traceList');
-
-      const resultTrace = await lastValueFrom(
-        ctx.ds.query({
-          ...createOpenSearchQuery([traceListTarget('traceList'), traceTarget]),
-        })
-      );
-
-      expect(resultTrace.data[0].refId).toEqual('trace');
     });
     it('can handle a metrics and a trace list query', async () => {
       datasourceRequestMock.mockImplementation((options) => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -544,9 +544,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
           (request.app === CoreApp.Explore &&
             target.queryType === QueryType.PPL &&
             (target.format === 'logs' || target.format === 'table')) ||
-          (request.app === CoreApp.Explore &&
-            target.luceneQueryType === LuceneQueryType.Traces &&
-            getTraceIdFromLuceneQueryString(target.query ?? ''))
+          target.luceneQueryType === LuceneQueryType.Traces
       )
     ) {
       // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface OpenSearchQuery extends DataQuery {
   queryType?: QueryType;
   format?: PPLFormatType;
   luceneQueryType?: LuceneQueryType;
-  nodeGraph?: boolean;
+  serviceMap?: boolean;
 }
 
 export type DataLinkConfig = {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
I think it makes sense for us to redirect all trace queries to the backend before we release the Service Map feature. It's a BE feature and if we don't redirect all trace queries to the BE, we won't have feature parity in Dashboards vs. Explore

I also renamed node graph to Service Map, since it looks like 'service map' is used elswhere (X-ray, Elastic, Tempo) for the feature, and Node Graph is used for the Grafana visualization. 

**Special notes for your reviewer**:
