### PR TITLE
Use resource handler to get version

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -182,12 +182,12 @@ func (ds *OpenSearchDatasource) CallResource(ctx context.Context, req *backend.C
 		return fmt.Errorf("invalid resource URL: %s", req.Path)
 	}
 
-	esUrl, err := createOpensearchURL(req, req.PluginContext.DataSourceInstanceSettings.URL)
+	osUrl, err := createOpensearchURL(req, req.PluginContext.DataSourceInstanceSettings.URL)
 	if err != nil {
 		return err
 	}
 
-	request, err := http.NewRequestWithContext(ctx, req.Method, esUrl, bytes.NewBuffer(req.Body))
+	request, err := http.NewRequestWithContext(ctx, req.Method, osUrl, bytes.NewBuffer(req.Body))
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (ds *OpenSearchDatasource) CallResource(ctx context.Context, req *backend.C
 		"content-type": {"application/json"},
 	}
 
-	if response.Header.Get("Content-Encoding") != "" {
+	if encoding := response.Header.Get("Content-Encoding"); encoding != "" {
 		responseHeaders["content-encoding"] = []string{response.Header.Get("Content-Encoding")}
 	}
 
@@ -223,12 +223,12 @@ func createOpensearchURL(req *backend.CallResourceRequest, urlStr string) (strin
 		return "", fmt.Errorf("failed to parse data source URL: %s, error: %w", urlStr, err)
 	}
 	osUrl.Path = path.Join(osUrl.Path, req.Path)
-	esUrlString := osUrl.String()
+	osUrlString := osUrl.String()
 	// If the request path is empty and the URL does not end with a slash, add a slash to the URL.
 	// This ensures that for version checks executed to the root URL, the URL ends with a slash.
 	// This is helpful, for example, for load balancers that expect URLs to match the pattern /.*.
-	if req.Path == "" && esUrlString[len(esUrlString)-1:] != "/" {
+	if req.Path == "" && osUrlString[len(osUrlString)-1:] != "/" {
 		return osUrl.String() + "/", nil
 	}
-	return esUrlString, nil
+	return osUrlString, nil
 }

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -1370,9 +1370,16 @@ describe('OpenSearchDatasource', function (this: any) {
   });
 
   describe('getOpenSearchVersion backend flow', () => {
-    it('should return OpenSearch version', async () => {
+    beforeEach(() => {
       // @ts-ignore-next-line
       config.featureToggles.openSearchBackendFlowEnabled = true;
+    });
+
+    afterEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = false;
+    });
+    it('should return OpenSearch version', async () => {
       const mockResource = jest.fn().mockResolvedValue({
         version: { distribution: 'opensearch', number: '2.6.0' },
       });
@@ -1387,8 +1394,6 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should return ElasticSearch version', async () => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = true;
       ctx.ds.getResource = jest.fn().mockResolvedValue({
         version: { number: '7.6.0' },
       });
@@ -1400,8 +1405,6 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should error for invalid version', async () => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = true;
       ctx.ds.getResource = jest.fn().mockResolvedValue({
         version: { number: '7.11.1' },
       });
@@ -1411,8 +1414,6 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should return ElasticSearch for ElasticSearch 7.10.2 without tagline', async () => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = true;
       ctx.ds.getResource = jest.fn().mockResolvedValue({
         version: { number: '7.10.2' },
       });
@@ -1423,8 +1424,6 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should return OpenSearch for ElasticSearch 7.10.2 with tagline', async () => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = true;
       ctx.ds.getResource = jest.fn().mockResolvedValue({
         version: { number: '7.10.2' },
         tagline: 'The OpenSearch Project: https://opensearch.org/',

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -1369,6 +1369,73 @@ describe('OpenSearchDatasource', function (this: any) {
     });
   });
 
+  describe('getOpenSearchVersion backend flow', () => {
+    it('should return OpenSearch version', async () => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      const mockResource = jest.fn().mockResolvedValue({
+        version: { distribution: 'opensearch', number: '2.6.0' },
+      });
+      ctx.ds.getResource = mockResource;
+
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.OpenSearch);
+      expect(version.version).toBe('2.6.0');
+      expect(version.label).toBe('OpenSearch 2.6.0');
+
+      expect(mockResource.mock.lastCall[0]).toBe('');
+    });
+
+    it('should return ElasticSearch version', async () => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      ctx.ds.getResource = jest.fn().mockResolvedValue({
+        version: { number: '7.6.0' },
+      });
+
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.Elasticsearch);
+      expect(version.version).toBe('7.6.0');
+      expect(version.label).toBe('ElasticSearch 7.6.0');
+    });
+
+    it('should error for invalid version', async () => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      ctx.ds.getResource = jest.fn().mockResolvedValue({
+        version: { number: '7.11.1' },
+      });
+      await expect(() => ctx.ds.getOpenSearchVersion()).rejects.toThrow(
+        'ElasticSearch version 7.11.1 is not supported by the OpenSearch plugin. Use the ElasticSearch plugin.'
+      );
+    });
+
+    it('should return ElasticSearch for ElasticSearch 7.10.2 without tagline', async () => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      ctx.ds.getResource = jest.fn().mockResolvedValue({
+        version: { number: '7.10.2' },
+      });
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.Elasticsearch);
+      expect(version.version).toBe('7.10.2');
+      expect(version.label).toBe('ElasticSearch 7.10.2');
+    });
+
+    it('should return OpenSearch for ElasticSearch 7.10.2 with tagline', async () => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      ctx.ds.getResource = jest.fn().mockResolvedValue({
+        version: { number: '7.10.2' },
+        tagline: 'The OpenSearch Project: https://opensearch.org/',
+      });
+      const version = await ctx.ds.getOpenSearchVersion();
+      expect(version.flavor).toBe(Flavor.OpenSearch);
+      expect(version.version).toBe('1.0.0');
+      expect(version.label).toBe('OpenSearch (compatibility mode)');
+    });
+  });
+
   describe('#executeLuceneQueries', () => {
     beforeEach(() => {
       createDatasource({


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This pr sets up the resource handler (taken from [elasticsearch](https://github.com/grafana/grafana/blob/d1ffcc22d915ab88599c627275cdcf6203e32084/pkg/tsdb/elasticsearch/elasticsearch.go#L190)) and uses it to get the opensearch version

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
