### PR TITLE
Revert Lucene and PPL migration to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+
 ## 2.15.1
 - Revert Lucene and PPL migration to backend [#8b1e396](https://github.com/grafana/opensearch-datasource/commit/8b1e3960c5b3643ddd6db569acfe8e6ed153b0b8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+## 2.15.1
+- Revert Lucene and PPL migration to backend [#8b1e396](https://github.com/grafana/opensearch-datasource/commit/8b1e3960c5b3643ddd6db569acfe8e6ed153b0b8)
 
 ## 2.15.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,10 +1,14 @@
 import {
   ArrayVector,
   CoreApp,
+  DataFrame,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
   DateTime,
+  dateTime,
+  Field,
+  FieldCache,
   MetricFindValue,
   MutableDataFrame,
   TimeRange,
@@ -26,7 +30,8 @@ import {
 } from './types';
 import { Filters } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import { matchers } from './dependencies/matchers';
-import { lastValueFrom, of } from 'rxjs';
+import { MetricAggregation } from 'components/QueryEditor/MetricAggregationsEditor/aggregations';
+import { firstValueFrom, lastValueFrom, of } from 'rxjs';
 
 expect.extend(matchers);
 
@@ -134,6 +139,260 @@ describe('OpenSearchDatasource', function (this: any) {
 
       const today = toUtc().format('YYYY.MM.DD');
       expect(requestOptions.url).toBe(`${OPENSEARCH_MOCK_URL}/asd-${today}/_mapping`);
+    });
+  });
+
+  describe('When issuing metric query with interval pattern', () => {
+    let requestOptions: any, parts: any, header: any, query: any, result: any;
+
+    beforeEach(async () => {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: '[asd-]YYYY.MM.DD',
+          interval: 'Daily',
+          version: '1.0.0',
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+      datasourceRequestMock.mockImplementation((options) => {
+        requestOptions = options;
+        return Promise.resolve({
+          data: {
+            responses: [
+              {
+                aggregations: {
+                  '1': {
+                    buckets: [
+                      {
+                        doc_count: 10,
+                        key: 1000,
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        });
+      });
+
+      query = {
+        range: {
+          from: toUtc([2015, 4, 30, 10]),
+          to: toUtc([2015, 5, 1, 10]),
+        },
+        targets: [
+          {
+            alias: '$varAlias',
+            bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '1' }],
+            metrics: [{ type: 'count', id: '1' }],
+            query: 'escape\\:test',
+          },
+        ],
+      };
+
+      result = await ctx.ds.query(query).toPromise();
+
+      parts = requestOptions.data.split('\n');
+      header = JSON.parse(parts[0]);
+    });
+
+    it('should translate index pattern to current day', () => {
+      expect(header.index).toEqual(['asd-2015.05.30', 'asd-2015.05.31', 'asd-2015.06.01']);
+    });
+
+    it('should not resolve the variable in the original alias field in the query', () => {
+      expect(query.targets[0].alias).toEqual('$varAlias');
+    });
+
+    it('should resolve the alias variable for the alias/target in the result', () => {
+      expect(result.data[0].name).toEqual('resolvedVariable');
+    });
+
+    it('should json escape lucene query', () => {
+      const body = JSON.parse(parts[1]);
+      expect(body.query.bool.filter[1].query_string.query).toBe('escape\\:test');
+    });
+  });
+
+  describe('When using sigV4 and POST request', () => {
+    it('should add correct header', async () => {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: 'mock-index',
+          interval: 'Daily',
+          version: '1.0.0',
+          timeField: '@timestamp',
+          serverless: true,
+          sigV4Auth: true,
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+      datasourceRequestMock.mockImplementation((options) => {
+        return Promise.resolve(logsResponse);
+      });
+
+      const query: DataQueryRequest<OpenSearchQuery> = {
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2019, 7, 1, 10])),
+        targets: [
+          {
+            alias: '$varAlias',
+            refId: 'A',
+            bucketAggs: [{ type: 'date_histogram', settings: { interval: 'auto' }, id: '2' }],
+            metrics: [{ type: 'count', id: '1' }],
+            query: 'escape\\:test',
+            isLogsQuery: true,
+            timeField: '@timestamp',
+          },
+        ],
+      } as DataQueryRequest<OpenSearchQuery>;
+
+      await ctx.ds.query(query).toPromise();
+
+      expect(datasourceRequestMock.mock.calls[0][0].headers['x-amz-content-sha256']).toBe(
+        '78a015e84f933e9624c9c0154771945fbc25bf358f8d8a79562a7310b60edb1c'
+      );
+    });
+  });
+
+  describe('When issuing logs query with interval pattern', () => {
+    async function setupDataSource(jsonData?: Partial<OpenSearchOptions>) {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: 'mock-index',
+          interval: 'Daily',
+          version: '1.0.0',
+          timeField: '@timestamp',
+          ...(jsonData || {}),
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+      datasourceRequestMock.mockImplementation((options) => {
+        return Promise.resolve(logsResponse);
+      });
+
+      const query: DataQueryRequest<OpenSearchQuery> = {
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2019, 7, 1, 10])),
+        targets: [
+          {
+            alias: '$varAlias',
+            refId: 'A',
+            bucketAggs: [{ type: 'date_histogram', settings: { interval: 'auto' }, id: '2' }],
+            metrics: [{ type: 'count', id: '1' }],
+            query: 'escape\\:test',
+            isLogsQuery: true,
+            timeField: '@timestamp',
+          },
+        ],
+      } as DataQueryRequest<OpenSearchQuery>;
+
+      const queryBuilderSpy = jest.spyOn(ctx.ds.queryBuilder, 'getLogsQuery');
+      const response = await ctx.ds.query(query).toPromise();
+      return { queryBuilderSpy, response };
+    }
+
+    it('should call getLogsQuery()', async () => {
+      const { queryBuilderSpy } = await setupDataSource();
+      expect(queryBuilderSpy).toHaveBeenCalled();
+    });
+
+    it('should enhance fields with links', async () => {
+      const { response } = await setupDataSource({
+        dataLinks: [
+          {
+            field: 'host',
+            url: 'http://localhost:3000/${__value.raw}',
+          },
+        ],
+      });
+
+      expect(response?.data.length).toBe(1);
+      const links = response?.data[0].fields.find((field: Field) => field.name === 'host').config.links;
+      expect(links.length).toBe(1);
+      expect(links[0].url).toBe('http://localhost:3000/${__value.raw}');
+    });
+  });
+
+  describe('When getting an error on response', () => {
+    const query: DataQueryRequest<OpenSearchQuery> = {
+      range: createTimeRange(toUtc([2020, 1, 1, 10]), toUtc([2020, 2, 1, 10])),
+      targets: [
+        {
+          refId: 'A',
+          alias: '$varAlias',
+          bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '1' }],
+          metrics: [{ type: 'count', id: '1' }],
+          query: 'escape\\:test',
+        },
+      ],
+    } as DataQueryRequest<OpenSearchQuery>;
+
+    createDatasource({
+      url: OPENSEARCH_MOCK_URL,
+      jsonData: {
+        database: '[asd-]YYYY.MM.DD',
+        interval: 'Daily',
+        version: '1.0.0',
+      } as OpenSearchOptions,
+    } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+    it('should process it properly', async () => {
+      datasourceRequestMock.mockImplementation(() => {
+        return Promise.resolve({
+          data: {
+            took: 1,
+            responses: [
+              {
+                error: {
+                  reason: 'all shards failed',
+                },
+                status: 400,
+              },
+            ],
+          },
+        });
+      });
+
+      const errObject = {
+        data: '{\n    "reason": "all shards failed"\n}',
+        message: 'all shards failed',
+      };
+
+      try {
+        await ctx.ds.query(query);
+      } catch (err) {
+        expect(err).toEqual(errObject);
+      }
+    });
+
+    it('should properly throw an unknown error', async () => {
+      datasourceRequestMock.mockImplementation(() => {
+        return Promise.resolve({
+          data: {
+            took: 1,
+            responses: [
+              {
+                error: {},
+                status: 400,
+              },
+            ],
+          },
+        });
+      });
+
+      const errObject = {
+        data: '{}',
+        message: 'Unknown OpenSearch error response',
+      };
+
+      try {
+        await ctx.ds.query(query);
+      } catch (err) {
+        expect(err).toEqual(errObject);
+      }
     });
   });
 
@@ -283,6 +542,51 @@ describe('OpenSearchDatasource', function (this: any) {
     });
   });
 
+  describe('When issuing aggregation query', () => {
+    let requestOptions: any, parts: any, header: any;
+
+    beforeEach(() => {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: 'test',
+          version: '1.0.0',
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+      datasourceRequestMock.mockImplementation((options) => {
+        requestOptions = options;
+        return Promise.resolve({ data: { responses: [] } });
+      });
+
+      const query: DataQueryRequest<OpenSearchQuery> = {
+        range: createTimeRange(dateTime([2015, 4, 30, 10]), dateTime([2015, 5, 1, 10])),
+        targets: [
+          {
+            refId: 'A',
+            bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '2' }],
+            metrics: [{ type: 'count', id: '1' }],
+            query: 'test',
+          },
+        ],
+      } as DataQueryRequest<OpenSearchQuery>;
+
+      ctx.ds.query(query);
+
+      parts = requestOptions.data.split('\n');
+      header = JSON.parse(parts[0]);
+    });
+
+    it('should not set search type to count', () => {
+      expect(header.search_type).not.toEqual('count');
+    });
+
+    it('should set size to 0', () => {
+      const body = JSON.parse(parts[1]);
+      expect(body.size).toBe(0);
+    });
+  });
+
   describe('When issuing metricFind query', () => {
     let requestOptions: any, parts, header: any, body: any;
     let results: MetricFindValue[];
@@ -360,36 +664,205 @@ describe('OpenSearchDatasource', function (this: any) {
   });
 
   describe('PPL Queries', () => {
-    describe('When issuing time series format PPL Query', () => {
-      const defaultPPLQuery =
-        "source=`test` | where `@time` >= timestamp('2015-05-30 10:00:00') and `@time` <= timestamp('2015-06-01 10:00:00')";
+    const defaultPPLQuery =
+      "source=`test` | where `@time` >= timestamp('2015-05-30 10:00:00') and `@time` <= timestamp('2015-06-01 10:00:00')";
 
-      function setup(targets: OpenSearchQuery[]) {
-        createDatasource({
-          url: OPENSEARCH_MOCK_URL,
+    function setup(targets: OpenSearchQuery[]) {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        database: 'test',
+        jsonData: {
           database: 'test',
-          jsonData: {
-            database: 'test',
-            version: '1.0.0',
-            timeField: '@time',
-          } as OpenSearchOptions,
-        } as DataSourceInstanceSettings<OpenSearchOptions>);
+          version: '1.0.0',
+          timeField: '@time',
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
 
-        const options: DataQueryRequest<OpenSearchQuery> = {
-          requestId: '',
-          interval: '',
-          intervalMs: 1,
-          scopedVars: {},
-          timezone: '',
-          app: CoreApp.Dashboard,
-          startTime: 0,
-          range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-          targets,
-        };
+      const options: DataQueryRequest<OpenSearchQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 1,
+        scopedVars: {},
+        timezone: '',
+        app: CoreApp.Dashboard,
+        startTime: 0,
+        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+        targets,
+      };
 
-        return { ds: ctx.ds, options };
-      }
+      return { ds: ctx.ds, options };
+    }
 
+    describe('When issuing empty PPL Query', () => {
+      const payloads: any[] = [];
+
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+      ];
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation((options) => {
+          payloads.push(options);
+          return Promise.resolve({ data: { schema: [], datarows: [] } });
+        });
+      });
+
+      it('should send the correct data source request', async () => {
+        const { ds, options } = setup(targets);
+        await ds.query(options).toPromise();
+        expect(payloads.length).toBe(1);
+        expect(payloads[0].url).toBe(`${OPENSEARCH_MOCK_URL}/_opendistro/_ppl`);
+        expect(JSON.parse(payloads[0].data).query).toBe(defaultPPLQuery);
+      });
+
+      it('should handle the data source response', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options)).toEmitValuesWith((received) => {
+          const result = received[0];
+          expect(result).toEqual(
+            expect.objectContaining({
+              data: [],
+            })
+          );
+        });
+      });
+    });
+
+    describe('When issuing table format PPL Query', () => {
+      const payloads: any[] = [];
+
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: 'source=`test` | where age > 21 | fields firstname, lastname',
+          refId: 'A',
+          format: 'table' as PPLFormatType,
+          isLogsQuery: false,
+        },
+      ];
+
+      const pplTableResponse = {
+        data: {
+          schema: [
+            {
+              name: 'firstname',
+              type: 'string',
+            },
+            {
+              name: 'lastname',
+              type: 'string',
+            },
+          ],
+          datarows: [
+            ['Amber', 'Duke'],
+            ['Hattie', 'Bond'],
+          ],
+          size: 2,
+          total: 2,
+        },
+      };
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation((options) => {
+          payloads.push(options);
+          return Promise.resolve(pplTableResponse);
+        });
+      });
+
+      it('should send the correct data source request', async () => {
+        const { ds, options } = setup(targets);
+        await ds.query(options).toPromise();
+        const expectedQuery = `${defaultPPLQuery} | where age > 21 | fields firstname, lastname`;
+        expect(payloads.length).toBe(1);
+        expect(payloads[0].url).toBe(`${OPENSEARCH_MOCK_URL}/_opendistro/_ppl`);
+        expect(JSON.parse(payloads[0].data).query).toBe(expectedQuery);
+      });
+
+      it('should handle the data source response', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
+          const result = received[0];
+          const dataFrame = result.data[0];
+          expect(dataFrame.length).toBe(2);
+          expect(dataFrame.refId).toBe('A');
+          const fieldCache = new FieldCache(dataFrame);
+          const field = fieldCache.getFieldByName('lastname');
+          expect(field?.values.toArray()).toEqual(['Duke', 'Bond']);
+        });
+      });
+    });
+
+    describe('When issuing logs format PPL Query', () => {
+      const payloads: any[] = [];
+
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: 'source=`test` | fields clientip, response',
+          refId: 'B',
+          format: 'logs' as PPLFormatType,
+          isLogsQuery: false,
+        },
+      ];
+
+      const pplLogsResponse = {
+        data: {
+          schema: [
+            {
+              name: 'clientip',
+              type: 'string',
+            },
+            {
+              name: 'response',
+              type: 'string',
+            },
+          ],
+          datarows: [
+            ['10.0.0.1', '200'],
+            ['10.0.0.2', '200'],
+          ],
+          size: 2,
+          total: 2,
+        },
+      };
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation((options) => {
+          payloads.push(options);
+          return Promise.resolve(pplLogsResponse);
+        });
+      });
+
+      it('should send the correct data source request', async () => {
+        const { ds, options } = setup(targets);
+        await ds.query(options).toPromise();
+        const expectedQuery = `${defaultPPLQuery} | fields clientip, response`;
+        expect(payloads.length).toBe(1);
+        expect(payloads[0].url).toBe(`${OPENSEARCH_MOCK_URL}/_opendistro/_ppl`);
+        expect(JSON.parse(payloads[0].data).query).toBe(expectedQuery);
+      });
+
+      it('should handle the data source response', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
+          const result = received[0];
+          const dataFrame = result.data[0] as DataFrame;
+          expect(dataFrame.length).toBe(2);
+          expect(dataFrame.refId).toBe('B');
+          expect(dataFrame.meta?.preferredVisualisationType).toBe('logs');
+          const fieldCache = new FieldCache(dataFrame);
+          const field = fieldCache.getFieldByName('clientip');
+          expect(field?.values.toArray()).toEqual(['10.0.0.1', '10.0.0.2']);
+        });
+      });
+    });
+
+    describe('When issuing time series format PPL Query', () => {
       const payloads: any[] = [];
 
       const targets = [
@@ -448,57 +921,212 @@ describe('OpenSearchDatasource', function (this: any) {
       });
     });
 
-    describe('When using SigV4', () => {
-      it('should add correct header', async () => {
-        createDatasource({
-          url: OPENSEARCH_MOCK_URL,
-          jsonData: {
-            database: 'mock-index',
-            interval: 'Daily',
-            version: '1.0.0',
-            timeField: '@timestamp',
-            serverless: true,
-            sigV4Auth: true,
-          } as OpenSearchOptions,
-        } as DataSourceInstanceSettings<OpenSearchOptions>);
+    describe('When issuing two PPL Queries', () => {
+      const payloads: any[] = [];
 
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: 'source=`test` | fields firstname',
+          refId: 'A',
+          format: 'table' as PPLFormatType,
+          isLogsQuery: false,
+        },
+        {
+          queryType: QueryType.PPL,
+          query: 'source=`test` | fields lastname',
+          refId: 'B',
+          format: 'table' as PPLFormatType,
+          isLogsQuery: false,
+        },
+      ];
+
+      beforeAll(() => {
         datasourceRequestMock.mockImplementation((options) => {
-          return Promise.resolve({ data: { datarows: [] } });
+          payloads.push(options);
+          return Promise.resolve({ data: { schema: [], datarows: [] } });
         });
+      });
 
-        const query: DataQueryRequest<OpenSearchQuery> = {
-          range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2019, 7, 1, 10])),
-          app: CoreApp.Dashboard,
-          targets: [
-            {
-              queryType: QueryType.PPL,
-              query: 'source=`test` | stats count(response) by timestamp',
-              refId: 'C',
-              format: 'time_series' as PPLFormatType,
-              isLogsQuery: false,
+      it('should send the correct data source requests', async () => {
+        const { ds, options } = setup(targets);
+        await ds.query(options).toPromise();
+        const firstExpectedQuery = `${defaultPPLQuery} | fields firstname`;
+        const secondExpectedQuery = `${defaultPPLQuery} | fields lastname`;
+
+        expect(payloads.length).toBe(2);
+        expect(payloads.some((payload) => JSON.parse(payload.data).query === firstExpectedQuery));
+        expect(payloads.some((payload) => JSON.parse(payload.data).query === secondExpectedQuery));
+      });
+
+      it('should handle the data source responses', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
+          expect(received.length).toBe(2);
+          expect(received).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                data: [],
+              }),
+              expect.objectContaining({
+                data: [],
+              }),
+            ])
+          );
+          expect(received[0].key && received[1].key && received[0].key !== received[1].key).toBe(true);
+        });
+      });
+    });
+
+    describe('When issuing PPL query and Lucene query', () => {
+      const payloads: any[] = [];
+
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+        {
+          queryType: QueryType.Lucene,
+          query: '*',
+          refId: 'B',
+          isLogsQuery: false,
+        },
+      ];
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation((options) => {
+          payloads.push(options);
+          if (options.url === `${OPENSEARCH_MOCK_URL}/_opendistro/_ppl`) {
+            return Promise.resolve({ data: { schema: [], datarows: [] } });
+          } else {
+            return Promise.resolve({ data: { responses: [] } });
+          }
+        });
+      });
+
+      it('should send the correct data source requests', async () => {
+        const { ds, options } = setup(targets);
+        await ds.query(options).toPromise();
+        expect(payloads.length).toBe(2);
+        expect(payloads).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ url: `${OPENSEARCH_MOCK_URL}/_opendistro/_ppl` }),
+            expect.objectContaining({ url: `${OPENSEARCH_MOCK_URL}/_msearch` }),
+          ])
+        );
+      });
+
+      it('should handle the data source responses', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options)).toEmitValuesWith((received: OpenSearchDataQueryResponse[]) => {
+          expect(received.length).toBe(2);
+          expect(received).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                data: [],
+              }),
+              expect.objectContaining({
+                data: [],
+              }),
+            ])
+          );
+          expect(received[0].key && received[1].key && received[0].key !== received[1].key).toBe(true);
+        });
+      });
+    });
+
+    describe('When getting an error with reason in data source response', () => {
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+      ];
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation(() => {
+          return Promise.resolve({
+            data: {
+              error: {
+                reason: 'Error occurred in Elasticsearch engine: no such index [unknown]',
+                details: 'org.elasticsearch.index.IndexNotFoundException: no such index [unknown]',
+                type: 'IndexNotFoundException',
+              },
+              status: 404,
             },
-          ],
-        } as DataQueryRequest<OpenSearchQuery>;
+          });
+        });
+      });
 
-        await ctx.ds.query(query).toPromise();
+      it('should process it properly', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options).toPromise()).rejects.toEqual(
+          expect.objectContaining({
+            message: 'Error occurred in Elasticsearch engine: no such index [unknown]',
+          })
+        );
+      });
+    });
 
-        expect(datasourceRequestMock.mock.calls[0][0].headers['x-amz-content-sha256']).toBe(
-          '1aa9a464d987268adfb5fe62a7204876606358f2d96bb7dbe9c59cd8604624fa'
+    describe('When getting an empty error in data source response', () => {
+      const targets = [
+        {
+          queryType: QueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+      ];
+
+      beforeAll(() => {
+        datasourceRequestMock.mockImplementation(() => {
+          return Promise.resolve({
+            data: {
+              error: {},
+              status: 404,
+            },
+          });
+        });
+      });
+
+      it('should properly throw an unknown error', async () => {
+        const { ds, options } = setup(targets);
+        await expect(ds.query(options).toPromise()).rejects.toEqual(
+          expect.objectContaining({
+            message: 'Unknown OpenSearch error response',
+          })
         );
       });
     });
   });
 
-  describe('query migration to the backend', () => {
-    beforeAll(() => {
-      createDatasource({
+  describe('query', () => {
+    it('should replace range as integer not string', () => {
+      const dataSource = new OpenSearchDatasource({
         url: OPENSEARCH_MOCK_URL,
         jsonData: {
-          database: 'test',
+          database: '[asd-]YYYY.MM.DD',
+          interval: 'Daily',
           version: '1.0.0',
-        } as OpenSearchOptions,
+          timeField: '@time',
+        },
       } as DataSourceInstanceSettings<OpenSearchOptions>);
 
+      (dataSource as any).post = jest.fn(() => Promise.resolve({ responses: [] }));
+      dataSource.query(createOpenSearchQuery());
+
+      const query = ((dataSource as any).post as jest.Mock).mock.calls[0][1];
+      expect(typeof JSON.parse(query.split('\n')[1]).query.bool.filter[0].range['@time'].gte).toBe('number');
+    });
+  });
+
+  describe('query migration to the backend', () => {
+    beforeAll(() => {
       datasourceRequestMock.mockImplementation(() => {
         return Promise.resolve({
           data: {
@@ -507,7 +1135,6 @@ describe('OpenSearchDatasource', function (this: any) {
         });
       });
     });
-
     it('should send raw_data queries', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
@@ -525,7 +1152,6 @@ describe('OpenSearchDatasource', function (this: any) {
             },
           },
         ],
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -559,7 +1185,6 @@ describe('OpenSearchDatasource', function (this: any) {
             },
           },
         ],
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -620,7 +1245,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
-    it('should send Lucene logs queries in Explore', () => {
+    it('should send logs queries in Explore', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -645,7 +1270,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
-    it('should send Lucene metric max group by terms query in Explore', () => {
+    it('should send metric max group by terms query in Explore', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -689,7 +1314,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalled();
     });
 
-    it('should send Lucene metric average and derivative query in Explore', () => {
+    it('should send metric average and derivative query in Explore', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -789,7 +1414,7 @@ describe('OpenSearchDatasource', function (this: any) {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplTimeSeriesQuery: OpenSearchQuery = {
+      const pplLogsQuery: OpenSearchQuery = {
         refId: 'A',
         queryType: QueryType.PPL,
         format: 'time_series',
@@ -804,7 +1429,7 @@ describe('OpenSearchDatasource', function (this: any) {
         app: CoreApp.Explore,
         startTime: 0,
         range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplTimeSeriesQuery],
+        targets: [pplLogsQuery],
       };
       ctx.ds.query(request);
       expect(mockedSuperQuery).toHaveBeenCalled();
@@ -829,7 +1454,6 @@ describe('OpenSearchDatasource', function (this: any) {
           },
         ],
         bucketAggs: [],
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -867,7 +1491,6 @@ describe('OpenSearchDatasource', function (this: any) {
           },
         ],
         bucketAggs: [],
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -905,7 +1528,6 @@ describe('OpenSearchDatasource', function (this: any) {
           },
         ],
         bucketAggs: [],
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -923,7 +1545,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(mockedSuperQuery).toHaveBeenCalledWith(expectedRequest);
     });
 
-    it('should send Lucene logs queries in Dashboard to backend', () => {
+    it('does not send logs queries in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -931,7 +1553,6 @@ describe('OpenSearchDatasource', function (this: any) {
         refId: 'A',
         metrics: [{ type: 'logs', id: '1' }],
         query: 'foo="bar"',
-        queryType: QueryType.Lucene,
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -945,10 +1566,11 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [logsQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
     });
 
-    it('should send Lucene metric max group by terms in Dashboard to backend', () => {
+    it('does not send metric max group by terms in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -989,10 +1611,11 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [metricQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
     });
 
-    it('should send Lucene metric average and derivative query in Dashboard to backend', () => {
+    it('does not send metric average and derivative query in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -1035,10 +1658,11 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [metricQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
     });
 
-    it('should send PPL logs format queries in Dashboard to backend', () => {
+    it('does not send PPL logs format queries in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -1060,10 +1684,11 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [pplLogsQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
     });
 
-    it('should send PPL table format queries in Dashboard to backend', () => {
+    it('does not send PPL table format queries in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
@@ -1085,14 +1710,15 @@ describe('OpenSearchDatasource', function (this: any) {
         targets: [pplLogsQuery],
       };
       ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+      expect(mockedSuperQuery).not.toHaveBeenCalled();
+      expect(datasourceRequestMock).toHaveBeenCalled();
     });
 
     it('does not send PPL time series format queries in Dashboard to backend', () => {
       const mockedSuperQuery = jest
         .spyOn(DataSourceWithBackend.prototype, 'query')
         .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplTimeSeriesQuery: OpenSearchQuery = {
+      const pplLogsQuery: OpenSearchQuery = {
         refId: 'A',
         queryType: QueryType.PPL,
         format: 'time_series',
@@ -1107,7 +1733,7 @@ describe('OpenSearchDatasource', function (this: any) {
         app: CoreApp.Dashboard,
         startTime: 0,
         range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplTimeSeriesQuery],
+        targets: [pplLogsQuery],
       };
       ctx.ds.query(request);
       expect(mockedSuperQuery).not.toHaveBeenCalled();
@@ -1133,13 +1759,11 @@ describe('OpenSearchDatasource', function (this: any) {
           },
         ],
         bucketAggs: [],
-        queryType: QueryType.Lucene,
       };
-      const pplTimeSeriesQuery: OpenSearchQuery = {
+      const countQuery: OpenSearchQuery = {
         refId: 'A',
-        queryType: QueryType.PPL,
-        format: 'time_series',
-        query: 'source = test-index',
+        metrics: [{ type: 'count', id: '1' }],
+        query: 'foo="bar"',
       };
       const request: DataQueryRequest<OpenSearchQuery> = {
         requestId: '',
@@ -1150,7 +1774,7 @@ describe('OpenSearchDatasource', function (this: any) {
         app: CoreApp.Dashboard,
         startTime: 0,
         range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery, pplTimeSeriesQuery],
+        targets: [rawDataQuery, countQuery],
       };
       ctx.ds.query(request);
       expect(mockedSuperQuery).not.toHaveBeenCalled();
@@ -1158,34 +1782,32 @@ describe('OpenSearchDatasource', function (this: any) {
     });
   });
 
-  describe('interpolateVariablesInQueries', () => {
-    it('should correctly interpolate variables in query', () => {
-      const query: OpenSearchQuery = {
-        refId: 'A',
-        bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '$var', label: '' }] }, id: '1' }],
-        metrics: [{ type: 'count', id: '1' }],
-        query: '$var',
-      };
+  it('should correctly interpolate variables in query', () => {
+    const query: OpenSearchQuery = {
+      refId: 'A',
+      bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '$var', label: '' }] }, id: '1' }],
+      metrics: [{ type: 'count', id: '1' }],
+      query: '$var',
+    };
 
-      const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
+    const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
 
-      expect(interpolatedQuery.query).toBe('resolvedVariable');
-      expect((interpolatedQuery.bucketAggs![0] as Filters).settings!.filters![0].query).toBe('resolvedVariable');
-    });
+    expect(interpolatedQuery.query).toBe('resolvedVariable');
+    expect((interpolatedQuery.bucketAggs![0] as Filters).settings!.filters![0].query).toBe('resolvedVariable');
+  });
 
-    it('should correctly handle empty query strings', () => {
-      const query: OpenSearchQuery = {
-        refId: 'A',
-        bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '', label: '' }] }, id: '1' }],
-        metrics: [{ type: 'count', id: '1' }],
-        query: '',
-      };
+  it('should correctly handle empty query strings', () => {
+    const query: OpenSearchQuery = {
+      refId: 'A',
+      bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '', label: '' }] }, id: '1' }],
+      metrics: [{ type: 'count', id: '1' }],
+      query: '',
+    };
 
-      const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
+    const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
 
-      expect(interpolatedQuery.query).toBe('*');
-      expect((interpolatedQuery.bucketAggs![0] as Filters).settings!.filters![0].query).toBe('*');
-    });
+    expect(interpolatedQuery.query).toBe('*');
+    expect((interpolatedQuery.bucketAggs![0] as Filters).settings!.filters![0].query).toBe('*');
   });
 
   describe('getSupportedQueryTypes', () => {
@@ -1242,6 +1864,130 @@ describe('OpenSearchDatasource', function (this: any) {
       await expect(() => ctx.ds.getOpenSearchVersion()).rejects.toThrow(
         'ElasticSearch version 7.11.1 is not supported by the OpenSearch plugin. Use the ElasticSearch plugin.'
       );
+    });
+  });
+  describe('#executeLuceneQueries', () => {
+    beforeEach(() => {
+      createDatasource({
+        uid: 'test',
+        name: 'opensearch',
+        type: 'opensearch',
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: '[asd-]YYYY.MM.DD',
+          interval: 'Daily',
+          version: '1.0.0',
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+    });
+    const logsTarget: OpenSearchQuery = {
+      refId: 'logs',
+      isLogsQuery: true,
+      query: 'logsQuery',
+    };
+    const traceTarget: OpenSearchQuery = {
+      refId: 'trace',
+      luceneQueryType: LuceneQueryType.Traces,
+      query: 'traceId: test',
+    };
+    const traceListTarget = (refId: string): OpenSearchQuery => ({
+      refId,
+      query: 'traceListQuery',
+      luceneQueryType: LuceneQueryType.Traces,
+    });
+    const metricsTarget = (refId: string): OpenSearchQuery => ({
+      refId,
+      isLogsQuery: false,
+      query: 'metricsQuery',
+      luceneQueryType: LuceneQueryType.Metric,
+      metrics: [
+        {
+          type: 'count',
+        } as MetricAggregation,
+      ],
+    });
+    it('can handle multiple metrics queries', async () => {
+      const mockResponses = {
+        responses: [emptyMetricsResponse.data.responses[0], emptyMetricsResponse.data.responses[0]],
+      };
+      datasourceRequestMock.mockImplementation((options) => {
+        return Promise.resolve({
+          data: mockResponses,
+        });
+      });
+      const result = await lastValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([metricsTarget('metrics1'), metricsTarget('metrics2')]),
+        })
+      );
+      expect(result.data[0].refId).toEqual('metrics1');
+      expect(result.data[1].refId).toEqual('metrics2');
+    });
+    it('can handle a metrics and a trace list query', async () => {
+      datasourceRequestMock.mockImplementation((options) => {
+        if (options.data.includes('traceList')) {
+          return Promise.resolve(emptyTraceListResponse);
+        } else {
+          return Promise.resolve(emptyMetricsResponse);
+        }
+      });
+      const resultTraceList = await firstValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([traceListTarget('traceList'), metricsTarget('metrics')]),
+        })
+      );
+      expect(resultTraceList.data[0].refId).toEqual('traceList');
+
+      const resultMetrics = await lastValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([traceListTarget('traceList'), metricsTarget('metrics')]),
+        })
+      );
+      expect(resultMetrics.data[0].refId).toEqual('metrics');
+    });
+    it('can handle a metrics and a trace  query', async () => {
+      datasourceRequestMock.mockImplementation((options) => {
+        if (options.data.includes('traceId')) {
+          return Promise.resolve(emptyTraceDetailsResponse);
+        } else {
+          return Promise.resolve(emptyMetricsResponse);
+        }
+      });
+      const resultTrace = await firstValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([traceTarget, metricsTarget('metrics')]),
+        })
+      );
+      expect(resultTrace.data[0].refId).toEqual('trace');
+
+      const resultMetrics = await lastValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([traceTarget, metricsTarget('metrics')]),
+        })
+      );
+      expect(resultMetrics.data[0].refId).toEqual('metrics');
+    });
+    it('can handle a logs and a trace details  query', async () => {
+      datasourceRequestMock.mockImplementation((options) => {
+        if (options.data.includes('traceId')) {
+          return Promise.resolve(emptyTraceDetailsResponse);
+        } else {
+          return Promise.resolve(logsResponse);
+        }
+      });
+      const result1 = await firstValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([logsTarget, traceTarget]),
+        })
+      );
+      expect(result1.data[0].refId).toEqual('trace');
+
+      const result2 = await lastValueFrom(
+        ctx.ds.query({
+          ...createOpenSearchQuery([logsTarget, traceTarget]),
+        })
+      );
+      expect(result2.data[0].refId).toEqual('logs');
     });
   });
 
@@ -1365,7 +2111,6 @@ describe('OpenSearchDatasource', function (this: any) {
       });
     });
   });
-
   describe('Data links', () => {
     it('should add links to dataframe for logs queries in the backend flow', async () => {
       createDatasource({
@@ -1476,6 +2221,130 @@ describe('enhanceDataFrame', () => {
   });
 });
 
+const createOpenSearchQuery = (targets?: OpenSearchQuery[]): DataQueryRequest<OpenSearchQuery> => {
+  return {
+    requestId: '',
+    interval: '',
+    panelId: 0,
+    intervalMs: 1,
+    scopedVars: {},
+    timezone: '',
+    app: CoreApp.Dashboard,
+    startTime: 0,
+    range: {
+      from: dateTime([2015, 4, 30, 10]),
+      to: dateTime([2015, 5, 1, 10]),
+    } as any,
+    targets: targets ?? [
+      {
+        refId: '',
+        isLogsQuery: false,
+        bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '2' }],
+        metrics: [{ type: 'count', id: '' }],
+        query: 'test',
+      },
+    ],
+  };
+};
+
+const logsResponse = {
+  data: {
+    responses: [
+      {
+        aggregations: {
+          '2': {
+            buckets: [
+              {
+                doc_count: 10,
+                key: 1000,
+              },
+              {
+                doc_count: 15,
+                key: 2000,
+              },
+            ],
+          },
+        },
+        hits: {
+          hits: [
+            {
+              '@timestamp': ['2019-06-24T09:51:19.765Z'],
+              _id: 'iAmID',
+              _type: '_doc',
+              _index: 'mock-index',
+              _source: {
+                '@timestamp': '2019-06-24T09:51:19.765Z',
+                host: 'iAmAHost',
+                message: 'hello, i am a message',
+              },
+              fields: {
+                '@timestamp': ['2019-06-24T09:51:19.765Z'],
+              },
+            },
+            {
+              '@timestamp': ['2019-06-24T09:52:19.765Z'],
+              _id: 'iAmAnotherID',
+              _type: '_doc',
+              _index: 'mock-index',
+              _source: {
+                '@timestamp': '2019-06-24T09:52:19.765Z',
+                host: 'iAmAnotherHost',
+                message: 'hello, i am also message',
+              },
+              fields: {
+                '@timestamp': ['2019-06-24T09:52:19.765Z'],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const emptyTraceListResponse = {
+  data: {
+    responses: [
+      {
+        aggregations: {
+          traces: {
+            buckets: [],
+          },
+        },
+      },
+    ],
+  },
+};
+
+const emptyTraceDetailsResponse = {
+  data: {
+    responses: [
+      {
+        hits: { hits: [] },
+      },
+    ],
+  },
+};
+const emptyMetricsResponse = {
+  data: {
+    responses: [
+      {
+        aggregations: {
+          '1': {
+            buckets: [
+              { doc_count: 1, key: 'test' },
+              {
+                doc_count: 2,
+                key: 'test2',
+                key_as_string: 'test2_as_string',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+};
 const dataLinkResponse: DataQueryResponse = {
   data: [
     {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -535,7 +535,14 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     if (
       request.targets.every(
         (target) =>
-          !(target.queryType === QueryType.PPL && target.format === 'time_series' && request.app === CoreApp.Dashboard)
+          target.metrics?.every(
+            (metric) =>
+              metric.type === 'raw_data' ||
+              metric.type === 'raw_document' ||
+              (request.app === CoreApp.Explore && target.queryType === QueryType.Lucene)
+          ) ||
+          (request.app === CoreApp.Explore && target.queryType === QueryType.PPL) ||
+          target.luceneQueryType === LuceneQueryType.Traces
       )
     ) {
       // @ts-ignore


### PR DESCRIPTION
Seems like switching Lucene and PPL queries to the backend in Dashboards broke some queries (#https://github.com/grafana/opensearch-datasource/issues/389 and https://github.com/grafana/opensearch-datasource/issues/388). Reverting it until we're able to debug and fix the issues.