### PR TITLE
Use tagline to detect OpenSearch in compatibility mode

### DIFF
--- a/src/configuration/OpenSearchDetails.test.tsx
+++ b/src/configuration/OpenSearchDetails.test.tsx
@@ -48,7 +48,6 @@ describe('OpenSearchDetails', () => {
     const selectEl = wrapper.getByLabelText('Pattern');
     await selectEvent.select(selectEl, 'Monthly');
 
-
     expect(onChangeMock.mock.calls[0][0].jsonData.interval).toBe('Monthly');
     expect(onChangeMock.mock.calls[0][0].database).toBe('[logstash-]YYYY.MM');
   });
@@ -180,6 +179,27 @@ describe('OpenSearchDetails', () => {
     });
   });
 
+  describe('version field', () => {
+    it('displays the passed label', () => {
+      const defaultConfig = createDefaultConfigOptions();
+      defaultConfig.jsonData.versionLabel = 'OpenSearch (compatibility mode)';
+      render(
+        <OpenSearchDetails onChange={jest.fn()} value={defaultConfig} saveOptions={jest.fn()} datasource={undefined} />
+      );
+
+      expect(screen.getByDisplayValue('OpenSearch (compatibility mode)')).toBeInTheDocument();
+    });
+
+    it('generates the label when one is not passed', () => {
+      const defaultConfig = createDefaultConfigOptions();
+      render(
+        <OpenSearchDetails onChange={jest.fn()} value={defaultConfig} saveOptions={jest.fn()} datasource={undefined} />
+      );
+
+      expect(screen.getByDisplayValue('OpenSearch 1.0.0')).toBeInTheDocument();
+    });
+  });
+
   describe('opensearchDetectVersion', () => {
     it('displays the error and removes it when getOpenSearchVersion succeeds', async () => {
       // check that it's initialized as null
@@ -188,7 +208,7 @@ describe('OpenSearchDetails', () => {
       mockDatasource.getOpenSearchVersion = jest
         .fn()
         .mockRejectedValueOnce(new Error('test err'))
-        .mockResolvedValueOnce({ flavor: Flavor.OpenSearch, version: '2.6.0' });
+        .mockResolvedValueOnce({ flavor: Flavor.OpenSearch, version: '2.6.0', label: 'OpenSearch 2.6.0' });
       const { rerender } = render(
         <OpenSearchDetails
           onChange={jest.fn()}
@@ -215,7 +235,11 @@ describe('OpenSearchDetails', () => {
       rerender(
         <OpenSearchDetails
           onChange={jest.fn()}
-          value={createDefaultConfigOptions({ flavor: Flavor.OpenSearch, version: '2.6.0' })}
+          value={createDefaultConfigOptions({
+            flavor: Flavor.OpenSearch,
+            version: '2.6.0',
+            versionLabel: 'OpenSearch 2.6.0',
+          })}
           saveOptions={saveOptionsMock}
           datasource={mockDatasource}
         />

--- a/src/configuration/OpenSearchDetails.tsx
+++ b/src/configuration/OpenSearchDetails.tsx
@@ -38,6 +38,7 @@ export const OpenSearchDetails = (props: Props) => {
             ...value.jsonData,
             version: version.version,
             flavor: version.flavor,
+            versionLabel: version.label,
             maxConcurrentShardRequests: getMaxConcurrentShardRequestOrDefault(
               version.flavor,
               version.version,
@@ -55,8 +56,8 @@ export const OpenSearchDetails = (props: Props) => {
     }
   };
 
-  let versionString = '';
-  if (value.jsonData.flavor && value.jsonData.version) {
+  let versionString = value.jsonData.versionLabel;
+  if (!versionString && value.jsonData.flavor && value.jsonData.version) {
     versionString = `${
       AVAILABLE_FLAVORS.find((f) => f.value === value.jsonData.flavor)?.label || value.jsonData.flavor
     } ${value.jsonData.version}`;

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -50,6 +50,7 @@ export const isValidOptions = (options: DataSourceSettings<OpenSearchOptions>): 
 export interface Version {
   version: string;
   flavor: Flavor;
+  label?: string;
 }
 
 export const AVAILABLE_VERSIONS: Array<SelectableValue<Version>> = [

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1321,6 +1321,7 @@ describe('OpenSearchDatasource', function (this: any) {
       const version = await ctx.ds.getOpenSearchVersion();
       expect(version.flavor).toBe(Flavor.OpenSearch);
       expect(version.version).toBe('2.6.0');
+      expect(version.label).toBe('OpenSearch 2.6.0');
 
       expect(requestOptions.url).toBe(`${OPENSEARCH_MOCK_URL}//`);
     });
@@ -1333,6 +1334,8 @@ describe('OpenSearchDatasource', function (this: any) {
       const version = await ctx.ds.getOpenSearchVersion();
       expect(version.flavor).toBe(Flavor.Elasticsearch);
       expect(version.version).toBe('7.6.0');
+
+      expect(version.label).toBe('ElasticSearch 7.6.0');
     });
 
     it('should error for invalid version', async () => {
@@ -1342,6 +1345,26 @@ describe('OpenSearchDatasource', function (this: any) {
       await expect(() => ctx.ds.getOpenSearchVersion()).rejects.toThrow(
         'ElasticSearch version 7.11.1 is not supported by the OpenSearch plugin. Use the ElasticSearch plugin.'
       );
+    });
+    it('should return ElasticSearch for ElasticSearch 7.10.2 without tagline', async () => {
+      datasourceRequestMock.mockImplementation(() => {
+        return Promise.resolve({ data: { version: { number: '7.10.2' } } });
+      });
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.Elasticsearch);
+      expect(version.version).toBe('7.10.2');
+      expect(version.label).toBe('ElasticSearch 7.10.2');
+    });
+    it('should return OpenSearch for ElasticSearch 7.10.2 with tagline', async () => {
+      datasourceRequestMock.mockImplementation(() => {
+        return Promise.resolve({
+          data: { version: { number: '7.10.2' }, tagline: 'The OpenSearch Project: https://opensearch.org/' },
+        });
+      });
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.OpenSearch);
+      expect(version.version).toBe('1.0.0');
+      expect(version.label).toBe('OpenSearch (compatibility mode)');
     });
   });
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1334,7 +1334,6 @@ describe('OpenSearchDatasource', function (this: any) {
       const version = await ctx.ds.getOpenSearchVersion();
       expect(version.flavor).toBe(Flavor.Elasticsearch);
       expect(version.version).toBe('7.6.0');
-
       expect(version.label).toBe('ElasticSearch 7.6.0');
     });
 
@@ -1346,6 +1345,7 @@ describe('OpenSearchDatasource', function (this: any) {
         'ElasticSearch version 7.11.1 is not supported by the OpenSearch plugin. Use the ElasticSearch plugin.'
       );
     });
+
     it('should return ElasticSearch for ElasticSearch 7.10.2 without tagline', async () => {
       datasourceRequestMock.mockImplementation(() => {
         return Promise.resolve({ data: { version: { number: '7.10.2' } } });
@@ -1355,6 +1355,7 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(version.version).toBe('7.10.2');
       expect(version.label).toBe('ElasticSearch 7.10.2');
     });
+
     it('should return OpenSearch for ElasticSearch 7.10.2 with tagline', async () => {
       datasourceRequestMock.mockImplementation(() => {
         return Promise.resolve({

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -803,7 +803,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
       // Handle an Opensearch instance in compatibility mode. They report ElasticSearch version 7.10.2 but they still use the OpenSearch tagline
       if (
         newVersion.flavor === Flavor.Elasticsearch &&
-        gte(newVersion.version, '7.10.2') &&
+        newVersion.version === '7.10.2' &&
         results.data.tagline === 'The OpenSearch Project: https://opensearch.org/'
       ) {
         newVersion.flavor = Flavor.OpenSearch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface OpenSearchOptions extends DataSourceJsonData {
   timeField: string;
   version: string;
   flavor: Flavor;
+  versionLabel?: string;
   interval?: string;
   timeInterval: string;
   maxConcurrentShardRequests?: number;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This updates the opensearch version detection to determine if its connecting to opensearch in compatibility mode.

**Which issue(s) this PR fixes**:

Fixes #206 

**Special notes for your reviewer**:
To run the data prepper (see [CONTRIBUTING.md](https://github.com/grafana/opensearch-datasource/blob/main/CONTRIBUTING.md)) in compatibility mode add the following line to the opensearch environment settings in the jaeger-hotrod docker compose file ([here](https://github.com/opensearch-project/data-prepper/blob/782ad5118c9bb9b6fb752edd5d0914309795f456/examples/jaeger-hotrod/docker-compose.yml#L58)):
`- compatibility.override_main_response_version=true`
