### PR TITLE
fix: use older timestamp format for older elasticsearch

### DIFF
--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -93,7 +93,8 @@ func (b *SearchRequestBuilder) Sort(order, field, unmappedType string) *SearchRe
 	return b
 }
 
-const timeFormat = "strict_date_optional_time_nanos"
+const post7TimeFormat = "strict_date_optional_time_nanos"
+const pre7TimeFormat = "strict_date_optional_time"
 
 // SetCustomProps adds timeField as field with standardized time format to not receive
 // invalid formats that Elasticsearch/OpenSearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
@@ -106,6 +107,11 @@ const timeFormat = "strict_date_optional_time_nanos"
 func (b *SearchRequestBuilder) SetCustomProps(timeField string, luceneQueryType string) {
 	// defaults - OpenSearch or Elasticsearch > 7
 	var key = "fields"
+	var timeFormat = post7TimeFormat
+	// the "strict_date_optional_time_nanos" format is invalid in Elasticsearch versions < 7
+	if b.flavor == Elasticsearch && b.version.Major() < 7 {
+		timeFormat = pre7TimeFormat
+	}
 	var value any = []any{map[string]string{"field": timeField, "format": timeFormat}}
 	if b.flavor == OpenSearch && luceneQueryType == "logs" {
 		b.customProps["docvalue_fields"] = []any{timeField}

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -267,7 +267,7 @@ func TestSearchRequest(t *testing.T) {
 			})
 		})
 	})
-	
+
 	t.Run("Given new search request builder for Elasticsearch 7.0.0", func(t *testing.T) {
 		version, _ := semver.NewVersion("7.0.0")
 		t.Run("When adding timestamp format should add new time format field", func(t *testing.T) {
@@ -278,6 +278,19 @@ func TestSearchRequest(t *testing.T) {
 			assert.True(t, ok)
 			assert.Len(t, fields, 1)
 			assert.Equal(t, map[string]string{"field": timeField, "format": "strict_date_optional_time_nanos"}, fields[0])
+
+		})
+	})
+	t.Run("Given new search request builder for Elasticsearch 6.8.9", func(t *testing.T) {
+		version, _ := semver.NewVersion("6.8.9")
+		t.Run("When adding timestamp format should add older time format field", func(t *testing.T) {
+			b := NewSearchRequestBuilder(Elasticsearch, version, tsdb.Interval{Value: 15 * time.Second, Text: "15s"})
+			b.SetCustomProps(timeField, "logs")
+
+			fields, ok := b.customProps["docvalue_fields"].([]any)
+			assert.True(t, ok)
+			assert.Len(t, fields, 1)
+			assert.Equal(t, map[string]string{"field": timeField, "format": "strict_date_optional_time"}, fields[0])
 
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the timestamp format used in requests for older versions of elasticsearch. The `strict_date_optional_time_nanos` format we're using is not valid for versions < 7.0.

**Which issue(s) this PR fixes**:

Fixes #417.