### PR TITLE
Backend migration: migrate getTerms

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -191,6 +191,7 @@ func (ds *OpenSearchDatasource) CallResource(ctx context.Context, req *backend.C
 	if err != nil {
 		return err
 	}
+	request.Header = req.GetHTTPHeaders()
 
 	response, err := ds.HttpClient.Do(request)
 	if err != nil {

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -1435,6 +1435,48 @@ describe('OpenSearchDatasource', function (this: any) {
     });
   });
 
+  describe('getTerms backend flow', () => {
+    beforeEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+    });
+
+    afterEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = false;
+    });
+
+    it('should parse the terms', async () => {
+      const mockResource = jest.fn().mockResolvedValue({
+        responses: [
+          {
+            aggregations: {
+              '1': {
+                buckets: [
+                  {
+                    key: 'FEMALE',
+                    doc_count: 1979,
+                  },
+                  {
+                    key: 'MALE',
+                    doc_count: 1821,
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+      ctx.ds.postResource = mockResource;
+
+      const terms = await ctx.ds.getTerms({ field: 'customer_gender', query: '*' });
+      expect(terms).toEqual([
+        { text: 'FEMALE', value: 'FEMALE' },
+        { text: 'MALE', value: 'MALE' },
+      ]);
+    });
+  });
+
   describe('#executeLuceneQueries', () => {
     beforeEach(() => {
       createDatasource({

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -591,6 +591,9 @@ describe('OpenSearchDatasource', function (this: any) {
     let results: MetricFindValue[];
 
     beforeEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = false;
+
       createDatasource({
         url: OPENSEARCH_MOCK_URL,
         jsonData: {
@@ -658,6 +661,92 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should not set terms aggregation size to 0', () => {
+      expect(body['aggs']['1']['terms'].size).not.toBe(0);
+    });
+  });
+
+  describe('When issuing metricFind query with backend flow', () => {
+    let results: MetricFindValue[];
+    let mockResource = jest.fn().mockResolvedValue({});
+
+    beforeEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = true;
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: 'test',
+          version: '1.0.0',
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+
+      mockResource = jest.fn().mockImplementation((options) => {
+        return Promise.resolve({
+          responses: [
+            {
+              aggregations: {
+                '1': {
+                  buckets: [
+                    { doc_count: 1, key: 'test' },
+                    {
+                      doc_count: 2,
+                      key: 'test2',
+                      key_as_string: 'test2_as_string',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        });
+      });
+      ctx.ds.postResource = mockResource;
+
+      ctx.ds.metricFindQuery('{"find": "terms", "field": "test"}').then((res) => {
+        results = res;
+      });
+    });
+
+    afterEach(() => {
+      // @ts-ignore-next-line
+      config.featureToggles.openSearchBackendFlowEnabled = false;
+    });
+
+    it('should get results with script', () => {
+      ctx.ds.metricFindQuery('{"find": "terms", "script": "test"}').then((res) => {
+        results = res;
+      });
+
+      expect(results.length).toEqual(2);
+    });
+
+    it('should get results', () => {
+      expect(results.length).toEqual(2);
+    });
+
+    it('should use key or key_as_string', () => {
+      expect(results[0].text).toEqual('test');
+      expect(results[1].text).toEqual('test2_as_string');
+    });
+
+    it('should not set search type to count', () => {
+      const data = mockResource.mock.lastCall[1];
+      const dataArray = data.split('\n');
+      const header = JSON.parse(dataArray[0]);
+      expect(header.search_type).not.toBe('count');
+    });
+
+    it('should set size to 0', () => {
+      const data = mockResource.mock.lastCall[1];
+      const dataArray = data.split('\n');
+      const body = JSON.parse(dataArray[1]);
+      expect(body.size).toBe(0);
+    });
+
+    it('should not set terms aggregation size to 0', () => {
+      const data = mockResource.mock.lastCall[1];
+      const dataArray = data.split('\n');
+      const body = JSON.parse(dataArray[1]);
       expect(body['aggs']['1']['terms'].size).not.toBe(0);
     });
   });
@@ -1432,48 +1521,6 @@ describe('OpenSearchDatasource', function (this: any) {
       expect(version.flavor).toBe(Flavor.OpenSearch);
       expect(version.version).toBe('1.0.0');
       expect(version.label).toBe('OpenSearch (compatibility mode)');
-    });
-  });
-
-  describe('getTerms backend flow', () => {
-    beforeEach(() => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = true;
-    });
-
-    afterEach(() => {
-      // @ts-ignore-next-line
-      config.featureToggles.openSearchBackendFlowEnabled = false;
-    });
-
-    it('should parse the terms', async () => {
-      const mockResource = jest.fn().mockResolvedValue({
-        responses: [
-          {
-            aggregations: {
-              '1': {
-                buckets: [
-                  {
-                    key: 'FEMALE',
-                    doc_count: 1979,
-                  },
-                  {
-                    key: 'MALE',
-                    doc_count: 1821,
-                  },
-                ],
-              },
-            },
-          },
-        ],
-      });
-      ctx.ds.postResource = mockResource;
-
-      const terms = await ctx.ds.getTerms({ field: 'customer_gender', query: '*' });
-      expect(terms).toEqual([
-        { text: 'FEMALE', value: 'FEMALE' },
-        { text: 'MALE', value: 'MALE' },
-      ]);
     });
   });
 

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { from, merge, of, Observable, lastValueFrom } from 'rxjs';
+import { from, merge, of, Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import {
   DataSourceInstanceSettings,
@@ -798,7 +798,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     // @ts-ignore-next-line
     const { openSearchBackendFlowEnabled } = config.featureToggles;
     const getDbVersionObservable = openSearchBackendFlowEnabled
-      ? lastValueFrom(from(this.getResourceRequest('')))
+      ? this.getResourceRequest('')
       : this.request('GET', '/');
     return getDbVersionObservable.then(
       (results: any) => {
@@ -942,11 +942,10 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     // @ts-ignore-next-line
     const { openSearchBackendFlowEnabled } = config.featureToggles;
     const termsPromise = openSearchBackendFlowEnabled
-      ? lastValueFrom(from(this.postResourceRequest(url, esQuery)))
+      ? this.postResourceRequest(url, esQuery)
       : this.postMultiSearch(url, esQuery);
 
-    return termsPromise.then((results: any) => {
-      const res = openSearchBackendFlowEnabled ? results : results.data;
+    return termsPromise.then((res: any) => {
       if (!res.responses[0].aggregations) {
         return [];
       }

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -211,10 +211,13 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
     return this.getResource(path, params, options);
   }
 
-  postResourceRequest(path: string, data?: BackendSrvRequest['data'], options?: Partial<BackendSrvRequest>) {
+  async postResourceRequest(path: string, data?: BackendSrvRequest['data'], options?: Partial<BackendSrvRequest>) {
     const resourceOptions = options ?? {};
     resourceOptions.headers = resourceOptions.headers ?? {};
     resourceOptions.headers['content-type'] = 'application/x-ndjson';
+    if (this.sigV4Auth && data) {
+      resourceOptions.headers['x-amz-content-sha256'] = await sha256(data);
+    }
 
     return this.postResource(path, data, resourceOptions);
   }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Makes it so that getTerms queries can run through the backend.

**Which issue(s) this PR fixes**:

Fixes #467 

**Special notes for your reviewer**:
This is the dashboard I was using to test it. GetTerms is triggered by changing the value for the filter
[opensearch-external-1728336389759.json](https://github.com/user-attachments/files/17284659/opensearch-external-1728336389759.json)
