### PR TITLE
chore: add combine_prs action

### DIFF
--- a/.github/combine_prs.yml
+++ b/.github/combine_prs.yml
@@ -1,0 +1,22 @@
+name: Combine PRs
+
+on:
+  workflow_dispatch: # manual activation, for now
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: combine-prs
+        id: combine-prs
+        uses: github/combine-prs@v5.1.0
+        with:
+          labels: combined-pr
+          pr_title: "Dependabot updates"
+          branch_prefix: dependabot # the default, just for clarity


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the "Combine PRs" action to streamline working with dependabot.
