### PR TITLE
Chore: Update plugin.json keywords

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -16,7 +16,7 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "keywords": ["elasticsearch", "opensearch", "aws", "cloud provider", "database", "logs", "nosql", "traces"],
+    "keywords": ["datasource", "elasticsearch", "opensearch", "aws", "amazon", "cloud provider", "database", "logs", "nosql", "traces"],
     "logos": {
       "small": "img/logo.svg",
       "large": "img/logo.svg"


### PR DESCRIPTION
Update plugin.json keywords to include "amazon" + "datasource"

Related to https://github.com/grafana/oss-plugin-partnerships/issues/1055