### PR TITLE
Fix serviceMap when source node doesn't have stats

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -354,18 +354,20 @@ func processServiceMapResponse(serviceMap []interface{}, spanServiceStats []inte
 		statsForService := serviceStatsMap[edgeSource]
 		// only include services that are active in the specific time frame returned for span stats
 		// TODO: actually we want to include all but with null numbers
-		if statsForService != nil {
-			nodeIds.Append(edgeSource)
-			nodeTitles.Append(edgeSource)
-			serviceLatency := statsForService.(map[string]interface{})["avg_latency_nanos"].(map[string]interface{})["value"].(float64) / float64(time.Millisecond)
-			serviceErrorRate := statsForService.(map[string]interface{})["error_rate"].(map[string]interface{})["value"].(float64)
-			nodeAvgLatencies.Append(serviceLatency)
-			nodeErrorRates.Append(serviceErrorRate)
-			nodeErrorRatesDetails.Append(serviceErrorRate * 100)
-			nodeSuccessRates.Append(1.0 - serviceErrorRate)
-			if traceId == "" {
-				nodeThroughputs.Append(statsForService.(map[string]interface{})["doc_count"].(float64) / minutes)
-			}
+		if statsForService == nil {
+			continue
+		}
+
+		nodeIds.Append(edgeSource)
+		nodeTitles.Append(edgeSource)
+		serviceLatency := statsForService.(map[string]interface{})["avg_latency_nanos"].(map[string]interface{})["value"].(float64) / float64(time.Millisecond)
+		serviceErrorRate := statsForService.(map[string]interface{})["error_rate"].(map[string]interface{})["value"].(float64)
+		nodeAvgLatencies.Append(serviceLatency)
+		nodeErrorRates.Append(serviceErrorRate)
+		nodeErrorRatesDetails.Append(serviceErrorRate * 100)
+		nodeSuccessRates.Append(1.0 - serviceErrorRate)
+		if traceId == "" {
+			nodeThroughputs.Append(statsForService.(map[string]interface{})["doc_count"].(float64) / minutes)
 		}
 		for _, destination := range service["destination_domain"].(map[string]interface{})["buckets"].([]interface{}) {
 			edgeDestination := destination.(map[string]interface{})["key"].(string)

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -3066,7 +3066,8 @@ func getFrameValue(name string, index int, fields []*data.Field) string {
 	}
 	return ""
 }
-func TestProcessServiceMapResponse(t *testing.T){
+
+func TestProcessServiceMapResponse(t *testing.T) {
 	targets := []tsdbQuery{{
 		refId: "A",
 		body: `{
@@ -3424,6 +3425,54 @@ func TestProcessServiceMapResponse(t *testing.T){
 								"doc_count_error_upper_bound":0,
 								"sum_other_doc_count":0
 							}
+							},
+							{
+								"destination_domain":{
+									"buckets":[
+										{
+											"destination_resource":{
+											"buckets":[
+												{
+													"doc_count":1,
+													"key":"FindDriverIDs"
+												},
+												{
+													"doc_count":1,
+													"key":"GetDriver"
+												}
+											],
+											"doc_count_error_upper_bound":0,
+											"sum_other_doc_count":0
+											},
+											"doc_count":2,
+											"key":"redis"
+										}
+									],
+									"doc_count_error_upper_bound":0,
+									"sum_other_doc_count":0
+								},
+								"doc_count":41,
+								"key":"no-stats",
+								"target_domain":{
+									"buckets":[
+										{
+											"doc_count":1,
+											"key":"driver",
+											"target_resource":{
+											"buckets":[
+												{
+													"doc_count":1,
+													"key":"/driver.DriverService/FindNearest"
+												}
+											],
+											"doc_count_error_upper_bound":0,
+											"sum_other_doc_count":0
+											}
+										}
+									],
+									"doc_count_error_upper_bound":0,
+									"sum_other_doc_count":0
+								}
 							}
 						],
 						"doc_count_error_upper_bound":0,
@@ -3455,7 +3504,7 @@ func TestProcessServiceMapResponse(t *testing.T){
 				  "status": 200
 			}
 		]
-	}`  
+	}`
 	rp, err := newResponseParserForTest(targets, response, nil, client.ConfiguredFields{TimeField: "@timestamp"}, &backend.DataSourceInstanceSettings{UID: "123", Name: "DatasourceInstanceName"})
 	assert.Nil(t, err)
 
@@ -3467,7 +3516,7 @@ func TestProcessServiceMapResponse(t *testing.T){
 	require.Len(t, finalDataFrames, 3)
 
 	require.NotNil(t, finalDataFrames)
-	
+
 	// trace list
 	traceListDataframe := finalDataFrames[0]
 	require.Equal(t, traceListDataframe.Name, "Trace List")
@@ -3485,6 +3534,4 @@ func TestProcessServiceMapResponse(t *testing.T){
 	assert.Equal(t, nodesFrame.Fields[0].Len(), 6)
 	assert.Equal(t, "frontend", nodesFrame.Fields[0].At(0))
 	assert.Equal(t, "redis", nodesFrame.Fields[0].At(1))
-
-
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
We currently only add nodes that have stats to the node graph, but we only check whether or not the destination node exists while adding edges. There's a todo in the code about supporting nodes without stats, but checking for source nodes without stats fixes the bug for how the code is currently supposed to work

**Which issue(s) this PR fixes**:

Fixes #427 

**Special notes for your reviewer**:
