### PR TITLE
Use application/x-ndjson content type for multisearch requests

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -114,5 +114,6 @@
     "Throughputs",
     "mainstat",
     "secondarystat",
+    "x-ndjson"
   ]
 }

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -299,7 +299,7 @@ func (c *baseClientImpl) executeRequest(ctx context.Context, method, uriPath, ur
 	}
 
 	req.Header.Set("User-Agent", "Grafana")
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/x-ndjson")
 
 	dsHttpOpts, err := c.ds.HTTPClientOptions(ctx)
 	if err != nil {

--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -91,6 +91,7 @@ func TestClient(t *testing.T) {
 					assert.NotNil(t, sc.request)
 					assert.Equal(t, http.MethodPost, sc.request.Method)
 					assert.Equal(t, "/_msearch", sc.request.URL.Path)
+					assert.Equal(t, "application/x-ndjson", sc.request.Header.Get("Content-Type"))
 					assert.Equal(t, "max_concurrent_shard_requests=6", sc.request.URL.RawQuery)
 
 					assert.NotNil(t, sc.requestBody)
@@ -178,6 +179,7 @@ func TestClient(t *testing.T) {
 					assert.NotNil(t, sc.request)
 					assert.Equal(t, http.MethodPost, sc.request.Method)
 					assert.Equal(t, "/_opendistro/_ppl", sc.request.URL.Path)
+					assert.Equal(t, "application/json", sc.request.Header.Get("Content-Type"))
 
 					assert.NotNil(t, sc.requestBody)
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -21,7 +21,14 @@ import { OpenSearchResponse } from './OpenSearchResponse';
 import { IndexPattern } from './index_pattern';
 import { QueryBuilder } from './QueryBuilder';
 import { defaultBucketAgg, hasMetricOfType } from './query_def';
-import { DataSourceWithBackend, FetchError, getBackendSrv, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
+import {
+  BackendSrvRequest,
+  DataSourceWithBackend,
+  FetchError,
+  getBackendSrv,
+  getDataSourceSrv,
+  getTemplateSrv,
+} from '@grafana/runtime';
 import { DataLinkConfig, Flavor, LuceneQueryType, OpenSearchOptions, OpenSearchQuery, QueryType } from './types';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 import {
@@ -103,26 +110,25 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     this.sigV4Auth = settingsData.sigV4Auth ?? false;
   }
 
-  private async request(method: string, url: string, data?: undefined) {
-    const options: any = {
+  private async request(method: string, url: string, data?: undefined, headers?: BackendSrvRequest['headers']) {
+    const options: BackendSrvRequest = {
       url: this.url + '/' + url,
-      method: method,
-      data: data,
+      method,
+      data,
     };
+    options.headers = headers ?? {};
 
     if (this.basicAuth || this.withCredentials) {
       options.withCredentials = true;
     }
-    const tempHeaders: { Authorization?: string; 'x-amz-content-sha256'?: string } = {};
+
     if (this.basicAuth) {
-      tempHeaders.Authorization = this.basicAuth;
+      options.headers.Authorization = this.basicAuth;
     }
 
     if (this.sigV4Auth && data) {
-      tempHeaders['x-amz-content-sha256'] = await sha256(data);
+      options.headers['x-amz-content-sha256'] = await sha256(data);
     }
-
-    options.headers = tempHeaders;
 
     return getBackendSrv()
       .datasourceRequest(options)
@@ -175,8 +181,12 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     }
   }
 
-  private post(url: string, data: any) {
-    return this.request('POST', url, data).then((results: any) => {
+  private postMultiSearch(url: string, data: any) {
+    return this.post(url, data, { 'Content-Type': 'application/x-ndjson' });
+  }
+
+  private post(url: string, data: any, headers?: BackendSrvRequest['headers']) {
+    return this.request('POST', url, data, headers).then((results: any) => {
       results.data.$$config = results.config;
       return results.data;
     });
@@ -252,7 +262,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
 
     const payload = JSON.stringify(header) + '\n' + JSON.stringify(data) + '\n';
 
-    return this.post('_msearch', payload).then((res: any) => {
+    return this.postMultiSearch('_msearch', payload).then((res: any) => {
       const list = [];
       const hits = res.responses[0].hits.hits;
 
@@ -651,7 +661,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
 
     const traceList$ =
       traceListTargets.length > 0
-        ? from(this.post(this.getMultiSearchUrl(), createQuery(traceListTargets))).pipe(
+        ? from(this.postMultiSearch(this.getMultiSearchUrl(), createQuery(traceListTargets))).pipe(
             map((res: any) => {
               return createListTracesDataFrame(traceListTargets, res, this.uid, this.name, this.type);
             })
@@ -660,7 +670,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
 
     const traceDetails$ =
       traceTargets.length > 0
-        ? from(this.post(this.getMultiSearchUrl(), createQuery(traceTargets))).pipe(
+        ? from(this.postMultiSearch(this.getMultiSearchUrl(), createQuery(traceTargets))).pipe(
             map((res: any) => {
               return createTraceDataFrame(traceTargets, res);
             })
@@ -668,7 +678,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
         : null;
     const otherQueries$ =
       otherTargets.length > 0
-        ? from(this.post(this.getMultiSearchUrl(), createQuery(otherTargets))).pipe(
+        ? from(this.postMultiSearch(this.getMultiSearchUrl(), createQuery(otherTargets))).pipe(
             map((res: any) => {
               const er = new OpenSearchResponse(otherTargets, res);
               // this condition that checks if some targets are logs, and if some are, enhance ALL data frames, even the ones that aren't
@@ -907,7 +917,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
 
     const url = this.getMultiSearchUrl();
 
-    return this.post(url, esQuery).then((res: any) => {
+    return this.postMultiSearch(url, esQuery).then((res: any) => {
       if (!res.responses[0].aggregations) {
         return [];
       }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Elasticsearch multisearch expects the content-type to be `application/x-ndjson` instead of `application/json` ([docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html#search-multi-search-api-desc)) so it causes issues with some reverse proxies. This corrects the content-type.

**Which issue(s) this PR fixes**:

Fixes #164

**Special notes for your reviewer**:

based on similar work in elastic https://github.com/grafana/grafana/pull/32282
