### PR TITLE
Bring back the selector for opensearch version

### DIFF
--- a/src/configuration/OpenSearchDetails.test.tsx
+++ b/src/configuration/OpenSearchDetails.test.tsx
@@ -182,28 +182,26 @@ describe('OpenSearchDetails', () => {
     const defaultConfig = createDefaultConfigOptions();
     testCases.forEach((tc) => {
       const expected = tc.expectedMaxConcurrentShardRequests;
-      it(`sets maxConcurrentShardRequests = ${expected} if version = ${tc.version} & flavor = ${tc.flavor},`, async () => {
-        it(`with auto detection`, async () => {
-          const mockDatasource = setupMockedDataSource();
-          mockDatasource.getOpenSearchVersion = jest.fn().mockResolvedValue({ flavor: tc.flavor, version: tc.version });
-          defaultConfig.jsonData.maxConcurrentShardRequests = tc.maxConcurrentShardRequests;
-          render(
-            <OpenSearchDetails
-              onChange={jest.fn()}
-              value={defaultConfig}
-              saveOptions={onChangeMock}
-              datasource={mockDatasource}
-            />
-          );
-          await userEvent.click(screen.getByRole('button', { name: 'Get Version and Save' }));
+      it(`sets maxConcurrentShardRequests = ${expected} if version = ${tc.version} & flavor = ${tc.flavor}, with auto detection`, async () => {
+        const mockDatasource = setupMockedDataSource();
+        mockDatasource.getOpenSearchVersion = jest.fn().mockResolvedValue({ flavor: tc.flavor, version: tc.version });
+        defaultConfig.jsonData.maxConcurrentShardRequests = tc.maxConcurrentShardRequests;
+        render(
+          <OpenSearchDetails
+            onChange={jest.fn()}
+            value={defaultConfig}
+            saveOptions={onChangeMock}
+            datasource={mockDatasource}
+          />
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Get Version and Save' }));
 
-          expect(onChangeMock).toHaveBeenCalled();
+        expect(onChangeMock).toHaveBeenCalled();
 
-          expect(last(onChangeMock.mock.calls)[0].jsonData.maxConcurrentShardRequests).toBe(expected);
-        });
+        expect(last(onChangeMock.mock.calls)[0].jsonData.maxConcurrentShardRequests).toBe(expected);
       });
 
-      it(`with dropdown`, async () => {
+      it(`sets maxConcurrentShardRequests = ${expected} if version = ${tc.version} & flavor = ${tc.flavor}, with dropdown`, async () => {
         const options: DataSourceSettings<OpenSearchOptions> = {
           ...defaultConfig,
           jsonData: {

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -54,7 +54,7 @@ export interface Version {
 
 export const AVAILABLE_VERSIONS: Array<SelectableValue<Version>> = [
   {
-    label: 'OpenSearch 1.0.x',
+    label: 'OpenSearch',
     value: {
       flavor: Flavor.OpenSearch,
       version: '1.0.0',


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
When opensearch is in compatible mode, it returns the version `ElasticSearch 7.10.2` for the version instead of the actual version, so that it can work with elasticseach tooling. This allows the user to correct the auto-detected version. We talked about just hiding the result, but there is a place in the backend where we behave differently for opensearch and elasticsearch 7+ so it does kind of matter.

**Which issue(s) this PR fixes**:

Fixes #206

**Special notes for your reviewer**:
