### PR TITLE
Backend migration: Send all queries to backend if openSearchBackendFlow toggle is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.16.1
+
+- Send all queries to backend if feature toggle is enabled in [#409](https://github.com/grafana/opensearch-datasource/pull/409)
+
 ## 2.16.0
 
 - Bugfix: Pass docvalue_fields for elasticsearch in the backend flow in [#404](https://github.com/grafana/opensearch-datasource/pull/404)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -20,7 +20,7 @@ import { enhanceDataFrame, OpenSearchDatasource } from './datasource';
 import { PPLFormatType } from './components/QueryEditor/PPLFormatEditor/formats';
 // import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 // @ts-ignore
-import { getBackendSrv, getTemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
+import { getBackendSrv, getTemplateSrv, DataSourceWithBackend, config } from '@grafana/runtime';
 import {
   Flavor,
   LuceneQueryType,
@@ -62,9 +62,9 @@ jest.mock('@grafana/runtime', () => ({
     };
   },
   getTemplateSrv: () => ({
-    replace: jest.fn((text: string) => {
+    replace: jest.fn((text: string | undefined) => {
       // Replace all $ words, except global variables ($__interval, $__interval_ms, etc.) - they get interpolated on the BE
-      const resolved = text.replace(/\$(?!__)\w+/g, "resolvedVariable");
+      const resolved = text?.replace(/\$(?!__)\w+/g, "resolvedVariable") ?? '';
       return resolved;
     }),
     getAdhocFilters: getAdHocFiltersMock,
@@ -1123,7 +1123,6 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(typeof JSON.parse(query.split('\n')[1]).query.bool.filter[0].range['@time'].gte).toBe('number');
     });
   });
-
   describe('query migration to the backend', () => {
     beforeAll(() => {
       datasourceRequestMock.mockImplementation(() => {
@@ -1134,543 +1133,167 @@ describe('OpenSearchDatasource', function (this: any) {
         });
       });
     });
-    it('should send raw_data queries', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const rawDataQuery: OpenSearchQuery = {
-        refId: 'A',
+    const testQueries: Array<OpenSearchQuery & { testCaseName: string }> = [
+      {
+        testCaseName: "Lucene raw_data",
+        refId: "A",
         metrics: [
           {
-            id: '1',
-            type: 'raw_data',
+            id: "1",
+            type: "raw_data",
             settings: {
-              size: '500',
-              order: 'desc',
+              size: "500",
+              order: "desc",
               useTimeRange: true,
             },
           },
         ],
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send raw_document queries', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const rawDataQuery: OpenSearchQuery = {
-        refId: 'A',
+      },
+      {
+        testCaseName: "Lucene raw_document",
+        refId: "A",
         metrics: [
           {
-            id: '1',
-            type: 'raw_document',
+            id: "1",
+            type: "raw_document",
             settings: {
-              size: '500',
-              order: 'desc',
+              size: "500",
+              order: "desc",
               useTimeRange: true,
             },
           },
         ],
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send trace span queries', () => {
-      const rawDataQuery: OpenSearchQuery = {
-        refId: 'A',
+      },
+      {
+        testCaseName: "Lucene trace spans",
+    
+        refId: "A",
         queryType: QueryType.Lucene,
         luceneQueryType: LuceneQueryType.Traces,
-        query: 'traceId:test',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send trace list queries', () => {
-      const rawDataQuery: OpenSearchQuery = {
-        refId: 'A',
+        query: "traceId:test",
+      },
+      {
+        testCaseName: "Lucene trace list",
+    
+        refId: "A",
         queryType: QueryType.Lucene,
         luceneQueryType: LuceneQueryType.Traces,
-        query: '',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send logs queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const logsQuery: OpenSearchQuery = {
-        refId: 'A',
-        metrics: [{ type: 'logs', id: '1' }],
+        query: "",
+      },
+      {
+        testCaseName: "Lucene logs",
+    
+        refId: "A",
+        metrics: [{ type: "logs", id: "1" }],
         query: 'foo="bar"',
         queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [logsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send metric max group by terms query in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const metricQuery: OpenSearchQuery = {
-        refId: 'A',
+      },
+      {
+        testCaseName: "Lucene metrics",
+    
+        refId: "A",
         bucketAggs: [
           {
-            field: 'AvgTicketPrice',
-            id: '2',
+            field: "AvgTicketPrice",
+            id: "2",
             settings: {
-              min_doc_count: '0',
-              order: 'desc',
-              orderBy: '_term',
-              size: '10',
+              min_doc_count: "0",
+              order: "desc",
+              orderBy: "_term",
+              size: "10",
             },
-            type: 'terms',
+            type: "terms",
           },
         ],
         metrics: [
           {
-            field: 'AvgTicketPrice',
-            id: '1',
-            type: 'max',
+            field: "AvgTicketPrice",
+            id: "1",
+            type: "max",
           },
         ],
-        query: '*',
+        query: "*",
         queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [metricQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send metric average and derivative query in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const metricQuery: OpenSearchQuery = {
-        refId: 'A',
-        bucketAggs: [
-          {
-            field: 'timestamp',
-            id: '2',
-            settings: {
-              interval: '1d',
-            },
-            type: 'date_histogram',
-          },
-        ],
-        metrics: [
-          {
-            field: 'AvgTicketPrice',
-            id: '1',
-            type: 'avg',
-          },
-          {
-            field: '1',
-            id: '3',
-            type: 'derivative',
-          },
-        ],
-        query: '*',
-        queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [metricQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send PPL logs format queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
+      },
+      {
+        testCaseName: "PPL Logs",
+    
+        refId: "A",
         queryType: QueryType.PPL,
-        format: 'logs',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send PPL table format queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
+        format: "logs",
+        query: "source = test-index",
+      },
+      {
+        testCaseName: "PPL Table",
+    
+        refId: "A",
         queryType: QueryType.PPL,
-        format: 'table',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
-    });
-
-    it('should send PPL time series format queries in Explore', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
+        format: "table",
+        query: "source = test-index",
+      },
+      {
+        testCaseName: "PPL Time Series",
+    
+        refId: "A",
         queryType: QueryType.PPL,
-        format: 'time_series',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Explore,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).toHaveBeenCalled();
+        format: "time_series",
+        query: "source = test-index",
+      },
+    ];
+    testQueries.forEach(query => {
+      it(`should send ${query.testCaseName} query to the backend in Explore`, () => {
+        const request: DataQueryRequest<OpenSearchQuery> = {
+          requestId: '',
+          interval: '',
+          intervalMs: 1,
+          scopedVars: {},
+          timezone: '',
+          app: CoreApp.Explore,
+          startTime: 0,
+          range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+          targets: [query],
+        };
+        ctx.ds.query(request);
+        expect(mockedSuperQuery).toHaveBeenCalled();
+      });
     });
-
-    it('does not send logs queries in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const logsQuery: OpenSearchQuery = {
-        refId: 'A',
-        metrics: [{ type: 'logs', id: '1' }],
-        query: 'foo="bar"',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [logsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
+    testQueries.forEach(query => {
+      it(`should send ${query.testCaseName} query to the backend in Dashboards if openSearchBackendFlowEnabled feature toggle is enabled`, () => {
+        // @ts-ignore-next-line
+        config.featureToggles.openSearchBackendFlowEnabled = true;
+        const request: DataQueryRequest<OpenSearchQuery> = {
+          requestId: '',
+          interval: '',
+          intervalMs: 1,
+          scopedVars: {},
+          timezone: '',
+          app: CoreApp.Dashboard,
+          startTime: 0,
+          range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+          targets: [query],
+        };
+        ctx.ds.query(request);
+        expect(mockedSuperQuery).toHaveBeenCalled();
+      });
+      it(`should't send ${query.testCaseName} query to the backend in Dashboards if openSearchBackendFlowEnabled feature toggle is disabled`, () => {
+        // @ts-ignore
+        config.featureToggles.openSearchBackendFlowEnabled = false;
+        const request: DataQueryRequest<OpenSearchQuery> = {
+          requestId: '',
+          interval: '',
+          intervalMs: 1,
+          scopedVars: {},
+          timezone: '',
+          app: CoreApp.Dashboard,
+          startTime: 0,
+          range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
+          targets: [query],
+        };
+        ctx.ds.query(request);
+        expect(mockedSuperQuery).not.toHaveBeenCalled();
+      });
     });
-
-    it('does not send metric max group by terms in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const metricQuery: OpenSearchQuery = {
-        refId: 'A',
-        bucketAggs: [
-          {
-            field: 'AvgTicketPrice',
-            id: '2',
-            settings: {
-              min_doc_count: '0',
-              order: 'desc',
-              orderBy: '_term',
-              size: '10',
-            },
-            type: 'terms',
-          },
-        ],
-        metrics: [
-          {
-            field: 'AvgTicketPrice',
-            id: '1',
-            type: 'max',
-          },
-        ],
-        query: '*',
-        queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [metricQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-
-    it('does not send metric average and derivative query in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const metricQuery: OpenSearchQuery = {
-        refId: 'A',
-        bucketAggs: [
-          {
-            field: 'timestamp',
-            id: '2',
-            settings: {
-              interval: '1d',
-            },
-            type: 'date_histogram',
-          },
-        ],
-        metrics: [
-          {
-            field: 'AvgTicketPrice',
-            id: '1',
-            type: 'avg',
-          },
-          {
-            field: '1',
-            id: '3',
-            type: 'derivative',
-          },
-        ],
-        query: '*',
-        queryType: QueryType.Lucene,
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [metricQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-
-    it('does not send PPL logs format queries in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
-        queryType: QueryType.PPL,
-        format: 'logs',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-
-    it('does not send PPL table format queries in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
-        queryType: QueryType.PPL,
-        format: 'table',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-
-    it('does not send PPL time series format queries in Dashboard to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const pplLogsQuery: OpenSearchQuery = {
-        refId: 'A',
-        queryType: QueryType.PPL,
-        format: 'time_series',
-        query: 'source = test-index',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [pplLogsQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-
-    it('does not send query including types not yet migrated to backend', () => {
-      const mockedSuperQuery = jest
-        .spyOn(DataSourceWithBackend.prototype, 'query')
-        .mockImplementation((request: DataQueryRequest<OpenSearchQuery>) => of());
-      const rawDataQuery: OpenSearchQuery = {
-        refId: 'A',
-        query: '',
-        metrics: [
-          {
-            id: '1',
-            type: 'raw_data',
-            settings: {
-              size: '500',
-              order: 'desc',
-              useTimeRange: true,
-            },
-          },
-        ],
-        bucketAggs: [],
-      };
-      const countQuery: OpenSearchQuery = {
-        refId: 'A',
-        metrics: [{ type: 'count', id: '1' }],
-        query: 'foo="bar"',
-      };
-      const request: DataQueryRequest<OpenSearchQuery> = {
-        requestId: '',
-        interval: '',
-        intervalMs: 1,
-        scopedVars: {},
-        timezone: '',
-        app: CoreApp.Dashboard,
-        startTime: 0,
-        range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
-        targets: [rawDataQuery, countQuery],
-      };
-      ctx.ds.query(request);
-      expect(mockedSuperQuery).not.toHaveBeenCalled();
-      expect(datasourceRequestMock).toHaveBeenCalled();
-    });
-  });
-  
+  })
   describe('getSupportedQueryTypes', () => {
     it('should return Lucene when no other types are set', () => {
       const instanceSettings = {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -64,7 +64,7 @@ jest.mock('@grafana/runtime', () => ({
   getTemplateSrv: () => ({
     replace: jest.fn((text: string | undefined) => {
       // Replace all $ words, except global variables ($__interval, $__interval_ms, etc.) - they get interpolated on the BE
-      const resolved = text?.replace(/\$(?!__)\w+/g, "resolvedVariable") ?? '';
+      const resolved = text?.replace(/\$(?!__)\w+/g, 'resolvedVariable') ?? '';
       return resolved;
     }),
     getAdhocFilters: getAdHocFiltersMock,
@@ -1135,112 +1135,106 @@ describe('OpenSearchDatasource', function (this: any) {
     });
     const testQueries: Array<OpenSearchQuery & { testCaseName: string }> = [
       {
-        testCaseName: "Lucene raw_data",
-        refId: "A",
+        testCaseName: 'Lucene raw_data',
+        refId: 'A',
         metrics: [
           {
-            id: "1",
-            type: "raw_data",
+            id: '1',
+            type: 'raw_data',
             settings: {
-              size: "500",
-              order: "desc",
+              size: '500',
+              order: 'desc',
               useTimeRange: true,
             },
           },
         ],
       },
       {
-        testCaseName: "Lucene raw_document",
-        refId: "A",
+        testCaseName: 'Lucene raw_document',
+        refId: 'A',
         metrics: [
           {
-            id: "1",
-            type: "raw_document",
+            id: '1',
+            type: 'raw_document',
             settings: {
-              size: "500",
-              order: "desc",
+              size: '500',
+              order: 'desc',
               useTimeRange: true,
             },
           },
         ],
       },
       {
-        testCaseName: "Lucene trace spans",
-    
-        refId: "A",
+        testCaseName: 'Lucene trace spans',
+        refId: 'A',
         queryType: QueryType.Lucene,
         luceneQueryType: LuceneQueryType.Traces,
-        query: "traceId:test",
+        query: 'traceId:test',
       },
       {
-        testCaseName: "Lucene trace list",
-    
-        refId: "A",
+        testCaseName: 'Lucene trace list',
+        refId: 'A',
         queryType: QueryType.Lucene,
         luceneQueryType: LuceneQueryType.Traces,
-        query: "",
+        query: '',
       },
       {
-        testCaseName: "Lucene logs",
-    
-        refId: "A",
-        metrics: [{ type: "logs", id: "1" }],
+        testCaseName: 'Lucene logs',
+        refId: 'A',
+        metrics: [{ type: 'logs', id: '1' }],
         query: 'foo="bar"',
         queryType: QueryType.Lucene,
       },
       {
-        testCaseName: "Lucene metrics",
-    
-        refId: "A",
+        testCaseName: 'Lucene metrics',
+        refId: 'A',
         bucketAggs: [
           {
-            field: "AvgTicketPrice",
-            id: "2",
+            field: 'AvgTicketPrice',
+            id: '2',
             settings: {
-              min_doc_count: "0",
-              order: "desc",
-              orderBy: "_term",
-              size: "10",
+              min_doc_count: '0',
+              order: 'desc',
+              orderBy: '_term',
+              size: '10',
             },
-            type: "terms",
+            type: 'terms',
           },
         ],
         metrics: [
           {
-            field: "AvgTicketPrice",
-            id: "1",
-            type: "max",
+            field: 'AvgTicketPrice',
+            id: '1',
+            type: 'max',
           },
         ],
-        query: "*",
+        query: '*',
         queryType: QueryType.Lucene,
       },
       {
-        testCaseName: "PPL Logs",
-    
-        refId: "A",
+        testCaseName: 'PPL Logs',
+        refId: 'A',
         queryType: QueryType.PPL,
-        format: "logs",
-        query: "source = test-index",
+        format: 'logs',
+        query: 'source = test-index',
       },
       {
-        testCaseName: "PPL Table",
-    
-        refId: "A",
+        testCaseName: 'PPL Table',
+
+        refId: 'A',
         queryType: QueryType.PPL,
-        format: "table",
-        query: "source = test-index",
+        format: 'table',
+        query: 'source = test-index',
       },
       {
-        testCaseName: "PPL Time Series",
-    
-        refId: "A",
+        testCaseName: 'PPL Time Series',
+        refId: 'A',
         queryType: QueryType.PPL,
-        format: "time_series",
-        query: "source = test-index",
+        format: 'time_series',
+        query: 'source = test-index',
       },
     ];
-    testQueries.forEach(query => {
+    testQueries.forEach((query) => {
       it(`should send ${query.testCaseName} query to the backend in Explore`, () => {
         const request: DataQueryRequest<OpenSearchQuery> = {
           requestId: '',
@@ -1257,7 +1251,7 @@ describe('OpenSearchDatasource', function (this: any) {
         expect(mockedSuperQuery).toHaveBeenCalled();
       });
     });
-    testQueries.forEach(query => {
+    testQueries.forEach((query) => {
       it(`should send ${query.testCaseName} query to the backend in Dashboards if openSearchBackendFlowEnabled feature toggle is enabled`, () => {
         // @ts-ignore-next-line
         config.featureToggles.openSearchBackendFlowEnabled = true;
@@ -1293,7 +1287,7 @@ describe('OpenSearchDatasource', function (this: any) {
         expect(mockedSuperQuery).not.toHaveBeenCalled();
       });
     });
-  })
+  });
   describe('getSupportedQueryTypes', () => {
     it('should return Lucene when no other types are set', () => {
       const instanceSettings = {
@@ -1692,7 +1686,14 @@ describe('OpenSearchDatasource', function (this: any) {
     it('should correctly interpolate variables in nested fields in Lucene query', () => {
       const query: OpenSearchQuery = {
         refId: 'A',
-        bucketAggs: [{field: 'avgPrice', settings:{interval: "$var", min_doc_count: "$var", trimEdges: "$var"}, type: 'date_histogram', id: '1'}],
+        bucketAggs: [
+          {
+            field: 'avgPrice',
+            settings: { interval: '$var', min_doc_count: '$var', trimEdges: '$var' },
+            type: 'date_histogram',
+            id: '1',
+          },
+        ],
         metrics: [{ type: 'count', id: '1' }],
         query: '$var AND foo:bar',
       };
@@ -1702,8 +1703,8 @@ describe('OpenSearchDatasource', function (this: any) {
       expect((interpolatedQuery.bucketAggs![0] as DateHistogram).settings!.interval).toBe('resolvedVariable');
       expect((interpolatedQuery.bucketAggs![0] as DateHistogram).settings!.min_doc_count).toBe('resolvedVariable');
       expect((interpolatedQuery.bucketAggs![0] as DateHistogram).settings!.trimEdges).toBe('resolvedVariable');
-    })
-    
+    });
+
     it('correctly applies template variables and adhoc filters to Lucene queries', () => {
       const adHocFilters: AdHocVariableFilter[] = [
         { key: 'bar', operator: '=', value: 'baz', condition: '' },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Gradually roll out backend migration with the feature toggle. 
Decided to keep the Explore queries also on backend flow, since that has been enabled for a long while and I didn't want to change functionality. 
Also refactored the tests a bit to reduce repetition. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
