### PR TITLE
Service Map: Build Stats request and process responses to dataframes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ e2e-results/
 .vscode/launch.json
 
 .DS_Store
+__debug_bin*

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -109,6 +109,9 @@
     "loru",
     "nosql",
     "Equalf",
-    "unmarshaled"
+    "unmarshaled",
+    "Throughputs",
+    "mainstat",
+    "secondarystat",
   ]
 }

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -276,14 +276,14 @@ func (a *AggContainer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(root)
 }
 
-type aggDef struct {
+type aggDefinition struct {
 	key         string
 	aggregation *AggContainer
 	builders    []AggBuilder
 }
 
-func newAggDef(key string, aggregation *AggContainer) *aggDef {
-	return &aggDef{
+func newAggDefinition(key string, aggregation *AggContainer) *aggDefinition {
+	return &aggDefinition{
 		key:         key,
 		aggregation: aggregation,
 		builders:    make([]AggBuilder, 0),

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -577,6 +577,7 @@ func (b *SearchRequestBuilder) SetTraceSpansFilters(to, from int64, traceId stri
 // display latency and throughput
 func (b *aggBuilderImpl) Stats() AggBuilder {
 	b.Terms("service_name", "serviceName", func(a *TermsAggregation, b AggBuilder) {
+		a.Size = 500
 		b.Metric("avg_latency_nanos", "avg", "durationInNanos", nil)
 		b.AddAggDef(&aggDefinition{
 			key: "error_count",

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -509,7 +509,6 @@ const termsOrderTerm = "_term"
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{
 		Field: field,
-		Size:  500,
 	}
 	aggDef := newAggDefinition(key, &AggContainer{
 		Type:        "terms",

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -238,17 +238,17 @@ func (b *SearchRequestBuilder) SetTraceListFilters(to, from int64, query string)
 
 func (b *aggBuilderImpl) ServiceMap() AggBuilder {
 	b.Terms("service_name", "serviceName", func(a *TermsAggregation, b AggBuilder) {
-		a.Size = 500
+		a.Size = nodeGraphSize
 		b.Terms("destination_domain", "destination.domain", func(a *TermsAggregation, b AggBuilder) {
-			a.Size = 500
+			a.Size = nodeGraphSize
 			b.Terms("destination_resource", "destination.resource", func(a *TermsAggregation, b AggBuilder) {
-				a.Size = 500
+				a.Size = nodeGraphSize
 			})
 		})
 		b.Terms("target_domain", "target.domain", func(a *TermsAggregation, b AggBuilder) {
-			a.Size = 500
+			a.Size = nodeGraphSize
 			b.Terms("target_resource", "target.resource", func(a *TermsAggregation, b AggBuilder) {
-				a.Size = 500
+				a.Size = nodeGraphSize
 			})
 		})
 	})

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -7,6 +7,9 @@ import (
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 )
 
+// nodeGraphSize is used for setting node graph query sizes. Arbitrarily chosen.
+const nodeGraphSize = 1000
+
 // SearchRequestBuilder represents a builder which can build a search request
 type SearchRequestBuilder struct {
 	flavor       Flavor
@@ -204,8 +207,7 @@ func (b *SearchRequestBuilder) SetStatsFilters(to, from int64, traceId string, p
 		},
 	}
 
-	b.Size(10)
-
+	b.Size(nodeGraphSize)
 }
 
 // SetTraceListFilters sets the "query" object of the query to OpenSearch for the trace list
@@ -577,7 +579,7 @@ func (b *SearchRequestBuilder) SetTraceSpansFilters(to, from int64, traceId stri
 // display latency and throughput
 func (b *aggBuilderImpl) Stats() AggBuilder {
 	b.Terms("service_name", "serviceName", func(a *TermsAggregation, b AggBuilder) {
-		a.Size = 500
+		a.Size = nodeGraphSize
 		b.Metric("avg_latency_nanos", "avg", "durationInNanos", nil)
 		b.AddAggDef(&aggDefinition{
 			key: "error_count",

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -317,13 +317,26 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
+	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
+		version, _ := semver.NewVersion("1.0.0")
+		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
+		aggBuilder := b.Agg()
+		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
+			innerBuilder.AddAggDef(&aggDefinition{
+				key: "error_count",
+				aggregation: &AggContainer{
+					Type:        "filter",
+					Aggregation: FilterAggregation{Key: "status.code", Value: "2"},
+				},
+			})
+		})
 
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 		aggBuilder := b.Agg()
 		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
-			innerBuilder.AddAggDef(&aggDef{
+			innerBuilder.AddAggDef(&aggDefinition{
 				key: "error_count",
 				aggregation: &AggContainer{
 					Type:        "filter",

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -317,20 +317,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
-	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
-		version, _ := semver.NewVersion("1.0.0")
-		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
-		aggBuilder := b.Agg()
-		aggBuilder.Terms("service_name", "fieldServiceName", func(a *TermsAggregation, innerBuilder AggBuilder) {
-			innerBuilder.AddAggDef(&aggDefinition{
-				key: "error_count",
-				aggregation: &AggContainer{
-					Type:        "filter",
-					Aggregation: FilterAggregation{Key: "status.code", Value: "2"},
-				},
-			})
-		})
-
+	
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -317,7 +317,7 @@ func Test_Given_new_search_request_builder_for_es_OpenSearch_1_0_0(t *testing.T)
 			assert.Equal(t, "@timestamp", secondLevelAgg.GetPath("date_histogram", "field").MustString())
 		})
 	})
-	
+
 	t.Run("and adding top level agg with child agg using AddAggDef. Should have one top level agg and one child agg", func(t *testing.T) {
 		version, _ := semver.NewVersion("1.0.0")
 		b := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -65,10 +65,14 @@ func (h *luceneHandler) processQuery(q *Query) error {
 	if q.luceneQueryType == luceneQueryTypeTraces {
 		traceId := getTraceId(q.RawQuery)
 		switch q.serviceMapInfo.Type {
-		case Prefetch:
+		case ServiceMap, Prefetch:
 			b.Size(0)
 			aggBuilder := b.Agg()
 			aggBuilder.ServiceMap()
+		case Stats:
+			b.SetStatsFilters(toMs, fromMs, traceId, q.serviceMapInfo.Parameters)
+			aggBuilder := b.Agg()
+			aggBuilder.Stats()
 		default:
 			if traceId != "" {
 				b.Size(1000)

--- a/pkg/opensearch/models.go
+++ b/pkg/opensearch/models.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 )
 
 // Query represents the time series query model of the datasource
@@ -19,6 +20,7 @@ type Query struct {
 	Interval        time.Duration
 	RefID           string
 	Format          string
+	TimeRange       backend.TimeRange
 
 	// serviceMapInfo is used on the backend to pass information for service map queries
 	serviceMapInfo serviceMapInfo
@@ -52,7 +54,7 @@ type MetricAgg struct {
 
 type serviceMapInfo struct {
 	Type       ServiceMapQueryType
-	Parameters StatsParameters
+	Parameters client.StatsParameters
 }
 
 type ServiceMapQueryType int
@@ -63,10 +65,6 @@ const (
 	Stats
 	Prefetch
 )
-type StatsParameters struct {
-	ServiceNames []string
-	Operations   []string
-}
 
 var metricAggType = map[string]string{
 	"count":          "Count",

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -107,6 +107,28 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 				//don't append the original query in this case
 				continue
 			}
+			queries = append(queries, &Query{
+				RawQuery:        rawQuery,
+				QueryType:       queryType,
+				luceneQueryType: luceneQueryType,
+				RefID:           q.RefID,
+				serviceMapInfo: serviceMapInfo{
+					Type: Stats,
+					Parameters: client.StatsParameters{
+						ServiceNames: model.Get("services").MustStringArray(),
+						Operations:   model.Get("operations").MustStringArray(),
+					},
+				},
+				TimeRange: q.TimeRange,
+			},
+				&Query{
+					RawQuery:        rawQuery,
+					QueryType:       queryType,
+					luceneQueryType: luceneQueryType,
+					RefID:           q.RefID,
+					serviceMapInfo:  serviceMapInfo{Type: ServiceMap},
+				},
+			)
 		}
 
 		queries = append(queries, &Query{

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -91,9 +91,13 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 		alias := model.Get("alias").MustString("")
 		format := model.Get("format").MustString("")
 
-		// separate out the service map queries since they need to be built and processed separately
-		serviceMap := model.Get("serviceMap").MustBool(false)
-		if luceneQueryType == "Traces" && serviceMap {
+		// For queries requesting the service map, we inject extra queries to handle retrieving
+		// the required information
+		hasServiceMap := model.Get("serviceMap").MustBool(false)
+		if luceneQueryType == "Traces" && hasServiceMap {
+			// The Prefetch request is used by itself for internal use, to get the parameters
+			// necessary for the Stats request. In this case there's no original query to
+			// pass along, so we continue below.
 			if model.Get("serviceMapPrefetch").MustBool() {
 				queries = append(queries, &Query{
 					RawQuery:        rawQuery,
@@ -107,20 +111,24 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 				//don't append the original query in this case
 				continue
 			}
-			queries = append(queries, &Query{
-				RawQuery:        rawQuery,
-				QueryType:       queryType,
-				luceneQueryType: luceneQueryType,
-				RefID:           q.RefID,
-				serviceMapInfo: serviceMapInfo{
-					Type: Stats,
-					Parameters: client.StatsParameters{
-						ServiceNames: model.Get("services").MustStringArray(),
-						Operations:   model.Get("operations").MustStringArray(),
+			// For service map requests that are not prefetch, we add extra queries - one
+			// for the service map and one for the associated stats. We also add the
+			// original query below.
+			queries = append(queries,
+				&Query{
+					RawQuery:        rawQuery,
+					QueryType:       queryType,
+					luceneQueryType: luceneQueryType,
+					RefID:           q.RefID,
+					serviceMapInfo: serviceMapInfo{
+						Type: Stats,
+						Parameters: client.StatsParameters{
+							ServiceNames: model.Get("services").MustStringArray(),
+							Operations:   model.Get("operations").MustStringArray(),
+						},
 					},
+					TimeRange: q.TimeRange,
 				},
-				TimeRange: q.TimeRange,
-			},
 				&Query{
 					RawQuery:        rawQuery,
 					QueryType:       queryType,

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -331,9 +331,9 @@ func processServiceMapResponse(serviceMap []interface{}, spanServiceStats []inte
 	nodeFields := Fields{}
 	nodeIds := nodeFields.Add("id", nil, []string{})
 	nodeTitles := nodeFields.Add("title", nil, []string{}, &data.FieldConfig{DisplayName: "Service name"})
-	nodeErrorRates := nodeFields.Add("arc__errors", nil, []float64{}, &data.FieldConfig{Color: map[string]interface{}{"mode": "fixed", "fixedColor": "red"}})
+	nodeErrorRates := nodeFields.Add("arc__errors", nil, []float64{}, &data.FieldConfig{DisplayName: "Error rate", Color: map[string]interface{}{"mode": "fixed", "fixedColor": "red"}})
 	nodeErrorRatesDetails := nodeFields.Add("detail__errors", nil, []float64{}, &data.FieldConfig{DisplayName: "Error rate", Unit: "%"})
-	nodeSuccessRates := nodeFields.Add("arc__success", nil, []float64{}, &data.FieldConfig{Color: map[string]interface{}{"mode": "fixed", "fixedColor": "green"}})
+	nodeSuccessRates := nodeFields.Add("arc__success", nil, []float64{}, &data.FieldConfig{DisplayName: "Success rate", Color: map[string]interface{}{"mode": "fixed", "fixedColor": "green"}})
 	nodeAvgLatencies := nodeFields.Add("mainstat", nil, []float64{}, &data.FieldConfig{DisplayName: "Avg. Latency", Unit: "ms"})
 	var nodeThroughputs *data.Field
 	if traceId == "" {

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -304,7 +304,7 @@ func processTraceSpansResponse(res *client.SearchResponse, queryRes backend.Data
 	}
 	frame.Meta.PreferredVisualization = data.VisTypeTrace
 
-	queryRes.Frames = append(queryRes.Frames, frame)
+	queryRes.Frames = data.Frames{frame}
 	return queryRes
 }
 

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -340,7 +340,6 @@ func processServiceMapResponse(serviceMap []interface{}, spanServiceStats []inte
 	}
 
 	minutes := duration.Minutes()
-
 	serviceStatsMap := createServiceStatsMap(spanServiceStats)
 
 	for _, s := range serviceMap {
@@ -352,7 +351,7 @@ func processServiceMapResponse(serviceMap []interface{}, spanServiceStats []inte
 		if statsForService != nil {
 			nodeIds.Append(edgeSource)
 			nodeTitles.Append(edgeSource)
-			serviceLatency := statsForService.(map[string]interface{})["avg_latency_nanos"].(map[string]interface{})["value"].(float64) / 1000000
+			serviceLatency := statsForService.(map[string]interface{})["avg_latency_nanos"].(map[string]interface{})["value"].(float64) / float64(time.Millisecond)
 			serviceErrorRate := statsForService.(map[string]interface{})["error_rate"].(map[string]interface{})["value"].(float64)
 			nodeAvgLatencies.Append(serviceLatency)
 			nodeErrorRates.Append(serviceErrorRate)
@@ -378,14 +377,12 @@ func processServiceMapResponse(serviceMap []interface{}, spanServiceStats []inte
 		}
 	}
 
-	edgeFrame := data.NewFrame("edges", edgeFields...).SetMeta(&data.FrameMeta{PreferredVisualization: "nodeGraph"})
-	nodeFrame := data.NewFrame("nodes", nodeFields...).SetMeta(&data.FrameMeta{PreferredVisualization: "nodeGraph"})
-
+	edgeFrame := data.NewFrame("edges", edgeFields...).SetMeta(&data.FrameMeta{PreferredVisualization: data.VisTypeNodeGraph})
+	nodeFrame := data.NewFrame("nodes", nodeFields...).SetMeta(&data.FrameMeta{PreferredVisualization: data.VisTypeNodeGraph})
 	return data.Frames{edgeFrame, nodeFrame}
 }
 
 // Fields holds a slice of dataframe fields
-// TODO: move this into grafana-plugin-sdk-go? It could work a little nicer there
 type Fields []*data.Field
 
 // Add adds a field to the Fields, with optional config.

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -442,7 +442,7 @@ func processTraceListResponse(res *client.SearchResponse, dsUID string, dsName s
 	allFields = append(allFields, data.NewField("Error Count", nil, traceErrorCounts))
 	allFields = append(allFields, data.NewField("Last Updated", nil, traceLastUpdated))
 
-	queryRes.Frames = append(queryRes.Frames, data.Frames{data.NewFrame("Trace List", allFields...)}...)
+	queryRes.Frames = data.Frames{data.NewFrame("Trace List", allFields...)}
 	return queryRes
 }
 

--- a/pkg/opensearch/snapshot_tests/lucene_service_map_prefetch_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_service_map_prefetch_test.go
@@ -43,7 +43,7 @@ func Test_service_map_prefetch_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"service_name":{"aggs":{"destination_domain":{"aggs":{"destination_resource":{"terms":{"field":"destination.resource","size":500}}},"terms":{"field":"destination.domain","size":500}},"target_domain":{"aggs":{"target_resource":{"terms":{"field":"target.resource","size":500}}},"terms":{"field":"target.domain","size":500}}},"terms":{"field":"serviceName","size":500}}},"query":{"bool":{}},"size":0}
+{"aggs":{"service_name":{"aggs":{"destination_domain":{"aggs":{"destination_resource":{"terms":{"field":"destination.resource","size":1000}}},"terms":{"field":"destination.domain","size":1000}},"target_domain":{"aggs":{"target_resource":{"terms":{"field":"target.resource","size":1000}}},"terms":{"field":"target.domain","size":1000}}},"terms":{"field":"serviceName","size":1000}}},"query":{"bool":{}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequests[0]))
 }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -35,6 +35,9 @@ function getQueryType(query: OpenSearchQuery) {
   }
 
   if (query.luceneQueryType === LuceneQueryType.Traces) {
+    if (query.serviceMap) {
+      return 'traces with service map'
+    }
     return 'traces';
   }
 


### PR DESCRIPTION
Split the feature into multiple PRs for ease of reviewing. The feature is not enabled by default but 'hidden' behind a provisional feature flag.
After [getting operationNames and serviceNames from the service map prefetch](https://github.com/grafana/opensearch-datasource/pull/362) request, we build the query for getting the stats (throughput, error_rate, avg_latency) for each node (i.e. service). 

This PR implements:
- Detecting the stats query in query_processing.go, and splitting the query in two - one for service map (to get the nodes and edges) and one for stats (latency etc.). They must be split because their aggregations are made on two different sets of filtered documents, so they cannot be combined into one query
- Building the stats query, with filters and aggregations (including filters for traceId in case one one trace is queried)
- in response_processing.go, combining the two results into dataframes that the Node Graph Grafana visualization can read. 


A few things to note: 
- This builds queries for otel + Open Search data prepper. Open Search can [store traces in raw Jaeger format](https://opensearch.org/docs/latest/observing-your-data/trace/index/#trace-analytics-with-jaeger-data), in which case the aggregations and responses should look slightly different. This is something we intend to implement in the future.
- We send the service map index request an extra time, together with the Stats request. This isn't necessary, but we thought it's the cleanest solution - we would otherwise have to encode the whole response in the Stats query `serviceMapInfo` field, to be later processed together with the response from Stats query. The current backend architecture makes this even more difficult because we cannot intercept raw response from Open Search anywhere. In order to mitigate this in the future, we intend to add client-side caching for the service map prefetch response (along with refactoring the backend querying, but that's a significant chunk of work that might take a while)

**Testing**

1. enable openSearchNodeGraph feature toggle in Grafana config
2. run the Data Prepper/examples/jaeger-hotrod
3. generate some traces in the browser app
4. select query type: Traces and switch on the Service Map button in the query editor
5. Run the query 
6. In explore, there will be a Node Graph panel along with the table panel. In dashboard panel, you'll be able to switch to the node graph panel
7. If you query a particular trace ID from the table `traceId: xyz` and select Service Map switch, you can see the Node Graph for that particular trace along with the span timeline