### PR TITLE
Clear version error when serverless toggled

### DIFF
--- a/src/configuration/OpenSearchDetails.tsx
+++ b/src/configuration/OpenSearchDetails.tsx
@@ -63,6 +63,7 @@ export const OpenSearchDetails = (props: Props) => {
   }
 
   const getServerlessSettings = (event: React.SyntheticEvent<HTMLInputElement, Event>) => {
+    setVersionErr('');
     // Adds the latest version if it isn't set (query construction requires a version)
     return {
       ...value,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
When serverless is toggled, we should clear the error from getting the server version

**Which issue(s) this PR fixes**:

Fixes #187 

**Special notes for your reviewer**:
I also updated the deprecated test functions that were being used while I was in `OpenSearchDetails.test.tsx`. I didn't update the `LegacyForm` imports in `OpenSearchDetails.tsx` because that seemed more risky.
