### PR TITLE
Fix: Add fields to frame if it does not already exist when grouping by multiple terms

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -1016,8 +1016,7 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 		for _, e := range fields {
 			for _, propKey := range propKeys {
 				if e.Name == propKey {
-					value := props[propKey]
-					e.Append(&value)
+					e.Append(utils.Pointer(props[propKey]))
 				}
 			}
 			if e.Name == aggDef.Field {

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -999,7 +999,7 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 	frames := data.Frames{}
 	var fields []*data.Field
 
-	if queryResult.Frames != nil && len(queryResult.Frames) != 0 {
+	if len(queryResult.Frames) != 0 {
 		for _, frame := range queryResult.Frames {
 			fields = append(fields, frame.Fields...)
 		}

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -999,7 +999,11 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 	frames := data.Frames{}
 	var fields []*data.Field
 
-	if queryResult.Frames == nil {
+	if queryResult.Frames != nil && len(queryResult.Frames) != 0 {
+		for _, frame := range queryResult.Frames {
+			fields = append(fields, frame.Fields...)
+		}
+	} else {
 		for _, propKey := range propKeys {
 			fields = append(fields, data.NewField(propKey, nil, []*string{}))
 		}
@@ -1012,7 +1016,8 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 		for _, e := range fields {
 			for _, propKey := range propKeys {
 				if e.Name == propKey {
-					e.Append(props[propKey])
+					value := props[propKey]
+					e.Append(&value)
 				}
 			}
 			if e.Name == aggDef.Field {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Multiple group by terms would only have the final group by term processed and added to the frame when executing on the backend.

This PR updates the way the frame is built up when processing aggregations. If the frame does not have any fields yet, the `propKeys` are added as fields (this will include all of the terms except the final term), otherwise if the frame already has fields, it will use those existing fields.

**Which issue(s) this PR fixes**:

Fixes #391 

**Special notes for your reviewer**:

Sending queries to the backend needs to be reenabled for this to work. Change the following condition in `datasource.ts`

```ts
      request.targets.every(
        (target) =>
          target.metrics?.every(
            (metric) =>
              metric.type === 'raw_data' ||
              metric.type === 'raw_document' ||
              (request.app === CoreApp.Explore && target.queryType === QueryType.Lucene)
          ) ||
          (request.app === CoreApp.Explore && target.queryType === QueryType.PPL) ||
          target.luceneQueryType === LuceneQueryType.Traces
      )
```

to the following

```ts
      request.targets.every(
        (target) =>
          !(target.queryType === QueryType.PPL && target.format === 'time_series' && request.app === CoreApp.Dashboard)
      )
```

We can reenable sending queries to the backend after the remaining backend migration related bugs are fixed.

Here's an example of a query you can test with. It just needs to have at least 2 group by terms.

<img width="1142" alt="Screenshot 2024-05-22 at 2 54 32 PM" src="https://github.com/grafana/opensearch-datasource/assets/19530599/b452c32e-b4e7-4c1f-9981-bb8e06590e2a">

