### PR TITLE
Fix: handle empty trace group and last updated values

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -430,8 +430,7 @@ func processTraceListResponse(res *client.SearchResponse, dsUID string, dsName s
 		traceErrorCounts = append(traceErrorCounts, trace["error_count"].(map[string]interface{})["doc_count"].(float64))
 
 		if lastUpdatedValue, exists := trace["last_updated"].(map[string]interface{})["value"].(float64); exists {
-			lastUpdated := time.Unix(0, int64(lastUpdatedValue)*int64(time.Millisecond))
-			traceLastUpdated = append(traceLastUpdated, &lastUpdated)
+			traceLastUpdated = append(traceLastUpdated, utils.Pointer(time.Unix(0, int64(lastUpdatedValue)*int64(time.Millisecond))))
 		} else {
 			traceLastUpdated = append(traceLastUpdated, nil)
 		}

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -2799,9 +2799,9 @@ func TestProcessTraceListResponse(t *testing.T) {
 	assert.Equal(t, "float64", errorCount.Type().ItemTypeString())
 
 	lastUpdated := frame.Fields[4]
-	assert.Equal(t, time.Unix(0, int64(1700074430928)*int64(time.Millisecond)), lastUpdated.At(0))
+	assert.Equal(t, utils.Pointer(time.Unix(0, int64(1700074430928)*int64(time.Millisecond))), lastUpdated.At(0))
 	assert.Equal(t, "Last Updated", lastUpdated.Name)
-	assert.Equal(t, "time.Time", lastUpdated.Type().ItemTypeString())
+	assert.Equal(t, "*time.Time", lastUpdated.Type().ItemTypeString())
 }
 
 func TestProcessTraceListResponseWithNoTraceGroupOrLastUpdated(t *testing.T) {

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -2804,6 +2804,89 @@ func TestProcessTraceListResponse(t *testing.T) {
 	assert.Equal(t, "time.Time", lastUpdated.Type().ItemTypeString())
 }
 
+func TestProcessTraceListResponseWithNoTraceGroupOrLastUpdated(t *testing.T) {
+	targets := []tsdbQuery{{
+		refId: "A",
+		body: `{
+			"timeField": "@timestamp",
+			"metrics": [{ "type": "count", "id": "1" }],
+			"luceneQueryType": "Traces"
+			}`,
+	}}
+
+	response := `
+		{
+			"responses": [{
+				"aggregations": {
+					"traces": {
+						"buckets": [{
+							"doc_count": 50,
+							"key": "000000000000000001c01e08995dd2e2",
+							"last_updated": {
+								"value": null
+							},
+							"latency": {
+								"value": 656.43
+							},
+							"trace_group": {
+								"buckets":[]
+							},
+							"error_count": {
+								"doc_count":0
+							}
+						}]
+					}
+				}
+			}]
+		}
+	`
+
+	rp, err := newResponseParserForTest(targets, response, nil, client.ConfiguredFields{TimeField: "@timestamp"}, &backend.DataSourceInstanceSettings{UID: "123", Name: "DatasourceInstanceName"})
+	assert.Nil(t, err)
+
+	result, err := rp.parseResponse()
+	require.NoError(t, err)
+	require.Len(t, result.Responses, 1)
+
+	queryRes := result.Responses["A"]
+	require.NotNil(t, queryRes)
+
+	dataframes := queryRes.Frames
+	require.Len(t, dataframes, 1)
+
+	frame := dataframes[0]
+
+	traceId := frame.Fields[0]
+	assert.Equal(t, "000000000000000001c01e08995dd2e2", traceId.At(0))
+	assert.Equal(t, "Trace Id", traceId.Name)
+	assert.Equal(t, "string", traceId.Type().ItemTypeString())
+	//deep link config to make it possible to click through to individual trace view
+	assert.Equal(t, "traceId: ${__value.raw}", traceId.Config.Links[0].Internal.Query.(map[string]interface{})["query"])
+	assert.Equal(t, "Traces", traceId.Config.Links[0].Internal.Query.(map[string]interface{})["luceneQueryType"])
+	assert.Equal(t, "123", traceId.Config.Links[0].Internal.DatasourceUID)
+	assert.Equal(t, "DatasourceInstanceName", traceId.Config.Links[0].Internal.DatasourceName)
+
+	traceGroup := frame.Fields[1]
+	assert.Equal(t, "", traceGroup.At(0))
+	assert.Equal(t, "Trace Group", traceGroup.Name)
+	assert.Equal(t, "string", traceGroup.Type().ItemTypeString())
+
+	latency := frame.Fields[2]
+	assert.Equal(t, 656.43, latency.At(0))
+	assert.Equal(t, "Latency (ms)", latency.Name)
+	assert.Equal(t, "float64", latency.Type().ItemTypeString())
+
+	errorCount := frame.Fields[3]
+	assert.Equal(t, float64(0), errorCount.At(0))
+	assert.Equal(t, "Error Count", errorCount.Name)
+	assert.Equal(t, "float64", errorCount.Type().ItemTypeString())
+
+	lastUpdated := frame.Fields[4]
+	assert.Nil(t, lastUpdated.At(0))
+	assert.Equal(t, "Last Updated", lastUpdated.Name)
+	assert.Equal(t, "*time.Time", lastUpdated.Type().ItemTypeString())
+}
+
 func TestProcessSpansResponse_withMultipleSpansQueries(t *testing.T) {
 	targets := []tsdbQuery{
 		{

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.expected_result_generated_snapshot.golden.jsonc
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_trace_list.expected_result_generated_snapshot.golden.jsonc
@@ -6,7 +6,7 @@
 //  +----------------------------------+--------------------+--------------------+-------------------+-----------------------------------+
 //  | Name: Trace Id                   | Name: Trace Group  | Name: Latency (ms) | Name: Error Count | Name: Last Updated                |
 //  | Labels:                          | Labels:            | Labels:            | Labels:           | Labels:                           |
-//  | Type: []string                   | Type: []string     | Type: []float64    | Type: []float64   | Type: []time.Time                 |
+//  | Type: []string                   | Type: []string     | Type: []float64    | Type: []float64   | Type: []*time.Time                |
 //  +----------------------------------+--------------------+--------------------+-------------------+-----------------------------------+
 //  | 00000000000000001c826277770e267d | HTTP GET /dispatch | 671.91             | 0                 | 2023-11-21 14:39:46.811 -0500 EST |
 //  | 0000000000000000252c7c74849b6fe7 | HTTP GET /dispatch | 760.23             | 0                 | 2023-11-21 14:39:48.782 -0500 EST |
@@ -74,7 +74,8 @@
             "name": "Last Updated",
             "type": "time",
             "typeInfo": {
-              "frame": "time.Time"
+              "frame": "time.Time",
+              "nullable": true
             }
           }
         ]


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Fixes an issue where some trace groups and last updated values are empty. This causes a panic when parsing the returned trace from OpenSearch into a data frame field.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
You can test this by:
1. Clone https://github.com/opensearch-project/opentelemetry-demo and run it with the following
   ```sh
   git clone https://github.com/opensearch-project/opentelemetry-demo.git
   cd opentelemetry-demo
   docker compose up -d
   ```
1. Start your local Grafana instance on another port other than 3000
   ```ini
   [server]
   http_port = 4000
   ```
1. Open http://localhost:4000 (use the port you set above) and create an opensearch data source with the following settings ([password](https://github.com/opensearch-project/opentelemetry-demo/blob/main/tutorial/GettingStarted.md#logging-in-dashboard) is `my_%New%_passW0rd!@#`) 
   <img width="872" alt="data source config" src="https://github.com/user-attachments/assets/2ec1e1f4-01e5-445c-92f4-642eb21107ea">
1. Go to http://localhost:8089/ click `Edit` under the "Running" heading in the header and increase the Number of users and Spawn rate settings (I used 250 for Number of users and 50 for Spawn rate)
1. Go to http://localhost:4000/explore set the time range to last 24 hours and run a Lucene Trace query (no need to fill in the query field).
1. When you run OpenSearch without this PR it should have an `An error occurred within the plugin` error. It should return results with the trace group and last updated field blank when running OpenSearch with this PR.
   <img width="1059" alt="fixed" src="https://github.com/user-attachments/assets/868c1a4f-97c9-4126-a3c4-6396c3b78301">
   Here's an image of the OpenSearch dashboard that shows that it leaves those fields blank
   <img width="1059" alt="opensearch" src="https://github.com/user-attachments/assets/75c101c8-b580-4793-a8f6-f67b66730e81">


Note: I'm not sure exactly when a trace without a trace group or last updated value is generated, you may have to wait some time though.
