### PR TITLE
chore: refactor interval calculation

### DIFF
--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -17,22 +17,20 @@ import (
 )
 
 type luceneHandler struct {
-	client             client.Client
-	reqQueries         []backend.DataQuery
-	intervalCalculator tsdb.IntervalCalculator
-	ms                 *client.MultiSearchRequestBuilder
-	queries            []*Query
-	dsSettings         *backend.DataSourceInstanceSettings
+	client     client.Client
+	reqQueries []backend.DataQuery
+	ms         *client.MultiSearchRequestBuilder
+	queries    []*Query
+	dsSettings *backend.DataSourceInstanceSettings
 }
 
-func newLuceneHandler(client client.Client, queries []backend.DataQuery, intervalCalculator tsdb.IntervalCalculator, dsSettings *backend.DataSourceInstanceSettings) *luceneHandler {
+func newLuceneHandler(client client.Client, queries []backend.DataQuery, dsSettings *backend.DataSourceInstanceSettings) *luceneHandler {
 	return &luceneHandler{
-		client:             client,
-		reqQueries:         queries,
-		intervalCalculator: intervalCalculator,
-		ms:                 client.MultiSearch(),
-		queries:            make([]*Query, 0),
-		dsSettings:         dsSettings,
+		client:     client,
+		reqQueries: queries,
+		ms:         client.MultiSearch(),
+		queries:    make([]*Query, 0),
+		dsSettings: dsSettings,
 	}
 }
 
@@ -53,7 +51,7 @@ func (h *luceneHandler) processQuery(q *Query) error {
 	if err != nil {
 		return err
 	}
-	interval := h.intervalCalculator.Calculate(&h.reqQueries[0].TimeRange, minInterval)
+	interval := tsdb.CalculateInterval(&h.reqQueries[0].TimeRange, minInterval)
 
 	h.queries = append(h.queries, q)
 

--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -7,30 +7,27 @@ import (
 	"github.com/bitly/go-simplejson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
-	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/grafana/opensearch-datasource/pkg/utils"
 )
 
 type queryRequest struct {
-	client             client.Client
-	queries            []backend.DataQuery
-	dsSettings         *backend.DataSourceInstanceSettings
-	intervalCalculator tsdb.IntervalCalculator
+	client     client.Client
+	queries    []backend.DataQuery
+	dsSettings *backend.DataSourceInstanceSettings
 }
 
-func newQueryRequest(client client.Client, queries []backend.DataQuery, dsSettings *backend.DataSourceInstanceSettings, intervalCalculator tsdb.IntervalCalculator) *queryRequest {
+func newQueryRequest(client client.Client, queries []backend.DataQuery, dsSettings *backend.DataSourceInstanceSettings) *queryRequest {
 	return &queryRequest{
-		client:             client,
-		queries:            queries,
-		dsSettings:         dsSettings,
-		intervalCalculator: intervalCalculator,
+		client:     client,
+		queries:    queries,
+		dsSettings: dsSettings,
 	}
 }
 
 func (e *queryRequest) execute(ctx context.Context) (*backend.QueryDataResponse, error) {
 	handlers := make(map[string]queryHandler)
 
-	handlers[Lucene] = newLuceneHandler(e.client, e.queries, e.intervalCalculator, e.dsSettings)
+	handlers[Lucene] = newLuceneHandler(e.client, e.queries, e.dsSettings)
 	handlers[PPL] = newPPLHandler(e.client, e.queries)
 
 	queries, err := parse(e.queries)

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
-	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -971,7 +970,7 @@ func executeTsdbQuery(c client.Client, body string, from, to time.Time, minInter
 	}
 
 	dsSettings := backend.DataSourceInstanceSettings{}
-	query := newQueryRequest(c, tsdbQuery, &dsSettings, tsdb.NewIntervalCalculator(&tsdb.IntervalOptions{MinInterval: minInterval}))
+	query := newQueryRequest(c, tsdbQuery, &dsSettings)
 	return query.execute(context.Background())
 }
 

--- a/pkg/tsdb/interval.go
+++ b/pkg/tsdb/interval.go
@@ -10,10 +10,9 @@ import (
 )
 
 var (
-	defaultRes         int64 = 1500
-	defaultMinInterval       = time.Millisecond * 1
-	year                     = time.Hour * 24 * 365
-	day                      = time.Hour * 24
+	defaultRes int64 = 1500
+	year             = time.Hour * 24 * 365
+	day              = time.Hour * 24
 )
 
 type Interval struct {
@@ -21,41 +20,13 @@ type Interval struct {
 	Value time.Duration
 }
 
-type intervalCalculator struct {
-	minInterval time.Duration
-}
-
-type IntervalCalculator interface {
-	Calculate(timeRange *backend.TimeRange, minInterval time.Duration) Interval
-}
-
-type IntervalOptions struct {
-	MinInterval time.Duration
-}
-
-func NewIntervalCalculator(opt *IntervalOptions) *intervalCalculator {
-	if opt == nil {
-		opt = &IntervalOptions{}
-	}
-
-	calc := &intervalCalculator{}
-
-	if opt.MinInterval == 0 {
-		calc.minInterval = defaultMinInterval
-	} else {
-		calc.minInterval = opt.MinInterval
-	}
-
-	return calc
-}
-
 func (i *Interval) Milliseconds() int64 {
 	return i.Value.Nanoseconds() / int64(time.Millisecond)
 }
 
-func (ic *intervalCalculator) Calculate(timerange *backend.TimeRange, minInterval time.Duration) Interval {
-	to := timerange.To.UnixNano()
-	from := timerange.From.UnixNano()
+func CalculateInterval(timeRange *backend.TimeRange, minInterval time.Duration) Interval {
+	to := timeRange.To.UnixNano()
+	from := timeRange.From.UnixNano()
 	interval := time.Duration((to - from) / defaultRes)
 
 	if interval < minInterval {
@@ -124,7 +95,7 @@ func FormatDuration(inter time.Duration) string {
 	return "1ms"
 }
 
-//nolint: gocyclo
+// nolint: gocyclo
 func roundInterval(interval time.Duration) time.Duration {
 	switch {
 	// 0.015s


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the largely unused machinery around interval calculation, both to streamline and to remove a global that could potentially become problematic.

**Which issue(s) this PR fixes**:
Part of multitenancy work.