### PR TITLE
Bugfix: Pass docvalue_fields for elasticsearch

### DIFF
--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -93,9 +93,10 @@ func (b *SearchRequestBuilder) Sort(order, field, unmappedType string) *SearchRe
 	return b
 }
 
-func (b *SearchRequestBuilder) AppendDocValueFields(field string) {
+func (b *SearchRequestBuilder) AddDocValueFields(field string) {
 	if b.version.Major() < 5 && b.flavor == Elasticsearch {
 		if b.customProps["fields"] == nil {
+			//'fields' is a list of strings or maps
 			b.customProps["fields"] = []any{"*", "_source"}
 		} else {
 			b.customProps["fields"] = append(b.customProps["fields"].([]any), "*", "_source")
@@ -112,6 +113,7 @@ const timeFormat = "strict_date_optional_time_nanos"
 func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string, luceneQueryType string) {
 	if b.flavor == Elasticsearch {
 		if b.version.Major() >= 5 && b.version.Major() <= 7 {
+			// 'docvalue_fields', 'fields' etc. is a list of strings or maps
 			b.customProps["docvalue_fields"] = []any{map[string]string{"field": timeField, "format": timeFormat}}
 		} else {
 			if b.version.Major() < 5 && luceneQueryType == "logs" {

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -107,14 +107,17 @@ func (b *SearchRequestBuilder) SetCustomProps(timeField string, luceneQueryType 
 	// defaults - OpenSearch or Elasticsearch > 7
 	var key = "fields"
 	var value any = []any{map[string]string{"field": timeField, "format": timeFormat}}
+	if b.flavor == OpenSearch && luceneQueryType == "logs" {
+		b.customProps["docvalue_fields"] = []any{timeField}
+	}
 	if b.flavor == Elasticsearch {
 		if b.version.Major() >= 5 && b.version.Major() <= 7 {
 			key = "docvalue_fields"
 		} else {
 			if b.version.Major() < 5 && luceneQueryType == "logs" {
-				key = "fielddata_fields"
-				value = timeField
-				b.customProps["fields"] = []any{"*", "_source"}
+				b.customProps["fielddata_fields"] = []any{timeField}
+				b.customProps["fields"] = []any{"*", "_source", value}
+				return
 			}
 		}
 	}

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -184,7 +184,7 @@ func TestSearchRequest(t *testing.T) {
 		t.Run("When adding doc value field", func(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
-			b.AddTimeFieldWithStandardizedFormat(timeField, "logs")
+			b.SetCustomProps(timeField, "logs")
 
 			t.Run("should set correct props", func(t *testing.T) {
 				fields, ok := b.customProps["fields"].([]any)
@@ -204,7 +204,7 @@ func TestSearchRequest(t *testing.T) {
 		t.Run("When adding timestamp format should add new time format field if it doesn't exist", func(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
-			b.AddTimeFieldWithStandardizedFormat(timeField)
+			b.SetCustomProps(timeField)
 
 			fields, ok := b.customProps["fields"].([]map[string]string)
 			assert.True(t, ok)
@@ -216,7 +216,7 @@ func TestSearchRequest(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
 			b.AddDocValueField(timeField)
-			b.AddTimeFieldWithStandardizedFormat(timeField)
+			b.SetCustomProps(timeField)
 
 			fields, ok := b.customProps["fields"].([]any)
 			assert.True(t, ok)
@@ -232,7 +232,7 @@ func TestSearchRequest(t *testing.T) {
 		t.Run("When adding timestamp format should add new time format field", func(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
-			b.AddTimeFieldWithStandardizedFormat(timeField)
+			b.SetCustomProps(timeField)
 
 			fields, ok := b.customProps["docvalue_fields"].([]map[string]string)
 			assert.True(t, ok)
@@ -244,7 +244,7 @@ func TestSearchRequest(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
 			b.AddDocValueField(timeField)
-			b.AddTimeFieldWithStandardizedFormat(timeField)
+			b.SetCustomProps(timeField)
 
 			fields, ok := b.customProps["docvalue_fields"].([]any)
 			assert.True(t, ok)

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -155,7 +155,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.True(t, ok)
 				assert.Len(t, scriptFields, 0)
 
-				docValueFields, ok := b.customProps["docvalue_fields"].([]string)
+				docValueFields, ok := b.customProps["docvalue_fields"].([]any)
 				assert.True(t, ok)
 				assert.Len(t, docValueFields, 1)
 				assert.Equal(t, timeField, docValueFields[0])
@@ -205,7 +205,7 @@ func TestSearchRequest(t *testing.T) {
 				assert.True(t, ok)
 				assert.Len(t, scriptFields, 0)
 
-				fieldDataFields, ok := b.customProps["fielddata_fields"].([]string)
+				fieldDataFields, ok := b.customProps["fielddata_fields"].([]any)
 				assert.True(t, ok)
 				assert.Len(t, fieldDataFields, 1)
 				assert.Equal(t, timeField, fieldDataFields[0])

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -213,7 +213,7 @@ func TestSearchRequest(t *testing.T) {
 			})
 		})
 
-		t.Run("When adding timestamp format should add new time format field if it doesnt exist", func(t *testing.T) {
+		t.Run("When adding timestamp format should add new time format field if it doesn't exist", func(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
 			b.AddTimeFieldWithStandardizedFormat(timeField)

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -151,10 +151,6 @@ func TestSearchRequest(t *testing.T) {
 			t.Run("should set correct props", func(t *testing.T) {
 				assert.Nil(t, b.customProps["fields"])
 
-				scriptFields, ok := b.customProps["script_fields"].(map[string]interface{})
-				assert.True(t, ok)
-				assert.Len(t, scriptFields, 0)
-
 				docValueFields, ok := b.customProps["docvalue_fields"].([]any)
 				assert.True(t, ok)
 				assert.Len(t, docValueFields, 1)
@@ -170,10 +166,6 @@ func TestSearchRequest(t *testing.T) {
 					assert.NoError(t, err)
 					json, err := simplejson.NewJson(body)
 					assert.NoError(t, err)
-
-					scriptFields, err := json.Get("script_fields").Map()
-					assert.NoError(t, err)
-					assert.Len(t, scriptFields, 0)
 
 					_, err = json.Get("fields").StringArray()
 					assert.Error(t, err)
@@ -192,7 +184,7 @@ func TestSearchRequest(t *testing.T) {
 		t.Run("When adding doc value field", func(t *testing.T) {
 			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
 
-			b.AddDocValueField(timeField)
+			b.AddTimeFieldWithStandardizedFormat(timeField, "logs")
 
 			t.Run("should set correct props", func(t *testing.T) {
 				fields, ok := b.customProps["fields"].([]any)
@@ -200,10 +192,6 @@ func TestSearchRequest(t *testing.T) {
 				assert.Len(t, fields, 2)
 				assert.Equal(t, "*", fields[0])
 				assert.Equal(t, "_source", fields[1])
-
-				scriptFields, ok := b.customProps["script_fields"].(map[string]interface{})
-				assert.True(t, ok)
-				assert.Len(t, scriptFields, 0)
 
 				fieldDataFields, ok := b.customProps["fielddata_fields"].([]any)
 				assert.True(t, ok)

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -119,9 +119,8 @@ func getTraceId(rawQuery string) string {
 func processLogsQuery(q *Query, b *client.SearchRequestBuilder, from, to int64, defaultTimeField string) {
 	metric := q.Metrics[0]
 	b.Sort(descending, defaultTimeField, "boolean")
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, "logs")
-	b.AddDocValueFields(defaultTimeField)
-	
+	b.SetCustomProps(defaultTimeField, "logs")
+
 	sizeString := metric.Settings.Get("size").MustString()
 	size, err := strconv.Atoi(sizeString)
 	if err != nil {
@@ -165,7 +164,7 @@ func processDocumentQuery(q *Query, b *client.SearchRequestBuilder, defaultTimeF
 	order := metric.Settings.Get("order").MustString()
 	b.Sort(order, defaultTimeField, "boolean")
 	b.Sort(order, "_doc", "")
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, "raw_document")
+	b.SetCustomProps(defaultTimeField, "raw_document")
 	sizeString := metric.Settings.Get("size").MustString()
 	size, err := strconv.Atoi(sizeString)
 	if err != nil {
@@ -323,7 +322,7 @@ func getParametersFromServiceMapResult(smResult *client.SearchResponse) ([]strin
 	// ensure consistent order for the snapshot tests in lucene_service_map_test.go
 	sort.Strings(services)
 	sort.Strings(operations)
-	
+
 	return services, operations
 }
 

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -119,8 +119,9 @@ func getTraceId(rawQuery string) string {
 func processLogsQuery(q *Query, b *client.SearchRequestBuilder, from, to int64, defaultTimeField string) {
 	metric := q.Metrics[0]
 	b.Sort(descending, defaultTimeField, "boolean")
-	b.AddDocValueField(defaultTimeField)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, "logs")
+	b.AppendDocValueFields(defaultTimeField)
+	
 	sizeString := metric.Settings.Get("size").MustString()
 	size, err := strconv.Atoi(sizeString)
 	if err != nil {
@@ -164,7 +165,7 @@ func processDocumentQuery(q *Query, b *client.SearchRequestBuilder, defaultTimeF
 	order := metric.Settings.Get("order").MustString()
 	b.Sort(order, defaultTimeField, "boolean")
 	b.Sort(order, "_doc", "")
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, "raw_document")
 	sizeString := metric.Settings.Get("size").MustString()
 	size, err := strconv.Atoi(sizeString)
 	if err != nil {

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -120,7 +120,7 @@ func processLogsQuery(q *Query, b *client.SearchRequestBuilder, from, to int64, 
 	metric := q.Metrics[0]
 	b.Sort(descending, defaultTimeField, "boolean")
 	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, "logs")
-	b.AppendDocValueFields(defaultTimeField)
+	b.AddDocValueFields(defaultTimeField)
 	
 	sizeString := metric.Settings.Get("size").MustString()
 	size, err := strconv.Atoi(sizeString)

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -88,7 +88,7 @@ func handleServiceMapPrefetch(ctx context.Context, osClient client.Client, req *
 		queryType := model.Get("queryType").MustString()
 		luceneQueryType := model.Get("luceneQueryType").MustString()
 		serviceMapRequested := model.Get("serviceMap").MustBool(false)
-		if queryType == Lucene && luceneQueryType == "Traces" && serviceMapRequested {
+		if queryType == Lucene && luceneQueryType == luceneQueryTypeTraces && serviceMapRequested {
 			prefetchQuery := createServiceMapPrefetchQuery(query)
 			q := newQueryRequest(osClient, []backend.DataQuery{prefetchQuery}, req.PluginContext.DataSourceInstanceSettings, intervalCalculator)
 			response, err := q.execute(ctx)

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -94,7 +94,7 @@ func parse(reqQueries []backend.DataQuery) ([]*Query, error) {
 		// For queries requesting the service map, we inject extra queries to handle retrieving
 		// the required information
 		hasServiceMap := model.Get("serviceMap").MustBool(false)
-		if luceneQueryType == "Traces" && hasServiceMap {
+		if luceneQueryType == luceneQueryTypeTraces && hasServiceMap {
 			// The Prefetch request is used by itself for internal use, to get the parameters
 			// necessary for the Stats request. In this case there's no original query to
 			// pass along, so we continue below.

--- a/pkg/opensearch/snapshot_tests/lucene_logs_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_logs_test.go
@@ -41,7 +41,7 @@ func Test_logs_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"1":{"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"script_fields":{},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}}]}
+{"aggs":{"1":{"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}}]}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
We had a bug reported in https://github.com/grafana/opensearch-datasource/issues/388#issuecomment-2125144165 where logs queries to ElasticSearch v7.8.1 with OpenSearch plugin were returning No Data. The reason for this was that we're sending "fields" [here](https://github.com/grafana/opensearch-datasource/blob/c8067fcf6c7ed0e30cad4854869286c8ca7f61be/pkg/opensearch/client/search_request.go#L110) to OpenSearch with the timestamp format we desire. 
ElasticSearch api, however, expects `docvalue_fields` instead, so it returns no data. Older versions of Elastic expect `fields` as well. 

There was also some refactoring, since without it, the time field was in some cases added twice in `fields` or `docvalue_fields` (e.g. `docvalue_fields: ["@timestamp", {"field": "@timestamp", "format": "date_time"}]`
- Moved adding the `timeField` to `AddTimeFieldWithStandardizedFormat`, where the field, along with its formatting will be added according to the flavor and version. Still not sure if `fielddata_fields` is completely necessary, but since it's only for Elastic < 5 and logs queries, it might not be relevant in time if we decide to deprecate. The same goes for the new version of `AddDocValueFields` function
- removed `script_fields` field since it doesn't seem to be used anywhere


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/opensearch-datasource/issues/405

**Special notes for your reviewer**:
To test with Elastic 7.8.1: 
- run make devenv sources=elasticstack elastic_version=7.8. and make run in main Grafana
- open http://localhost:5601/app/kibana#/home/tutorial_directory/logging and add some sample data (Sample web logs)
- add a new OpenS datasource with this config
<img src="https://github.com/grafana/opensearch-datasource/assets/16140639/d3fbeb9c-7aff-4286-995c-b728e082f05f" width="200"/>

- make a logs query/raw document query
- there should be data shown
