### PR TITLE
Fix flaky tests

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -315,7 +314,6 @@ func getParametersFromServiceMapResult(smResult *client.SearchResponse) ([]strin
 	for op := range operationMap {
 		operations = append(operations, op)
 	}
-	slices.Sort(operations)
 	return services, operations
 }
 

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -309,10 +310,12 @@ func getParametersFromServiceMapResult(smResult *client.SearchResponse) ([]strin
 			}
 		}
 	}
+
 	operations := make([]string, 0, len(operationMap))
 	for op := range operationMap {
 		operations = append(operations, op)
 	}
+	slices.Sort(operations)
 	return services, operations
 }
 

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -60,26 +60,28 @@ func TestServiceMapPreFetch(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		queries           map[string]string
+		queries           []tsdbQuery
 		response          *client.MultiSearchResponse
 		shouldEditQuery   bool
 		expectedQueryJson string
 	}{
 		{
 			name: "no service map query",
-			queries: map[string]string{
-				"A": `{
+			queries: []tsdbQuery{{
+				refId: "A",
+				body: `{
 					"timeField": "@timestamp",
 					"metrics": [{ "type": "count", "id": "1" }, {"type": "avg", "field": "value", "id": "2" }],
 		 			"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "3" }]
 				}`,
-			},
+			}},
 			shouldEditQuery: false,
 		},
 		{
 			name: "correctly set services and operations",
-			queries: map[string]string{
-				"A": `{
+			queries: []tsdbQuery{{
+				refId: "A",
+				body: `{
 					"bucketAggs":[{ "field":"@timestamp", "id":"2", "settings":{"interval": "auto"}, "type": "date_histogram" }],
 					"luceneQueryType": "Traces",
 					"metrics": [{"id": "1", "type": "count" }],
@@ -88,6 +90,7 @@ func TestServiceMapPreFetch(t *testing.T) {
 					"timeField": "@timestamp",
 					"serviceMap": true
 				}`,
+			},
 			},
 			response: &client.MultiSearchResponse{
 				Responses: responses,

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
+	"github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 	"github.com/stretchr/testify/assert"
@@ -110,8 +112,23 @@ func TestServiceMapPreFetch(t *testing.T) {
 			err := handleServiceMapPrefetch(context.Background(), c, &req)
 			require.NoError(t, err)
 
+			// handleServiceMapPrefetch may not put the operation in the same order every time
+			model, err := simplejson.NewJson(req.Queries[0].JSON)
+			require.NoError(t, err)
+
+			ops := model.Get("operations").MustArray()
+			var sortedOperations []string
+			for _, op := range ops {
+				sortedOperations = append(sortedOperations, op.(string))
+			}
+			slices.Sort(sortedOperations)
+			model.Set("operations", sortedOperations)
+
+			sortedQuery, err := model.Encode()
+			require.NoError(t, err)
+
 			if tc.shouldEditQuery {
-				assert.Equal(t, json.RawMessage(tc.expectedQueryJson), req.Queries[0].JSON)
+				assert.Equal(t, []byte(tc.expectedQueryJson), sortedQuery)
 			}
 		})
 	}

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -152,9 +152,13 @@ func processPrefetchResponse(res *client.SearchResponse, queryRes backend.DataRe
 
 func processTraceSpansResponse(res *client.SearchResponse, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
-	docs := make([]map[string]interface{}, len(res.Hits.Hits))
+	var hits []map[string]interface{}
+	if res.Hits != nil {
+		hits = res.Hits.Hits
+	}
+	docs := make([]map[string]interface{}, len(hits))
 
-	for hitIdx, hit := range res.Hits.Hits {
+	for hitIdx, hit := range hits {
 		var withKeysToObj map[string]interface{}
 		if hit["_source"] != nil {
 			// some k:v pairs come from OpenSearch with field names in dot notation: 'span.attributes.http@status_code': 200,

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -152,13 +152,9 @@ func processPrefetchResponse(res *client.SearchResponse, queryRes backend.DataRe
 
 func processTraceSpansResponse(res *client.SearchResponse, queryRes backend.DataResponse) backend.DataResponse {
 	propNames := make(map[string]bool)
-	var hits []map[string]interface{}
-	if res.Hits != nil {
-		hits = res.Hits.Hits
-	}
-	docs := make([]map[string]interface{}, len(hits))
+	docs := make([]map[string]interface{}, len(res.Hits.Hits))
 
-	for hitIdx, hit := range hits {
+	for hitIdx, hit := range res.Hits.Hits {
 		var withKeysToObj map[string]interface{}
 		if hit["_source"] != nil {
 			// some k:v pairs come from OpenSearch with field names in dot notation: 'span.attributes.http@status_code': 200,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Due to backend.Responses being a map, we end up getting the services/operations in an inconsistent order when we have multiple responses. This makes some of the tests flaky ([test 1](https://github.com/grafana/opensearch-datasource/blob/8b2f845fe03cd6d9f3c20e42ebd0227552a2a4e4/pkg/opensearch/response_parser_test.go#L2667) and [test 2](https://github.com/grafana/opensearch-datasource/blob/8b2f845fe03cd6d9f3c20e42ebd0227552a2a4e4/pkg/opensearch/opensearch_test.go#L39)). One fix for that is just sorting the operations and services (done in this pr), though if we think that's too expensive (I don't think we should have that many of them?) we could also try to rework the tests, though considering that one of them involves checking a big json string that could either be a bit complex or just involve not using 2 responses (though that reduces the test coverage).

The other change was to avoid a seg fault in `TestProcessTraceListAndTraceSpansResponse`, which was happening because the helper that generated the test queries used a map and was unordered. Changed to an array.

**Which issue(s) this PR fixes**:

Fixes #368 

**Special notes for your reviewer**:
