### PR TITLE
Service Map: Implement service map index prefetch

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -108,6 +108,7 @@
     "sympatheticmoose",
     "loru",
     "nosql",
-    "Equalf"
+    "Equalf",
+    "unmarshaled"
   ]
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -265,11 +265,8 @@ type AggContainer struct {
 
 // MarshalJSON returns the JSON encoding of the aggregation container
 func (a *AggContainer) MarshalJSON() ([]byte, error) {
-	root := make(map[string]interface{})
-	if m, ok := a.Aggregation.(json.Marshaler); ok {
-		root[a.Type] = m
-	} else {
-		root[a.Type] = a.Aggregation
+	root := map[string]interface{}{
+		a.Type: a.Aggregation,
 	}
 
 	if len(a.Aggs) > 0 {

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -265,8 +265,11 @@ type AggContainer struct {
 
 // MarshalJSON returns the JSON encoding of the aggregation container
 func (a *AggContainer) MarshalJSON() ([]byte, error) {
-	root := map[string]interface{}{
-		a.Type: a.Aggregation,
+	root := make(map[string]interface{})
+	if m, ok := a.Aggregation.(json.Marshaler); ok {
+		root[a.Type] = m
+	} else {
+		root[a.Type] = a.Aggregation
 	}
 
 	if len(a.Aggs) > 0 {
@@ -337,7 +340,7 @@ type BucketScriptAggregation struct {
 type TermsAggregation struct {
 	Field       string                 `json:"field"`
 	Size        int                    `json:"size"`
-	Order       map[string]interface{} `json:"order"`
+	Order       map[string]interface{} `json:"order,omitempty"`
 	MinDocCount *int                   `json:"min_doc_count,omitempty"`
 	Missing     *string                `json:"missing,omitempty"`
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -337,7 +337,7 @@ type BucketScriptAggregation struct {
 type TermsAggregation struct {
 	Field       string                 `json:"field"`
 	Size        int                    `json:"size"`
-	Order       map[string]interface{} `json:"order"`
+	Order       map[string]interface{} `json:"order,omitempty"`
 	MinDocCount *int                   `json:"min_doc_count,omitempty"`
 	Missing     *string                `json:"missing,omitempty"`
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -340,7 +340,7 @@ type BucketScriptAggregation struct {
 type TermsAggregation struct {
 	Field       string                 `json:"field"`
 	Size        int                    `json:"size"`
-	Order       map[string]interface{} `json:"order,omitempty"`
+	Order       map[string]interface{} `json:"order"`
 	MinDocCount *int                   `json:"min_doc_count,omitempty"`
 	Missing     *string                `json:"missing,omitempty"`
 }

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -422,6 +422,7 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
+		Order: make(map[string]interface{}),
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",
@@ -435,7 +436,6 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 	}
 
 	if (b.version.Major() >= 6 || b.flavor == OpenSearch) && len(innerAgg.Order) > 0 {
-		innerAgg.Order = make(map[string]interface{})
 		if orderBy, exists := innerAgg.Order[termsOrderTerm]; exists {
 			innerAgg.Order["_key"] = orderBy
 			delete(innerAgg.Order, termsOrderTerm)

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -434,6 +434,7 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
+		Size: 500,
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -170,9 +170,18 @@ func (b *SearchRequestBuilder) SetTraceListFilters(to, from int64, query string)
 
 func (b *aggBuilderImpl) ServiceMap() AggBuilder {
 	b.Terms("service_name", "serviceName", func(a *TermsAggregation, b AggBuilder) {
-		b.Terms("destination_domain", "destination.domain", func(a *TermsAggregation, b AggBuilder) { b.Terms("destination_resource", "destination.resource", nil) })
+		a.Size = 500
+		b.Terms("destination_domain", "destination.domain", func(a *TermsAggregation, b AggBuilder) {
+			a.Size = 500
+			b.Terms("destination_resource", "destination.resource", func(a *TermsAggregation, b AggBuilder) {
+				a.Size = 500
+			})
+		})
 		b.Terms("target_domain", "target.domain", func(a *TermsAggregation, b AggBuilder) {
-			b.Terms("target_resource", "target.resource", nil)
+			a.Size = 500
+			b.Terms("target_resource", "target.resource", func(a *TermsAggregation, b AggBuilder) {
+				a.Size = 500
+			})
 		})
 	})
 	return b
@@ -433,7 +442,6 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
-		Size:  500,
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -171,7 +171,6 @@ func (b *SearchRequestBuilder) SetTraceListFilters(to, from int64, query string)
 func (b *aggBuilderImpl) ServiceMap() AggBuilder {
 	b.Terms("service_name", "serviceName", func(a *TermsAggregation, b AggBuilder) {
 		b.Terms("destination_domain", "destination.domain", func(a *TermsAggregation, b AggBuilder) { b.Terms("destination_resource", "destination.resource", nil) })
-
 		b.Terms("target_domain", "target.domain", func(a *TermsAggregation, b AggBuilder) {
 			b.Terms("target_resource", "target.resource", nil)
 		})
@@ -434,7 +433,7 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
-		Size: 500,
+		Size:  500,
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -422,7 +422,6 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
-		Order: make(map[string]interface{}),
 	}
 	aggDef := newAggDef(key, &AggContainer{
 		Type:        "terms",
@@ -436,6 +435,7 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 	}
 
 	if (b.version.Major() >= 6 || b.flavor == OpenSearch) && len(innerAgg.Order) > 0 {
+		innerAgg.Order = make(map[string]interface{})
 		if orderBy, exists := innerAgg.Order[termsOrderTerm]; exists {
 			innerAgg.Order["_key"] = orderBy
 			delete(innerAgg.Order, termsOrderTerm)

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -329,20 +329,6 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			})
 		})
 
-	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
-		version, _ := semver.NewVersion("1.0.0")
-		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
-		aggBuilder := b.Agg()
-		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
-			innerBuilder.AddAggDef(&aggDef{
-				key: "error_count",
-				aggregation: &AggContainer{
-					Type:        "filter",
-					Aggregation: FilterAggregation{Key: "status.code", Value: "2"},
-				},
-			})
-		})
-
 		sr, err := b.Build()
 		assert.NoError(t, err)
 

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -83,7 +83,6 @@ func TestSearchRequest(t *testing.T) {
 				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
 				assert.Equal(t, []string{""}, mustNotFilters.Values)
 			})
-
 			t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
 				body, err := json.Marshal(sr)
 				assert.NoError(t, err)
@@ -280,7 +279,6 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 
 		})
 	})
-
 	t.Run("and adding top level agg with child agg, When building search request, Should have 1 top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
@@ -317,6 +315,19 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
+	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
+		version, _ := semver.NewVersion("1.0.0")
+		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
+		aggBuilder := b.Agg()
+		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
+			innerBuilder.AddAggDef(&aggDef{
+				key: "error_count",
+				aggregation: &AggContainer{
+					Type:        "filter",
+					Aggregation: FilterAggregation{Key: "status.code", Value: "2"},
+				},
+			})
+		})
 
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -83,6 +83,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.Equal(t, "parentSpanId", mustNotFilters.Key)
 				assert.Equal(t, []string{""}, mustNotFilters.Values)
 			})
+
 			t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
 				body, err := json.Marshal(sr)
 				assert.NoError(t, err)
@@ -90,7 +91,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.NoError(t, err)
 
 				parentSpanId, err := json.GetPath("query", "bool", "filter", "bool", "should", "bool", "filter", "bool", "must_not", "term", "parentSpanId", "value").String()
-				
+
 				assert.NoError(t, err)
 				assert.Equal(t, "", parentSpanId)
 
@@ -279,6 +280,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 
 		})
 	})
+
 	t.Run("and adding top level agg with child agg, When building search request, Should have 1 top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
@@ -315,6 +317,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
+
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -80,23 +80,22 @@ func (h *luceneHandler) processQuery(q *Query) error {
 				aggBuilder.TraceList()
 			}
 		}
-	} else {
-		filters.AddDateRangeFilter(defaultTimeField, client.DateFormatEpochMS, toMs, fromMs)
-
-		if q.RawQuery != "" && q.luceneQueryType != luceneQueryTypeTraces {
-			filters.AddQueryStringFilter(q.RawQuery, true)
-		}
-
-		switch q.Metrics[0].Type {
-		case rawDocumentType, rawDataType:
-			processDocumentQuery(q, b, defaultTimeField)
-		case logsType:
-			processLogsQuery(q, b, fromMs, toMs, defaultTimeField)
-		default:
-			processTimeSeriesQuery(q, b, fromMs, toMs, defaultTimeField)
-		}
+		return nil
 	}
 
+	filters.AddDateRangeFilter(defaultTimeField, client.DateFormatEpochMS, toMs, fromMs)
+	if q.RawQuery != "" && q.luceneQueryType != luceneQueryTypeTraces {
+		filters.AddQueryStringFilter(q.RawQuery, true)
+	}
+
+	switch q.Metrics[0].Type {
+	case rawDocumentType, rawDataType:
+		processDocumentQuery(q, b, defaultTimeField)
+	case logsType:
+		processLogsQuery(q, b, fromMs, toMs, defaultTimeField)
+	default:
+		processTimeSeriesQuery(q, b, fromMs, toMs, defaultTimeField)
+	}
 	return nil
 }
 

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -37,9 +37,11 @@ func newLuceneHandler(client client.Client, queries []backend.DataQuery, interva
 
 func (h *luceneHandler) processQuery(q *Query) error {
 	if len(q.BucketAggs) == 0 {
-		// If no aggregations, only document and logs queries are valid
-		if  q.luceneQueryType != "Traces" && (len(q.Metrics) == 0 || !(len(q.Metrics) > 0 && (q.Metrics[0].Type == rawDataType || q.Metrics[0].Type == rawDocumentType))) {
-			return fmt.Errorf("invalid query, missing metrics and aggregations")
+		// If no aggregations, only trace, document, and logs queries are valid
+		if(q.luceneQueryType != "Traces") {
+			if len(q.Metrics) == 0 || !(q.Metrics[0].Type == rawDataType || q.Metrics[0].Type == rawDocumentType) {
+				return fmt.Errorf("invalid query, missing metrics and aggregations")
+			}
 		}
 	}
 
@@ -95,8 +97,8 @@ func (h *luceneHandler) processQuery(q *Query) error {
 			processTimeSeriesQuery(q, b, fromMs, toMs, defaultTimeField)
 		}
 	}
-	return nil
 
+	return nil
 }
 
 func getTraceId(rawQuery string) string {

--- a/pkg/opensearch/models.go
+++ b/pkg/opensearch/models.go
@@ -19,6 +19,9 @@ type Query struct {
 	Interval        time.Duration
 	RefID           string
 	Format          string
+
+	// serviceMapInfo is used on the backend to pass information for service map queries
+	serviceMapInfo serviceMapInfo
 }
 
 // queryHandler is an interface for handling queries of the same type
@@ -45,6 +48,24 @@ type MetricAgg struct {
 	Settings          *simplejson.Json  `json:"settings"`
 	Meta              *simplejson.Json  `json:"meta"`
 	Type              string            `json:"type"`
+}
+
+type serviceMapInfo struct {
+	Type       ServiceMapQueryType
+	Parameters StatsParameters
+}
+
+type ServiceMapQueryType int
+
+const (
+	Not ServiceMapQueryType = iota
+	ServiceMap
+	Stats
+	Prefetch
+)
+type StatsParameters struct {
+	ServiceNames []string
+	Operations   []string
 }
 
 var metricAggType = map[string]string{

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -102,17 +102,19 @@ func handleServiceMapPrefetch(ctx context.Context, osClient client.Client, req *
 		services, operations := extractParametersFromServiceMapFrames(response)
 
 		// encode the services and operations back to the JSON of the query to be used in the stats request
+		// (NewJson cannot return an error here, since we just called it on line 86.)
 		model, _ := simplejson.NewJson(req.Queries[serviceMapQueryIndex].JSON)
 		model.Set("services", services)
 		model.Set("operations", operations)
 		newJson, err := model.Encode()
+		// An error here _should_ be impossible but since services and operations are coming from outside,
+		// handle it just in case
 		if err != nil {
 			return err
 		}
 		req.Queries[serviceMapQueryIndex].JSON = newJson
 	}
 	return nil
-
 }
 
 func wrapError(response *backend.QueryDataResponse, err error) (*backend.QueryDataResponse, error) {

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -155,6 +155,11 @@ func createServiceMapPrefetchQuery(q backend.DataQuery) backend.DataQuery {
 func extractParametersFromServiceMapFrames(resp *backend.QueryDataResponse) ([]string, []string) {
 	services := make([]string, 0)
 	operations := make([]string, 0)
+
+	if resp == nil {
+		return []string{}, []string{}
+	}
+
 	for _, response := range resp.Responses {
 		for _, frame := range response.Frames {
 			if frame.Name == "services" {

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -95,7 +95,10 @@ func handleServiceMapPrefetch(ctx context.Context, osClient client.Client, req *
 	}
 	if serviceMapQuery.JSON != nil {
 		query := newQueryRequest(osClient, []backend.DataQuery{serviceMapQuery}, req.PluginContext.DataSourceInstanceSettings, intervalCalculator)
-		response, _ := wrapError(query.execute(ctx))
+		response, err := wrapError(query.execute(ctx))
+		if err != nil {
+			return err
+		}
 		services, operations := extractParametersFromServiceMapFrames(response)
 
 		// encode the services and operations back to the JSON of the query to be used in the stats request

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -84,9 +84,10 @@ func handleServiceMapPrefetch(ctx context.Context, osClient client.Client, req *
 	var serviceMapQueryIndex int
 	for i, query := range req.Queries {
 		model, _ := simplejson.NewJson(query.JSON)
+		queryType := model.Get("queryType").MustString()
 		luceneQueryType := model.Get("luceneQueryType").MustString()
 		serviceMapRequested := model.Get("serviceMap").MustBool(false)
-		if luceneQueryType == "Traces" && serviceMapRequested {
+		if queryType == Lucene && luceneQueryType == "Traces" && serviceMapRequested {
 			serviceMapQueryIndex = i
 			serviceMapQuery = createServiceMapPrefetchQuery(query)
 			break

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -70,7 +70,7 @@ func TestServiceMapPreFetch(t *testing.T) {
 			"service_name": buckets}},
 	}
 
-	testcases := []struct {
+	testCases := []struct {
 		name              string
 		queries           map[string]string
 		response          *client.MultiSearchResponse
@@ -109,7 +109,7 @@ func TestServiceMapPreFetch(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newFakeClient(client.OpenSearch, "2.3.0")
 			c.multiSearchResponse = tc.response

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -49,13 +49,13 @@ func TestServiceMapPreFetch(t *testing.T) {
 			}
 		]
 	}`
-	var unmarshaledBuckets interface{}
-	err := json.Unmarshal([]byte(buckets), &unmarshaledBuckets)
+	var unmarshalledBuckets interface{}
+	err := json.Unmarshal([]byte(buckets), &unmarshalledBuckets)
 	assert.NoError(t, err)
 
 	responses := []*client.SearchResponse{
 		{Aggregations: map[string]interface{}{
-			"service_name": unmarshaledBuckets}},
+			"service_name": unmarshalledBuckets}},
 	}
 
 	testCases := []struct {

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -30,3 +30,6 @@ func Test_wrapError(t *testing.T) {
 		assert.Equal(t, "OpenSearch data source error: some error", err.Error())
 	})
 }
+func TestServiceMapPreFetch(t *testing.T) {
+	
+}

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -49,13 +49,13 @@ func TestServiceMapPreFetch(t *testing.T) {
 			}
 		]
 	}`
-	var unmarshalledBuckets interface{}
-	err := json.Unmarshal([]byte(buckets), &unmarshalledBuckets)
+	var unmarshaledBuckets interface{}
+	err := json.Unmarshal([]byte(buckets), &unmarshaledBuckets)
 	assert.NoError(t, err)
 
 	responses := []*client.SearchResponse{
 		{Aggregations: map[string]interface{}{
-			"service_name": unmarshalledBuckets}},
+			"service_name": unmarshaledBuckets}},
 	}
 
 	testCases := []struct {

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -1,10 +1,15 @@
 package opensearch
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_wrapError(t *testing.T) {
@@ -30,6 +35,93 @@ func Test_wrapError(t *testing.T) {
 		assert.Equal(t, "OpenSearch data source error: some error", err.Error())
 	})
 }
+
 func TestServiceMapPreFetch(t *testing.T) {
-	
+	targets1 := map[string]interface{}{
+		"buckets": []interface{}{
+			map[string]interface{}{"target_resource": map[string]interface{}{"buckets": []interface{}{
+				map[string]interface{}{"key": "op1"},
+				map[string]interface{}{"key": "op2"},
+			}}},
+		},
+	}
+	targets2 := map[string]interface{}{
+		"buckets": []interface{}{
+			map[string]interface{}{"target_resource": map[string]interface{}{"buckets": []interface{}{
+				map[string]interface{}{"key": "op2"},
+				map[string]interface{}{"key": "op3"},
+			}}},
+		},
+	}
+	buckets := map[string]interface{}{
+		"buckets": []interface{}{
+			map[string]interface{}{
+				"key":           "service1",
+				"target_domain": targets1,
+			},
+			map[string]interface{}{
+				"key":           "service2",
+				"target_domain": targets2,
+			},
+		},
+	}
+	responses := []*client.SearchResponse{
+		{Aggregations: map[string]interface{}{
+			"service_name": buckets}},
+	}
+
+	testcases := []struct {
+		name              string
+		queries           map[string]string
+		response          *client.MultiSearchResponse
+		shouldEditQuery   bool
+		expectedQueryJson string
+	}{
+		{
+			name: "no service map query",
+			queries: map[string]string{
+				"A": `{
+					"timeField": "@timestamp",
+					"metrics": [{ "type": "count", "id": "1" }, {"type": "avg", "field": "value", "id": "2" }],
+		 			"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "3" }]
+				}`,
+			},
+			shouldEditQuery: false,
+		},
+		{
+			name: "correctly set services and operations",
+			queries: map[string]string{
+				"A": `{
+					"bucketAggs":[{ "field":"@timestamp", "id":"2", "settings":{"interval": "auto"}, "type": "date_histogram" }],
+					"luceneQueryType": "Traces",
+					"metrics": [{"id": "1", "type": "count" }],
+					"query": "traceId:000000000000000011faa8ff95fa3eb8",
+					"queryType": "lucene",
+					"timeField": "@timestamp",
+					"serviceMap": true
+				}`,
+			},
+			response: &client.MultiSearchResponse{
+				Responses: responses,
+			},
+			expectedQueryJson: `{"bucketAggs":[{"field":"@timestamp","id":"2","settings":{"interval":"auto"},"type":"date_histogram"}],"luceneQueryType":"Traces","metrics":[{"id":"1","type":"count"}],"operations":["op1","op2","op3"],"query":"traceId:000000000000000011faa8ff95fa3eb8","queryType":"lucene","serviceMap":true,"services":["service1","service2"],"timeField":"@timestamp"}`,
+			shouldEditQuery:   true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newFakeClient(client.OpenSearch, "2.3.0")
+			c.multiSearchResponse = tc.response
+			req := backend.QueryDataRequest{
+				Queries: createDataQueriesForTests(tc.queries),
+			}
+			err := handleServiceMapPrefetch(context.Background(), c, &req)
+			require.NoError(t, err)
+
+			if tc.shouldEditQuery {
+				assert.Equal(t, json.RawMessage(tc.expectedQueryJson), req.Queries[0].JSON)
+			}
+		})
+	}
 }

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -37,37 +37,25 @@ func Test_wrapError(t *testing.T) {
 }
 
 func TestServiceMapPreFetch(t *testing.T) {
-	targets1 := map[string]interface{}{
-		"buckets": []interface{}{
-			map[string]interface{}{"target_resource": map[string]interface{}{"buckets": []interface{}{
-				map[string]interface{}{"key": "op1"},
-				map[string]interface{}{"key": "op2"},
-			}}},
-		},
-	}
-	targets2 := map[string]interface{}{
-		"buckets": []interface{}{
-			map[string]interface{}{"target_resource": map[string]interface{}{"buckets": []interface{}{
-				map[string]interface{}{"key": "op2"},
-				map[string]interface{}{"key": "op3"},
-			}}},
-		},
-	}
-	buckets := map[string]interface{}{
-		"buckets": []interface{}{
-			map[string]interface{}{
-				"key":           "service1",
-				"target_domain": targets1,
+	buckets := `{
+		"buckets": [
+			{
+				"key": "service1",
+				"target_domain": {"buckets": [{"target_resource": {"buckets": [{"key": "op1"},{"key": "op2"}]}}]}
 			},
-			map[string]interface{}{
-				"key":           "service2",
-				"target_domain": targets2,
-			},
-		},
-	}
+			{
+				"key": "service2",
+				"target_domain":{"buckets": [{"target_resource": {"buckets": [{"key": "op2"},{"key": "op3"}]}}]}
+			}
+		]
+	}`
+	var unmarshaledBuckets interface{}
+	err := json.Unmarshal([]byte(buckets), &unmarshaledBuckets)
+	assert.NoError(t, err)
+
 	responses := []*client.SearchResponse{
 		{Aggregations: map[string]interface{}{
-			"service_name": buckets}},
+			"service_name": unmarshaledBuckets}},
 	}
 
 	testCases := []struct {

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -91,6 +91,24 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 		alias := model.Get("alias").MustString("")
 		format := model.Get("format").MustString("")
 
+		// separate out the service map queries since they need to be built and processed separately
+		serviceMap := model.Get("serviceMap").MustBool(false)
+		if luceneQueryType == "Traces" && serviceMap {
+			if model.Get("serviceMapPrefetch").MustBool() {
+				queries = append(queries, &Query{
+					RawQuery:        rawQuery,
+					QueryType:       queryType,
+					luceneQueryType: luceneQueryType,
+					RefID:           q.RefID,
+					serviceMapInfo: serviceMapInfo{
+						Type: Prefetch,
+					},
+				})
+				//don't append the original query in this case
+				continue
+			}
+		}
+
 		queries = append(queries, &Query{
 			RawQuery:        rawQuery,
 			QueryType:       queryType,

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -140,7 +140,6 @@ func (rp *responseParser) parseResponse() (*backend.QueryDataResponse, error) {
 	return result, nil
 }
 
-
 func processPrefetchResponse(res *client.SearchResponse, queryRes backend.DataResponse) backend.DataResponse {
 	services, operations := getParametersFromServiceMapResult(res)
 	servicesField := data.NewField("services", nil, services)

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newResponseParserForTest(tsdbQueries map[string]string, responseBody string, debugInfo *client.SearchDebugInfo, configuredFields client.ConfiguredFields, dsSettings *backend.DataSourceInstanceSettings) (*responseParser, error) {
+func createDataQueriesForTests(tsdbQueries map[string]string) []backend.DataQuery {
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
 	dataQueries := []backend.DataQuery{}
@@ -32,7 +32,11 @@ func newResponseParserForTest(tsdbQueries map[string]string, responseBody string
 			},
 		})
 	}
+	return dataQueries
+}
 
+func newResponseParserForTest(tsdbQueries map[string]string, responseBody string, debugInfo *client.SearchDebugInfo, configuredFields client.ConfiguredFields, dsSettings *backend.DataSourceInstanceSettings) (*responseParser, error) {
+	dataQueries := createDataQueriesForTests(tsdbQueries)
 	var response client.MultiSearchResponse
 	err := json.Unmarshal([]byte(responseBody), &response)
 	if err != nil {
@@ -2771,7 +2775,7 @@ func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 
 	assert.Len(t, frame.Fields, 24)
 	assert.Equal(t, getFrameValue("operationName", 0, frame.Fields), "test domain A")
-	
+
 	// 2nd query
 	queryResTraceSpans2 := result.Responses["B"]
 	require.NotNil(t, queryResTraceSpans2)
@@ -2906,7 +2910,6 @@ func TestProcessTraceListAndTraceSpansResponse(t *testing.T) {
 	assert.Len(t, frame.Fields, 24)
 
 }
-
 
 func getFrameValue(name string, index int, fields []*data.Field) string {
 	for _, field := range fields {

--- a/pkg/opensearch/snapshot_tests/lucene_service_map_prefetch_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_service_map_prefetch_test.go
@@ -1,0 +1,49 @@
+package snapshot_tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_service_map_prefetch_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_service_map_prefetch_input.json")
+	require.NoError(t, err)
+	var interceptedRequests [][]byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				request, err := io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				interceptedRequests = append(interceptedRequests, request)
+				
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, interceptedRequests, 2)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"service_name":{"aggs":{"destination_domain":{"aggs":{"destination_resource":{"terms":{"field":"destination.resource","size":500}}},"terms":{"field":"destination.domain","size":500}},"target_domain":{"aggs":{"target_resource":{"terms":{"field":"target.resource","size":500}}},"terms":{"field":"target.domain","size":500}}},"terms":{"field":"serviceName","size":500}}},"query":{"bool":{}},"size":0}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequests[0]))
+}

--- a/pkg/opensearch/snapshot_tests/lucene_trace_spans_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_trace_spans_test.go
@@ -39,7 +39,7 @@ func Test_trace_spans_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
+{"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -71,9 +71,9 @@ func Test_trace_spans_request_with_multiple_spans_queries(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
+{"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
 {"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test123"}}]}},"size":1000}
+{"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test123"}}]}},"size":1000}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -105,7 +105,7 @@ func Test_trace_spans_request_with_trace_list_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
+{"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"term":{"traceId":"test"}}]}},"size":1000}
 {"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
 {"aggs":{"traces":{"aggs":{"error_count":{"filter":{"term":{"traceGroupFields.statusCode":"2"}}},"last_updated":{"max":{"field":"traceGroupFields.endTime"}},"latency":{"max":{"script":{"source":"\n                if (doc.containsKey('traceGroupFields.durationInNanos') \u0026\u0026 !doc['traceGroupFields.durationInNanos'].empty) {\n                  return Math.round(doc['traceGroupFields.durationInNanos'].value / 10000) / 100.0\n                }\n                return 0\n                ","lang":"painless"}}},"trace_group":{"terms":{"field":"traceGroup","size":1}}},"terms":{"field":"traceId","size":100,"order":{"_key":"asc"}}}},"query":{"bool":{"must":[{"range":{"startTime":{"gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"some query"}}]}},"size":10}
 `

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_service_map_prefetch_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_service_map_prefetch_input.json
@@ -1,0 +1,34 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "a2a05fd1-c06c-4008-b469-720fea03add2"
+    },
+    "serviceMap": true,
+    "luceneQueryType": "Traces",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "count"
+      }
+    ],
+    "query": "some query",
+    "queryType": "lucene",
+    "refId": "A",
+    "timeField": "@timestamp",
+    "datasourceId": 2020,
+    "intervalMs": 10000,
+    "maxDataPoints": 1124
+  }
+]


### PR DESCRIPTION
Split the feature into multiple PRs for ease of reviewing. The feature is not enabled by deafult but 'hidden' behind a provisional feature flag. 

In order to get stats for the service map (service info that's displayed inside a node: `avg latency`, `throughput`, `error rate`), we have to build an aggregation query on the `span` indices. The documents (spans) need to be filtered by operationNames and serviceNames, in order to get and aggregate *only* on spans that represent requests from one service to another (not internal processes). 
This reflects how the aggregations are build for the Service Map panel in Open Search. 

To get the operationNames and serviceNames, we have to first query the `service-map` indices and get operations and services from the `serviceName` and `destination.resource` fields of the index. 

**This PR implements:** 

1. detecting if the query requested from GF Open Search plugin has the serviceMap flag enabled
2. creating a separate query just for the `service-map` indices with the flag `serviceMapPrefetch`
3. adding flows that detect the `serviceMapPrefetch` flag and build the aggregations and the query
4. process the response from OpenSearch and store operation names and service names into Data Frames
5. putting those operations and services into the model of a service map Stats query and forwarding it along with the original query array (can contain other types of queries as well)
6. subsequent PRs will deal with building the stats query and processing it into final data frames that will be displayed in Grafana Node Graph visualization ([draft PR](https://github.com/grafana/opensearch-datasource/pull/363))

**Note:** This builds queries for otel + Open Search data prepper. Open Search can [store traces in raw Jaeger format](https://opensearch.org/docs/latest/observing-your-data/trace/index/#trace-analytics-with-jaeger-data), in which case the aggregations and responses should look slightly different. This is something we intend to implement in the future. 

**To test:**
1. enable `openSearchNodeGraph` feature toggle in Grafana config
2. run the Data Prepper/examples/jaeger-hotrod
3. generate some traces in the browser app
4. run the plugin in debugging mode
5. select query type: Traces and switch on the Service Map button in the query editor
6. you should be getting services and operations when you break on [this line](https://github.com/grafana/opensearch-datasource/blob/f6e1db87d81b77f8173703fa42ed8047c0c27c2e/pkg/opensearch/opensearch.go#L98)
7. nothing will show in the visualization yet, since we don't have stats processing yet