### PR TITLE
Rename ES Client to Client, cleanup 

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -231,12 +231,11 @@ type multiRequest struct {
 }
 
 func (c *baseClientImpl) executeBatchRequest(ctx context.Context, uriPath, uriQuery string, requests []*multiRequest) (*response, error) {
-	req, err := c.encodeBatchRequests(requests)
-	backend.Logger.Debug(string(req))
+	bytes, err := c.encodeBatchRequests(requests)
 	if err != nil {
 		return nil, err
 	}
-	return c.executeRequest(ctx, http.MethodPost, uriPath, uriQuery, req)
+	return c.executeRequest(ctx, http.MethodPost, uriPath, uriQuery, bytes)
 }
 
 func (c *baseClientImpl) encodeBatchRequests(requests []*multiRequest) ([]byte, error) {
@@ -261,10 +260,6 @@ func (c *baseClientImpl) encodeBatchRequests(requests []*multiRequest) ([]byte, 
 		body = strings.ReplaceAll(body, "$__interval", r.interval.Text)
 
 		payload.WriteString(body + "\n")
-
-		// this one works
-		// payload.WriteString("{\"aggs\":{\"service_name\":{\"terms\":{\"field\":\"serviceName\",\"size\":500,\"order\": {}},\"aggs\":{\"destination_resource\":{\"terms\":{\"field\":\"destination.resource\",\"size\":1000,\"order\": {}},\"aggs\":{\"destination_domain\":{\"terms\":{\"field\":\"destination.domain\",\"size\":1000,\"order\": {}}}}},\"target_resource\":{\"terms\":{\"field\":\"target.resource\",\"size\":1000,\"order\": {}},\"aggs\":{\"target_domain\":{\"terms\":{\"field\":\"target.domain\",\"size\":1000,\"order\": {}}}}}}}}}"+ "\n")
-
 	}
 
 	elapsed := time.Since(start)

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -90,7 +90,7 @@ type Client interface {
 	GetVersion() *semver.Version
 	GetFlavor() Flavor
 	GetConfiguredFields() ConfiguredFields
-	GetMinInterval(queryInterval string) (time.Duration, error)
+	GetMinInterval(queryInterval time.Duration) (time.Duration, error)
 	GetIndex() string
 	ExecuteMultisearch(ctx context.Context, r *MultiSearchRequest) (*MultiSearchResponse, error)
 	MultiSearch() *MultiSearchRequestBuilder
@@ -213,9 +213,10 @@ func (c *baseClientImpl) GetIndex() string {
 	return c.index
 }
 
-func (c *baseClientImpl) GetMinInterval(queryInterval string) (time.Duration, error) {
+func (c *baseClientImpl) GetMinInterval(queryInterval time.Duration) (time.Duration, error) {
+	interval := strconv.FormatInt(queryInterval.Milliseconds(), 10) + "ms"
 	intervalJSON := simplejson.New()
-	intervalJSON.Set("interval", queryInterval)
+	intervalJSON.Set("interval", interval)
 	return tsdb.GetIntervalFrom(c.ds, intervalJSON, 5*time.Second)
 }
 

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -30,7 +30,7 @@ var (
 
 func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstanceSettings) (*http.Client, error) {
 	var settings struct {
-		IsServerless     bool `json:"serverless"`
+		IsServerless  bool `json:"serverless"`
 		OauthPassThru bool `json:"oauthPassThru"`
 	}
 	err := json.Unmarshal(ds.JSONData, &settings)
@@ -231,11 +231,12 @@ type multiRequest struct {
 }
 
 func (c *baseClientImpl) executeBatchRequest(ctx context.Context, uriPath, uriQuery string, requests []*multiRequest) (*response, error) {
-	bytes, err := c.encodeBatchRequests(requests)
+	req, err := c.encodeBatchRequests(requests)
+	backend.Logger.Debug(string(req))
 	if err != nil {
 		return nil, err
 	}
-	return c.executeRequest(ctx, http.MethodPost, uriPath, uriQuery, bytes)
+	return c.executeRequest(ctx, http.MethodPost, uriPath, uriQuery, req)
 }
 
 func (c *baseClientImpl) encodeBatchRequests(requests []*multiRequest) ([]byte, error) {
@@ -260,6 +261,10 @@ func (c *baseClientImpl) encodeBatchRequests(requests []*multiRequest) ([]byte, 
 		body = strings.ReplaceAll(body, "$__interval", r.interval.Text)
 
 		payload.WriteString(body + "\n")
+
+		// this one works
+		// payload.WriteString("{\"aggs\":{\"service_name\":{\"terms\":{\"field\":\"serviceName\",\"size\":500,\"order\": {}},\"aggs\":{\"destination_resource\":{\"terms\":{\"field\":\"destination.resource\",\"size\":1000,\"order\": {}},\"aggs\":{\"destination_domain\":{\"terms\":{\"field\":\"destination.domain\",\"size\":1000,\"order\": {}}}}},\"target_resource\":{\"terms\":{\"field\":\"target.resource\",\"size\":1000,\"order\": {}},\"aggs\":{\"target_domain\":{\"terms\":{\"field\":\"target.domain\",\"size\":1000,\"order\": {}}}}}}}}}"+ "\n")
+
 	}
 
 	elapsed := time.Since(start)

--- a/pkg/opensearch/client/index_pattern.go
+++ b/pkg/opensearch/client/index_pattern.go
@@ -94,7 +94,7 @@ func (ip *dynamicIndexPattern) GetIndices(timeRange *backend.TimeRange) ([]strin
 
 // PPL currently does not support multi-indexing through lists, so a wildcard
 // pattern is used to match all patterns and relies on the time range filter
-// to filter out the incorrect indecies.
+// to filter out the incorrect indices.
 func (ip *dynamicIndexPattern) GetPPLIndex() (string, error) {
 	index := ""
 

--- a/pkg/opensearch/models.go
+++ b/pkg/opensearch/models.go
@@ -2,6 +2,7 @@ package opensearch
 
 import (
 	"context"
+	"time"
 
 	"github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -15,7 +16,7 @@ type Query struct {
 	BucketAggs      []*BucketAgg `json:"bucketAggs"`
 	Metrics         []*MetricAgg `json:"metrics"`
 	Alias           string       `json:"alias"`
-	Interval        string
+	Interval        time.Duration
 	RefID           string
 	Format          string
 }

--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -4,21 +4,21 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	os "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	client "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 )
 
 type pplHandler struct {
-	client     os.Client
+	client     client.Client
 	reqQueries []backend.DataQuery
-	builders   map[string]*os.PPLRequestBuilder
+	builders   map[string]*client.PPLRequestBuilder
 	queries    map[string]*Query
 }
 
-func newPPLHandler(client os.Client, queries []backend.DataQuery) *pplHandler {
+func newPPLHandler(openSearchClient client.Client, queries []backend.DataQuery) *pplHandler {
 	return &pplHandler{
-		client:     client,
+		client:     openSearchClient,
 		reqQueries: queries,
-		builders:   make(map[string]*os.PPLRequestBuilder),
+		builders:   make(map[string]*client.PPLRequestBuilder),
 		queries:    make(map[string]*Query),
 	}
 }

--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -4,21 +4,21 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	os "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 )
 
 type pplHandler struct {
-	client     es.Client
+	client     os.Client
 	reqQueries []backend.DataQuery
-	builders   map[string]*es.PPLRequestBuilder
+	builders   map[string]*os.PPLRequestBuilder
 	queries    map[string]*Query
 }
 
-func newPPLHandler(client es.Client, queries []backend.DataQuery) *pplHandler {
+func newPPLHandler(client os.Client, queries []backend.DataQuery) *pplHandler {
 	return &pplHandler{
 		client:     client,
 		reqQueries: queries,
-		builders:   make(map[string]*es.PPLRequestBuilder),
+		builders:   make(map[string]*os.PPLRequestBuilder),
 		queries:    make(map[string]*Query),
 	}
 }

--- a/pkg/opensearch/ppl_response_parser.go
+++ b/pkg/opensearch/ppl_response_parser.go
@@ -9,15 +9,15 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/opensearch-datasource/pkg/null"
-	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 	"github.com/grafana/opensearch-datasource/pkg/utils"
 )
 
 type pplResponseParser struct {
-	Response *es.PPLResponse
+	Response *client.PPLResponse
 }
 
-func newPPLResponseParser(response *es.PPLResponse, query *Query) *pplResponseParser {
+func newPPLResponseParser(response *client.PPLResponse, query *Query) *pplResponseParser {
 	return &pplResponseParser{
 		Response: response,
 	}
@@ -30,7 +30,7 @@ type responseMeta struct {
 	timeFieldFormat string
 }
 
-func (rp *pplResponseParser) parseResponse(configuredFields es.ConfiguredFields, format string) (*backend.DataResponse, error) {
+func (rp *pplResponseParser) parseResponse(configuredFields client.ConfiguredFields, format string) (*backend.DataResponse, error) {
 	var debugInfo *simplejson.Json
 	if rp.Response.DebugInfo != nil {
 		debugInfo = utils.NewJsonFromAny(rp.Response.DebugInfo)
@@ -64,15 +64,15 @@ func (rp *pplResponseParser) parseResponse(configuredFields es.ConfiguredFields,
 }
 
 func (rp *pplResponseParser) parseTables(queryRes *backend.DataResponse) (*backend.DataResponse, error) {
-	return rp.parsePPLResponse(queryRes, es.ConfiguredFields{}, false)
+	return rp.parsePPLResponse(queryRes, client.ConfiguredFields{}, false)
 }
 
-func (rp *pplResponseParser) parseLogs(queryRes *backend.DataResponse, configuredFields es.ConfiguredFields) (*backend.DataResponse, error) {
+func (rp *pplResponseParser) parseLogs(queryRes *backend.DataResponse, configuredFields client.ConfiguredFields) (*backend.DataResponse, error) {
 	return rp.parsePPLResponse(queryRes, configuredFields, true)
 }
 
 // parsePPLResponse parses responses for the logs and table format
-func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, configuredFields es.ConfiguredFields, isLogsQuery bool) (*backend.DataResponse, error) {
+func (rp *pplResponseParser) parsePPLResponse(queryRes *backend.DataResponse, configuredFields client.ConfiguredFields, isLogsQuery bool) (*backend.DataResponse, error) {
 	propNames := make(map[string]bool)
 	docs := make([]map[string]interface{}, len(rp.Response.Datarows))
 
@@ -159,7 +159,7 @@ func (rp *pplResponseParser) parseTimeSeries(queryRes *backend.DataResponse) (*b
 	return queryRes, nil
 }
 
-func (rp *pplResponseParser) addDatarow(frame *data.Frame, i int, datarow es.Datarow, t responseMeta) error {
+func (rp *pplResponseParser) addDatarow(frame *data.Frame, i int, datarow client.Datarow, t responseMeta) error {
 	value, err := rp.parseValue(datarow[t.valueIndex])
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func (rp *pplResponseParser) getSeriesName(valueIndex int) string {
 	return schema[valueIndex].Name
 }
 
-func getTimeSeriesResponseMeta(schema []es.FieldSchema) (responseMeta, error) {
+func getTimeSeriesResponseMeta(schema []client.FieldSchema) (responseMeta, error) {
 	if len(schema) != 2 {
 		return responseMeta{}, fmt.Errorf("response should have 2 fields but found %v", len(schema))
 	}
@@ -227,7 +227,7 @@ func getTimeSeriesResponseMeta(schema []es.FieldSchema) (responseMeta, error) {
 	return responseMeta{valueIndex: 1 - timeIndex, timeFieldIndex: timeIndex, timeFieldFormat: format}, nil
 }
 
-func getErrorFromPPLResponse(response *es.PPLResponse) error {
+func getErrorFromPPLResponse(response *client.PPLResponse) error {
 	var err error
 	json := utils.NewJsonFromAny(response.Error)
 	reason := json.Get("reason").MustString()

--- a/pkg/opensearch/ppl_response_parser_test.go
+++ b/pkg/opensearch/ppl_response_parser_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,7 +35,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat), formatUnixMs(200, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -73,7 +73,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat), formatUnixMs(200, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -111,7 +111,7 @@ func TestPPLResponseParser(t *testing.T) {
 			response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 			rp, err := newPPLResponseParserForTest(targets, response)
 			assert.NoError(t, err)
-			queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+			queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 			assert.NoError(t, err)
 			assert.NotNil(t, queryRes)
 			assert.Len(t, queryRes.Frames, 1)
@@ -141,7 +141,7 @@ func TestPPLResponseParser(t *testing.T) {
 				formattedResponse := fmt.Sprintf(response, "timestamp", formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -158,7 +158,7 @@ func TestPPLResponseParser(t *testing.T) {
 				formattedResponse := fmt.Sprintf(response, "datetime", formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -175,7 +175,7 @@ func TestPPLResponseParser(t *testing.T) {
 				formattedResponse := fmt.Sprintf(response, "date", formatUnixMs(0, pplDateFormat))
 				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -211,7 +211,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 
@@ -234,7 +234,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 
@@ -258,7 +258,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 
@@ -282,7 +282,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 
@@ -305,7 +305,7 @@ func TestPPLResponseParser(t *testing.T) {
 						}`
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 
@@ -328,7 +328,7 @@ func TestPPLResponseParser(t *testing.T) {
 						}`
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				_, err = rp.parseResponse(es.ConfiguredFields{}, "")
+				_, err = rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.Error(t, err)
 			})
 		})
@@ -348,7 +348,7 @@ func TestPPLResponseParser(t *testing.T) {
 					}`
 			rp, err := newPPLResponseParserForTest(targets, response)
 			assert.NoError(t, err)
-			queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+			queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 			assert.NotNil(t, queryRes)
 			assert.Equal(t, "Error occurred in Elasticsearch engine: no such index [unknown]", queryRes.Error.Error())
 			assert.Len(t, queryRes.Frames, 1)
@@ -376,7 +376,7 @@ func TestPPLResponseParser(t *testing.T) {
 				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -398,7 +398,7 @@ func TestPPLResponseParser(t *testing.T) {
 						}`
 				rp, err := newPPLResponseParserForTest(targets, response)
 				assert.NoError(t, err)
-				queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+				queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 				assert.NoError(t, err)
 				assert.NotNil(t, queryRes)
 				assert.Len(t, queryRes.Frames, 1)
@@ -424,7 +424,7 @@ func Test_parseResponse_should_return_error_from_ppl_response(t *testing.T) {
 			}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{}, "")
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{}, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, queryRes)
 	assert.Equal(t, 1, len(queryRes.Frames))
@@ -451,7 +451,7 @@ func Test_parseResponse_logs_format_query_should_return_data_frame_with_timefiel
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField: "@timestamp",
 	}, logsType)
 	assert.NoError(t, err)
@@ -483,7 +483,7 @@ func Test_parseResponse_logs_format_query_should_return_log_message_field_as_the
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField:       "@timestamp",
 		LogMessageField: "realMessageField",
 	}, logsType)
@@ -518,7 +518,7 @@ func Test_parseResponse_logs_format_query_should_flatten_nested_fields(t *testin
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField: "@timestamp",
 	}, logsType)
 	assert.NoError(t, err)
@@ -552,7 +552,7 @@ func Test_parseResponse_logs_format_query_should_add_level_field_if_log_level_is
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField:     "@timestamp",
 		LogLevelField: "loglevel",
 	}, logsType)
@@ -586,7 +586,7 @@ func Test_parseResponse_logs_format_query_should_handle_different_date_and_time_
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField: "@timestamp",
 	}, logsType)
 	assert.NoError(t, err)
@@ -628,7 +628,7 @@ func Test_parseResponse_logs_format_query_should_set_preferred_visualization_to_
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{}, logsType)
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{}, logsType)
 	assert.NoError(t, err)
 	assert.Equal(t, data.VisTypeLogs, string(queryRes.Frames[0].Meta.PreferredVisualization))
 }
@@ -655,7 +655,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 	}`
 		rp, err := newPPLResponseParserForTest(targets, response)
 		assert.NoError(t, err)
-		queryRes, err := rp.parseResponse(es.ConfiguredFields{
+		queryRes, err := rp.parseResponse(client.ConfiguredFields{
 			TimeField: "@timestamp",
 		}, tableType)
 		assert.NoError(t, err)
@@ -698,7 +698,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 		}`
 		rp, err := newPPLResponseParserForTest(targets, response)
 		assert.NoError(t, err)
-		queryRes, err := rp.parseResponse(es.ConfiguredFields{
+		queryRes, err := rp.parseResponse(client.ConfiguredFields{
 			TimeField: "@timestamp",
 		}, tableType)
 		assert.NoError(t, err)
@@ -732,7 +732,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 		}`
 		rp, err := newPPLResponseParserForTest(targets, response)
 		assert.NoError(t, err)
-		queryRes, err := rp.parseResponse(es.ConfiguredFields{}, tableType)
+		queryRes, err := rp.parseResponse(client.ConfiguredFields{}, tableType)
 		assert.NoError(t, err)
 		assert.Equal(t, data.VisTypeTable, string(queryRes.Frames[0].Meta.PreferredVisualization))
 	})
@@ -756,7 +756,7 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 	}`
 	rp, err := newPPLResponseParserForTest(targets, response)
 	assert.NoError(t, err)
-	queryRes, err := rp.parseResponse(es.ConfiguredFields{
+	queryRes, err := rp.parseResponse(client.ConfiguredFields{
 		TimeField:       "timestamp",
 		LogLevelField:   "loglevel",
 		LogMessageField: "message",
@@ -775,14 +775,14 @@ func TestParseResponseWithTableFormatQuery(t *testing.T) {
 }
 
 func newPPLResponseParserForTest(tsdbQueries map[string]string, responseBody string) (*pplResponseParser, error) {
-	var response es.PPLResponse
+	var response client.PPLResponse
 	err := json.Unmarshal([]byte(responseBody), &response)
 	if err != nil {
 		return nil, err
 	}
 
-	response.DebugInfo = &es.PPLDebugInfo{
-		Response: &es.PPLResponseInfo{
+	response.DebugInfo = &client.PPLDebugInfo{
+		Response: &client.PPLResponseInfo{
 			Status: 200,
 		},
 	}

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -3,23 +3,22 @@ package opensearch
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/grafana/opensearch-datasource/pkg/utils"
 )
 
 type queryRequest struct {
-	client             es.Client
+	client             client.Client
 	queries            []backend.DataQuery
 	dsSettings         *backend.DataSourceInstanceSettings
 	intervalCalculator tsdb.IntervalCalculator
 }
 
-func newQueryRequest(client es.Client, queries []backend.DataQuery, dsSettings *backend.DataSourceInstanceSettings, intervalCalculator tsdb.IntervalCalculator) *queryRequest {
+func newQueryRequest(client client.Client, queries []backend.DataQuery, dsSettings *backend.DataSourceInstanceSettings, intervalCalculator tsdb.IntervalCalculator) *queryRequest {
 	return &queryRequest{
 		client:             client,
 		queries:            queries,
@@ -90,7 +89,6 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 			return nil, err
 		}
 		alias := model.Get("alias").MustString("")
-		interval := strconv.FormatInt(q.Interval.Milliseconds(), 10) + "ms"
 		format := model.Get("format").MustString("")
 
 		queries = append(queries, &Query{
@@ -100,7 +98,7 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 			BucketAggs:      bucketAggs,
 			Metrics:         metrics,
 			Alias:           alias,
-			Interval:        interval,
+			Interval:        q.Interval,
 			RefID:           q.RefID,
 			Format:          format,
 		})

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -13,7 +13,7 @@ import (
 	simplejson "github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	es "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 	utils "github.com/grafana/opensearch-datasource/pkg/utils"
 )
 
@@ -42,14 +42,14 @@ const (
 )
 
 type responseParser struct {
-	Responses        []*es.SearchResponse
+	Responses        []*client.SearchResponse
 	Targets          []*Query
-	DebugInfo        *es.SearchDebugInfo
-	ConfiguredFields es.ConfiguredFields
+	DebugInfo        *client.SearchDebugInfo
+	ConfiguredFields client.ConfiguredFields
 	DSSettings       *backend.DataSourceInstanceSettings
 }
 
-func newResponseParser(responses []*es.SearchResponse, targets []*Query, debugInfo *es.SearchDebugInfo, configuredFields es.ConfiguredFields, dsSettings *backend.DataSourceInstanceSettings) *responseParser {
+func newResponseParser(responses []*client.SearchResponse, targets []*Query, debugInfo *client.SearchDebugInfo, configuredFields client.ConfiguredFields, dsSettings *backend.DataSourceInstanceSettings) *responseParser {
 	return &responseParser{
 		Responses:        responses,
 		Targets:          targets,
@@ -132,7 +132,7 @@ func (rp *responseParser) parseResponse() (*backend.QueryDataResponse, error) {
 	return result, nil
 }
 
-func processTraceSpansResponse(res *es.SearchResponse, queryRes backend.DataResponse) backend.DataResponse {
+func processTraceSpansResponse(res *client.SearchResponse, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
 	docs := make([]map[string]interface{}, len(res.Hits.Hits))
 
@@ -271,9 +271,9 @@ func processTraceSpansResponse(res *es.SearchResponse, queryRes backend.DataResp
 	return queryRes
 }
 
-func processTraceListResponse(res *es.SearchResponse, dsUID string, dsName string, queryRes backend.DataResponse) backend.DataResponse {
+func processTraceListResponse(res *client.SearchResponse, dsUID string, dsName string, queryRes backend.DataResponse) backend.DataResponse {
 	// trace list queries are hardcoded with a fairly hardcoded response format
-	// but es.SearchResponse is deliberately not typed as in other query cases it can be much more open ended
+	// but client.SearchResponse is deliberately not typed as in other query cases it can be much more open ended
 	rawTraces := res.Aggregations["traces"].(map[string]interface{})["buckets"].([]interface{})
 
 	// get values from raw traces response
@@ -321,7 +321,7 @@ func processTraceListResponse(res *es.SearchResponse, dsUID string, dsName strin
 	return queryRes
 }
 
-func processLogsResponse(res *es.SearchResponse, configuredFields es.ConfiguredFields, queryRes backend.DataResponse) backend.DataResponse {
+func processLogsResponse(res *client.SearchResponse, configuredFields client.ConfiguredFields, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
 	docs := make([]map[string]interface{}, len(res.Hits.Hits))
 
@@ -379,7 +379,7 @@ func processLogsResponse(res *es.SearchResponse, configuredFields es.ConfiguredF
 	return queryRes
 }
 
-func processRawDataResponse(res *es.SearchResponse, configuredFields es.ConfiguredFields, queryRes backend.DataResponse) backend.DataResponse {
+func processRawDataResponse(res *client.SearchResponse, configuredFields client.ConfiguredFields, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
 	documents := make([]map[string]interface{}, len(res.Hits.Hits))
 	for hitIdx, hit := range res.Hits.Hits {
@@ -434,7 +434,7 @@ func sortPropNames(propNames map[string]bool, fieldsToGoInFront []string) []stri
 	return append(fieldsInFront, sortedPropNames...)
 }
 
-func processRawDocumentResponse(res *es.SearchResponse, refID string, queryRes backend.DataResponse) backend.DataResponse {
+func processRawDocumentResponse(res *client.SearchResponse, refID string, queryRes backend.DataResponse) backend.DataResponse {
 	documents := make([]map[string]interface{}, len(res.Hits.Hits))
 	for hitIdx, hit := range res.Hits.Hits {
 		doc := map[string]interface{}{
@@ -1203,7 +1203,7 @@ func findAgg(target *Query, aggID string) (*BucketAgg, error) {
 	return nil, errors.New("can't found aggDef, aggID:" + aggID)
 }
 
-func getErrorFromOpenSearchResponse(response *es.SearchResponse) error {
+func getErrorFromOpenSearchResponse(response *client.SearchResponse) error {
 	var err error
 	json := utils.NewJsonFromAny(response.Error)
 	reason := json.Get("reason").MustString()


### PR DESCRIPTION
Just a small cleanup to eventually make the SG pull request smaller. Looks like a lot but it's mostly renaming 

- uses `client` or `os` instead of `es`, presumably `es` was a remnant of the elastic repo
- typos
- change type of Interval field to time.Duration and convert it only in getMinInterval