### PR TITLE
Add Stalebot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    # run at 1:30 every day
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # start from the oldest issues/PRs when performing stale operations
+          ascending: true
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          exempt-issue-labels: no stalebot,type/epic
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 30 days. Thank you for your contributions!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # start from the oldest issues/PRs when performing stale operations
+          # start from the oldest issues when performing stale operations
           ascending: true
           days-before-issue-stale: 365
           days-before-issue-close: 30


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

- This PR adds a workflow to mark issues as stale after 1 year of no activity, then closing it 30 days after marked as stale.
- This is the same workflow that is present in grafana/grafana.
- Do we want to try this in some data source repos?

