### PR TITLE
Service Map: Add aggregations and query filters to use in service map queries

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -107,6 +107,7 @@
     "Menges",
     "sympatheticmoose",
     "loru",
-    "nosql"
+    "nosql",
+    "Equalf"
   ]
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -264,11 +264,8 @@ type AggContainer struct {
 
 // MarshalJSON returns the JSON encoding of the aggregation container
 func (a *AggContainer) MarshalJSON() ([]byte, error) {
-	root := make(map[string]interface{})
-	if m, ok := a.Aggregation.(json.Marshaler); ok {
-		root[a.Type] = m
-	} else {
-		root[a.Type] = a.Aggregation
+	root := map[string]interface{}{
+		a.Type: a.Aggregation,
 	}
 
 	if len(a.Aggs) > 0 {

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -100,10 +100,10 @@ type Query struct {
 
 // BoolQuery represents a bool query
 type BoolQuery struct {
-	Filters     []Filter
-	MustFilters []Filter
-	MustNotFilters []Filter `json:"must_not,omitempty"`
-	ShouldFilters  []Filter `json:"should,omitempty"`
+	Filters        []Filter
+	MustFilters    []Filter
+	MustNotFilters []Filter
+	ShouldFilters  []Filter
 }
 
 // MarshalJSON returns the JSON encoding of the boolean query.
@@ -336,12 +336,11 @@ type BucketScriptAggregation struct {
 	Script string            `json:"script"`
 }
 
-
 // TermsAggregation represents a terms aggregation
 type TermsAggregation struct {
 	Field       string                 `json:"field"`
 	Size        int                    `json:"size"`
-	Order       map[string]interface{} `json:"order,omitempty"`
+	Order       map[string]interface{} `json:"order"`
 	MinDocCount *int                   `json:"min_doc_count,omitempty"`
 	Missing     *string                `json:"missing,omitempty"`
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -325,7 +325,6 @@ func (f FilterAggregation) MarshalJSON() ([]byte, error) {
 			f.Key: f.Value,
 		},
 	}
-
 	return json.Marshal(root)
 }
 
@@ -372,7 +371,6 @@ func (a *MetricAggregation) MarshalJSON() ([]byte, error) {
 			root[k] = v
 		}
 	}
-
 	return json.Marshal(root)
 }
 
@@ -393,7 +391,6 @@ func (a *PipelineAggregation) MarshalJSON() ([]byte, error) {
 			root[k] = v
 		}
 	}
-
 	return json.Marshal(root)
 }
 
@@ -428,7 +425,6 @@ func (req *PPLRequest) MarshalJSON() ([]byte, error) {
 	root := map[string]interface{}{
 		"query": req.Query,
 	}
-
 	return json.Marshal(root)
 }
 

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -186,12 +186,13 @@ func (t TermsFilter) MarshalJSON() ([]byte, error) {
 				t.Key: {"value": t.Values[0]},
 			},
 		})
+	} else {
+		return json.Marshal(map[string]map[string][]string{
+			"terms": {
+				t.Key: t.Values,
+			},
+		})
 	}
-	return json.Marshal(map[string]map[string][]string{
-		"terms": {
-			t.Key: t.Values,
-		},
-	})
 }
 
 // RangeFilter represents a range search filter

--- a/pkg/opensearch/client/models_test.go
+++ b/pkg/opensearch/client/models_test.go
@@ -25,7 +25,6 @@ func TestTermsFilter_MarshalJSON(t *testing.T) {
 			values: []string{"goodbye", "hello"},
 			want:   `{"terms":{"hello":["goodbye","hello"]}}`,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/opensearch/client/models_test.go
+++ b/pkg/opensearch/client/models_test.go
@@ -17,7 +17,7 @@ func TestTermsFilter_MarshalJSON(t *testing.T) {
 			name:   "single key -> term, no list",
 			key:    "hello",
 			values: []string{"goodbye"},
-			want:   `{"term":{"hello":"goodbye"}}`,
+			want:   `{"term":{"hello":{"value":"goodbye"}}}`,
 		},
 		{
 			name:   "multiple values -> terms, with list",
@@ -60,24 +60,24 @@ func TestBoolQuery_MarshalJSON(t *testing.T) {
 			want: `{"bool":{"must_not":{"terms":{"service":["a","b"]}}}}`,
 		},
 		{
-			name: "should filters with multiple terms inside bool query", 
+			name: "should filters with multiple terms inside bool query",
 			should: []Filter{
 				TermsFilter{
-					Key: "service",
+					Key:    "service",
 					Values: []string{"a", "b"},
 				},
 				TermsFilter{
-					Key: "name",
+					Key:    "name",
 					Values: []string{"bob"},
 				},
 			},
 			want: `{"bool":{"should":[{"terms":{"service":["a","b"]}},{"term":{"name":{"value":"bob"}}}]}}`,
 		},
 		{
-			name: "one should filter inside bool query", 
+			name: "one should filter inside bool query",
 			should: []Filter{
 				TermsFilter{
-					Key: "service",
+					Key:    "service",
 					Values: []string{"a", "b"},
 				},
 			},

--- a/pkg/opensearch/client/models_test.go
+++ b/pkg/opensearch/client/models_test.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTermsFilter_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		values []string
+		want   string
+	}{
+		{
+			name:   "single key -> term, no list",
+			key:    "hello",
+			values: []string{"goodbye"},
+			want:   `{"term":{"hello":"goodbye"}}`,
+		},
+		{
+			name:   "multiple values -> terms, with list",
+			key:    "hello",
+			values: []string{"goodbye", "hello"},
+			want:   `{"terms":{"hello":["goodbye","hello"]}}`,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := &TermsFilter{
+				Key:    tt.key,
+				Values: tt.values,
+			}
+			got, err := tf.MarshalJSON()
+			assert.Nil(t, err)
+			assert.Equalf(t, tt.want, string(got), "MarshalJSON()")
+		})
+	}
+}
+
+func TestBoolQuery_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []Filter
+		must    []Filter
+		mustNot []Filter
+		should  []Filter
+		want    string
+	}{
+		{
+			name: "terms filter inside",
+			mustNot: []Filter{
+				TermsFilter{
+					Key:    "service",
+					Values: []string{"a", "b"},
+				},
+			},
+			want: `{"bool":{"must_not":{"terms":{"service":["a","b"]}}}}`,
+		},
+		{
+			name: "should filters with multiple terms inside bool query", 
+			should: []Filter{
+				TermsFilter{
+					Key: "service",
+					Values: []string{"a", "b"},
+				},
+				TermsFilter{
+					Key: "name",
+					Values: []string{"bob"},
+				},
+			},
+			want: `{"bool":{"should":[{"terms":{"service":["a","b"]}},{"term":{"name":{"value":"bob"}}}]}}`,
+		},
+		{
+			name: "one should filter inside bool query", 
+			should: []Filter{
+				TermsFilter{
+					Key: "service",
+					Values: []string{"a", "b"},
+				},
+			},
+			want: `{"bool":{"should":{"terms":{"service":["a","b"]}}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := Query{
+				&BoolQuery{
+					Filters:        tt.filters,
+					MustFilters:    tt.must,
+					MustNotFilters: tt.mustNot,
+					ShouldFilters:  tt.should,
+				},
+			}
+			got, err := json.Marshal(q)
+			assert.Nil(t, err)
+			assert.Equalf(t, tt.want, string(got), "MarshalJSON()")
+		})
+	}
+}

--- a/pkg/opensearch/client/models_test.go
+++ b/pkg/opensearch/client/models_test.go
@@ -2,8 +2,9 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTermsFilter_MarshalJSON(t *testing.T) {
@@ -48,6 +49,26 @@ func TestBoolQuery_MarshalJSON(t *testing.T) {
 		should  []Filter
 		want    string
 	}{
+		{
+			name: "filter inside",
+			filters: []Filter{
+				TermsFilter{
+					Key:    "filterKey",
+					Values: []string{"a", "b"},
+				},
+			},
+			want: `{"bool":{"filter":{"terms":{"filterKey":["a","b"]}}}}`,
+		},
+		{
+			name: "must filter inside",
+			must: []Filter{
+				TermsFilter{
+					Key:    "mustTermKey",
+					Values: []string{"a", "b"},
+				},
+			},
+			want: `{"bool":{"must":{"terms":{"mustTermKey":["a","b"]}}}}`,
+		},
 		{
 			name: "terms filter inside",
 			mustNot: []Filter{

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -228,7 +228,6 @@ func (b *QueryBuilder) Bool() *BoolQueryBuilder {
 type BoolQueryBuilder struct {
 	filterQueryBuilder *FilterQueryBuilder
 	mustFilterList     *FilterList
-	shouldFilterList   *FilterList
 }
 
 // NewBoolQueryBuilder create a new bool query builder

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -422,6 +422,7 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
+		Order: make(map[string]interface{}),
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",
@@ -435,7 +436,6 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 	}
 
 	if (b.version.Major() >= 6 || b.flavor == OpenSearch) && len(innerAgg.Order) > 0 {
-		innerAgg.Order = make(map[string]interface{})
 		if orderBy, exists := innerAgg.Order[termsOrderTerm]; exists {
 			innerAgg.Order["_key"] = orderBy
 			delete(innerAgg.Order, termsOrderTerm)

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -68,13 +68,14 @@ func TestSearchRequest(t *testing.T) {
 			t.Run("Should have correct size", func(t *testing.T) {
 				assert.Equal(t, 200, sr.Size)
 			})
+
 			t.Run("Should have must not filter inside a should filter", func(t *testing.T) {
 				boolQuery, ok := sr.Query.Bool.Filters[0].(Query)
 				assert.True(t, ok)
-				mustNotFilters := boolQuery.Bool.ShouldFilters[0].(Query).Bool.Filters[0].(Query).Bool.MustNotFilters[0].(TermsFilter)
-				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
-				assert.Equal(t, []string{""}, mustNotFilters.Values)
+				mustNotFilters := boolQuery.Bool.ShouldFilters[0].(Query).Bool.Filters[0].(Query).Bool.MustNotFilters
+				assert.Len(t, mustNotFilters, 1)
 			})
+
 			t.Run("Should have a terms filter inside a must not filter", func(t *testing.T) {
 				boolQuery, ok := sr.Query.Bool.Filters[0].(Query)
 				assert.True(t, ok)
@@ -82,6 +83,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
 				assert.Equal(t, []string{""}, mustNotFilters.Values)
 			})
+
 			t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
 				body, err := json.Marshal(sr)
 				assert.NoError(t, err)
@@ -89,12 +91,13 @@ func TestSearchRequest(t *testing.T) {
 				assert.NoError(t, err)
 
 				parentSpanId, err := json.GetPath("query", "bool", "filter", "bool", "should", "bool", "filter", "bool", "must_not", "term", "parentSpanId", "value").String()
+				
 				assert.NoError(t, err)
-
 				assert.Equal(t, "", parentSpanId)
 
 			})
 		})
+
 		t.Run("When adding size, sort, filters, When building search request", func(t *testing.T) {
 			b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 			b.Size(200)
@@ -275,10 +278,9 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@hostname", json.GetPath("aggs", "1", "terms", "field").MustString())
 			assert.Equal(t, "@timestamp", json.GetPath("aggs", "2", "date_histogram", "field").MustString())
 
-			// test for nested terms aggregations
-
 		})
 	})
+
 	t.Run("and adding top level agg with child agg, When building search request, Should have 1 top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
@@ -315,6 +317,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
+
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
@@ -360,8 +363,8 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			termFilterForError := errorCountChildAgg.GetPath("filter", "term")
 			assert.Equal(t, "2", termFilterForError.GetPath("status.code").MustString())
 		})
-
 	})
+
 	t.Run("and adding two top level aggs with child agg, When building search request, Should have 2 top level aggs with one child agg each", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -92,7 +92,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.Equal(t, "", parentSpanId)
-				
+
 			})
 		})
 		t.Run("When adding size, sort, filters, When building search request", func(t *testing.T) {
@@ -244,7 +244,8 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 
 		// adding nested terms aggregations
 		aggBuilder.Terms("aggregation_name", "field_name", func(a *TermsAggregation, b AggBuilder) {
-			b.Terms("inner_aggregation_name", "field_name.inner_field", nil) })
+			b.Terms("inner_aggregation_name", "field_name.inner_field", nil)
+		})
 
 		sr, err := b.Build()
 		assert.NoError(t, err)
@@ -359,7 +360,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			termFilterForError := errorCountChildAgg.GetPath("filter", "term")
 			assert.Equal(t, "2", termFilterForError.GetPath("status.code").MustString())
 		})
-		
+
 	})
 	t.Run("and adding two top level aggs with child agg, When building search request, Should have 2 top level aggs with one child agg each", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -41,12 +41,68 @@ func TestSearchRequest(t *testing.T) {
 			})
 		})
 
+		t.Run("When adding nested bool query filters, When building search request", func(t *testing.T) {
+			b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
+			b.Size(200)
+			b.Sort("desc", timeField, "boolean")
+			filters := b.Query().Bool().Filter()
+			filters.AddFilterQuery(Query{
+				&BoolQuery{
+					ShouldFilters: []Filter{
+						Query{
+							&BoolQuery{
+								Filters: []Filter{
+									Query{&BoolQuery{MustNotFilters: []Filter{TermsFilter{
+										Key:    "parentSpanId",
+										Values: []string{""},
+									}}}},
+								},
+							},
+						},
+					},
+				},
+			})
+			sr, err := b.Build()
+			assert.NoError(t, err)
+
+			t.Run("Should have correct size", func(t *testing.T) {
+				assert.Equal(t, 200, sr.Size)
+			})
+			t.Run("Should have must not filter inside a should filter", func(t *testing.T) {
+				boolQuery, ok := sr.Query.Bool.Filters[0].(Query)
+				assert.True(t, ok)
+				mustNotFilters := boolQuery.Bool.ShouldFilters[0].(Query).Bool.Filters[0].(Query).Bool.MustNotFilters[0].(TermsFilter)
+				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
+				assert.Equal(t, []string{""}, mustNotFilters.Values)
+			})
+			t.Run("Should have a terms filter inside a must not filter", func(t *testing.T) {
+				boolQuery, ok := sr.Query.Bool.Filters[0].(Query)
+				assert.True(t, ok)
+				mustNotFilters := boolQuery.Bool.ShouldFilters[0].(Query).Bool.Filters[0].(Query).Bool.MustNotFilters[0].(TermsFilter)
+				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
+				assert.Equal(t, []string{""}, mustNotFilters.Values)
+			})
+			t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
+				body, err := json.Marshal(sr)
+				assert.NoError(t, err)
+				json, err := simplejson.NewJson(body)
+				assert.NoError(t, err)
+
+				parentSpanId, err := json.GetPath("query", "bool", "filter", "bool", "should", "bool", "filter", "bool", "must_not", "term", "parentSpanId", "value").String()
+				assert.NoError(t, err)
+
+				assert.Equal(t, "", parentSpanId)
+				
+			})
+		})
 		t.Run("When adding size, sort, filters, When building search request", func(t *testing.T) {
+			b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 			b.Size(200)
 			b.Sort("desc", timeField, "boolean")
 			filters := b.Query().Bool().Filter()
 			filters.AddDateRangeFilter(timeField, DateFormatEpochMS, 10, 5)
 			filters.AddQueryStringFilter("test", true)
+			filters.AddTermsFilter("service_name", []string{"frontend", "redis"})
 
 			sr, err := b.Build()
 			assert.NoError(t, err)
@@ -69,6 +125,13 @@ func TestSearchRequest(t *testing.T) {
 				assert.Equal(t, int64(5), f.Gte)
 				assert.Equal(t, int64(10), f.Lte)
 				assert.Equal(t, "epoch_millis", f.Format)
+			})
+
+			t.Run("Should have terms filter", func(t *testing.T) {
+				f, ok := sr.Query.Bool.Filters[2].(*TermsFilter)
+				assert.True(t, ok)
+				assert.Equal(t, "service_name", f.Key)
+				assert.Equal(t, []string{"frontend", "redis"}, f.Values)
 			})
 
 			t.Run("Should have query string filter", func(t *testing.T) {
@@ -179,15 +242,27 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 		aggBuilder.Terms("1", "@hostname", nil)
 		aggBuilder.DateHistogram("2", "@timestamp", nil)
 
+		// adding nested terms aggregations
+		aggBuilder.Terms("aggregation_name", "field_name", func(a *TermsAggregation, b AggBuilder) {
+			b.Terms("inner_aggregation_name", "field_name.inner_field", nil) })
+
 		sr, err := b.Build()
 		assert.NoError(t, err)
 
 		aggs := sr.Aggs
-		assert.Len(t, aggs, 2)
+		assert.Len(t, aggs, 3)
 		assert.Equal(t, "1", aggs[0].Key)
 		assert.Equal(t, "terms", aggs[0].Aggregation.Type)
 		assert.Equal(t, "2", aggs[1].Key)
 		assert.Equal(t, "date_histogram", aggs[1].Aggregation.Type)
+
+		// test nested terms aggregation
+		assert.Equal(t, "aggregation_name", aggs[2].Key)
+		assert.Equal(t, "terms", aggs[2].Aggregation.Type)
+		assert.Equal(t, "field_name", aggs[2].Aggregation.Aggregation.(*TermsAggregation).Field)
+		assert.Equal(t, "inner_aggregation_name", aggs[2].Aggregation.Aggs[0].Key)
+		assert.Equal(t, "terms", aggs[2].Aggregation.Aggs[0].Aggregation.Type)
+		assert.Equal(t, "field_name.inner_field", aggs[2].Aggregation.Aggs[0].Aggregation.Aggregation.(*TermsAggregation).Field)
 
 		t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
 			body, err := json.Marshal(sr)
@@ -195,12 +270,14 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			json, err := simplejson.NewJson(body)
 			assert.NoError(t, err)
 
-			assert.Len(t, json.Get("aggs").MustMap(), 2)
+			assert.Len(t, json.Get("aggs").MustMap(), 3)
 			assert.Equal(t, "@hostname", json.GetPath("aggs", "1", "terms", "field").MustString())
 			assert.Equal(t, "@timestamp", json.GetPath("aggs", "2", "date_histogram", "field").MustString())
+
+			// test for nested terms aggregations
+
 		})
 	})
-
 	t.Run("and adding top level agg with child agg, When building search request, Should have 1 top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
@@ -237,7 +314,53 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
+	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
+		version, _ := semver.NewVersion("1.0.0")
+		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
+		aggBuilder := b.Agg()
+		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
+			innerBuilder.AddAggDef(&aggDef{
+				key: "error_count",
+				aggregation: &AggContainer{
+					Type:        "filter",
+					Aggregation: FilterAggregation{Key: "status.code", Value: "2"},
+				},
+			})
+		})
 
+		sr, err := b.Build()
+		assert.NoError(t, err)
+
+		aggs := sr.Aggs
+		assert.Len(t, aggs, 1)
+
+		topAgg := aggs[0]
+		assert.Equal(t, "service_name", topAgg.Key)
+		assert.Equal(t, "fieldServiceName", topAgg.Aggregation.Aggregation.(*TermsAggregation).Field)
+		assert.Equal(t, "terms", topAgg.Aggregation.Type)
+		assert.Len(t, topAgg.Aggregation.Aggs, 1)
+
+		childAgg := aggs[0].Aggregation.Aggs[0]
+		assert.Equal(t, "error_count", childAgg.Key)
+		assert.Equal(t, "filter", childAgg.Aggregation.Type)
+		assert.Equal(t, "status.code", childAgg.Aggregation.Aggregation.(FilterAggregation).Key)
+		assert.Equal(t, "2", childAgg.Aggregation.Aggregation.(FilterAggregation).Value)
+
+		t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
+			body, err := json.Marshal(sr)
+			assert.NoError(t, err)
+			json, err := simplejson.NewJson(body)
+			assert.NoError(t, err)
+
+			termsAgg := json.GetPath("aggs", "service_name")
+			assert.Equal(t, "fieldServiceName", termsAgg.GetPath("terms", "field").MustString())
+
+			errorCountChildAgg := termsAgg.GetPath("aggs", "error_count")
+			termFilterForError := errorCountChildAgg.GetPath("filter", "term")
+			assert.Equal(t, "2", termFilterForError.GetPath("status.code").MustString())
+		})
+		
+	})
 	t.Run("and adding two top level aggs with child agg, When building search request, Should have 2 top level aggs with one child agg each", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})


### PR DESCRIPTION
Service Map feature: Add aggregations and query filters to use in service map queries

We're using some new aggregation types (`openSeachQuery.aggs`) and query filters (`openSearchQuery.query`) in requests for service map data to Open search. 

Query filters are what Open Search will filter the documents by, before applying the aggregations to the filtered set. 

**Query filters:** 
- MustNotFilters
- ShouldFilters (functions as OR for conditions inside it)
- Terms/Term filter (they must get marshaled differently depending on whether they have one or multiple values

**Aggregations:** 
- Script aggregation
- Terms aggregation (different than Terms filter) aggregating by term (field) `serviceName`

**Also:**
- tests
- renamed MustQueryBuilder to FilterList, as this struct wasn't Must-specific

**Note:**

The Bool filters that we need to add in order to get the right stats for the service map are quite nested and look a bit messy. This is because `filter`, `must _not`, `must`... filters always need to be nested under the `bool` filter, so there's a lot of repetition in the nesting. Once we start using them, we will need to have a complex query that looks like this:
 
<img width="903" alt="Screenshot 2024-04-15 at 11 17 24" src="https://github.com/grafana/opensearch-datasource/assets/16140639/c0338d0a-096e-4380-974c-7a76403fdd71">


**What this PR does / why we need it**:
Part of the service map feature

**Special notes for your reviewer**:
Not using them in main, but they will be used in subsequent PRs for Service map