### PR TITLE
Improve error message by handling caused_by.reason

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -1342,12 +1342,15 @@ func getErrorFromOpenSearchResponse(response *client.SearchResponse) error {
 	json := utils.NewJsonFromAny(response.Error)
 	reason := json.Get("reason").MustString()
 	rootCauseReason := json.Get("root_cause").GetIndex(0).Get("reason").MustString()
+	causedByReason := json.Get("caused_by").Get("reason").MustString()
 
 	switch {
 	case rootCauseReason != "":
 		err = errors.New(rootCauseReason)
 	case reason != "":
 		err = errors.New(reason)
+	case causedByReason != "":
+		err = errors.New(causedByReason)
 	default:
 		err = errors.New("unknown OpenSearch error response")
 	}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Lucene query error responses sometimes have the error message in the `caused_by.reason` property. This handles that case so the user can get a more helpful error message instead of "unknown OpenSearch error response" (see #400)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Use the provisioned "AWS OpenSearch" data source with the following query in Explore. It show the error message shown in the screenshot instead of "unknown OpenSearch error response"

<img width="2395" alt="Screenshot 2024-05-29 at 12 08 54 PM" src="https://github.com/grafana/opensearch-datasource/assets/19530599/38164513-8ec9-4a09-ab29-7f2a5d5bf6d6">