### PR TITLE
Migrate Annotation Queries to run through the backend

### DIFF
--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -934,7 +934,11 @@ describe('OpenSearchDatasource', function (this: any) {
 
         expect(annotations).toHaveLength(2);
         expect(annotations[0].time).toBe(1);
+        expect(annotations[0].tags?.[0]).toBe('foo');
+        expect(annotations[0].text).toBe(undefined);
         expect(annotations[1].time).toBe(3);
+        expect(annotations[1].tags?.[0]).toBe('bar');
+        expect(annotations[1].text).toBe(undefined);
       });
 
       it('should return annotation events using options', async () => {

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -902,14 +902,24 @@ describe('OpenSearchDatasource', function (this: any) {
 
   describe('annotationQuery', () => {
     describe('results processing', () => {
+      beforeEach(() => {
+        // @ts-ignore-next-line
+        config.featureToggles.openSearchBackendFlowEnabled = true;
+      });
+
+      afterEach(() => {
+        // @ts-ignore-next-line
+        config.featureToggles.openSearchBackendFlowEnabled = false;
+      });
+
       it('should return simple annotations using defaults', async () => {
         const mockResource = jest.fn().mockResolvedValue({
           responses: [
             {
               hits: {
                 hits: [
-                  { _source: { '@timestamp': 1, '@test_tags': 'foo', text: 'abc' } },
-                  { _source: { '@timestamp': 3, '@test_tags': 'bar', text: 'def' } },
+                  { _source: { '@timestamp': 1, tags: 'foo', text: 'abc' } },
+                  { _source: { '@timestamp': 3, tags: 'bar', text: 'def' } },
                 ],
               },
             },
@@ -918,7 +928,7 @@ describe('OpenSearchDatasource', function (this: any) {
         ctx.ds.postResource = mockResource;
 
         const annotations = await ctx.ds.annotationQuery({
-          annotation: { query: 'foo' },
+          annotation: { query: 'abc' },
           range: createTimeRange(toUtc([2015, 4, 30, 10]), toUtc([2015, 5, 1, 10])),
         });
 

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { from, merge, of, Observable } from 'rxjs';
+import { from, merge, of, Observable, lastValueFrom } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import {
   DataSourceInstanceSettings,
@@ -18,6 +18,8 @@ import {
   QueryFilterOptions,
   AdHocVariableFilter,
   CoreApp,
+  TypedVariableModel,
+  AnnotationEvent,
 } from '@grafana/data';
 import { OpenSearchResponse } from './OpenSearchResponse';
 import { IndexPattern } from './index_pattern';
@@ -33,7 +35,15 @@ import {
   getDataSourceSrv,
   getTemplateSrv,
 } from '@grafana/runtime';
-import { DataLinkConfig, Flavor, LuceneQueryType, OpenSearchOptions, OpenSearchQuery, QueryType } from './types';
+import {
+  DataLinkConfig,
+  Flavor,
+  LuceneQueryType,
+  OpenSearchAnnotationQuery,
+  OpenSearchOptions,
+  OpenSearchQuery,
+  QueryType,
+} from './types';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 import {
   isMetricAggregationWithField,
@@ -235,12 +245,24 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
   }
 
   annotationQuery(options: any): Promise<any> {
+    const payload = this.prepareAnnotationRequest(options);
+    // TODO: make this a query instead of a resource request
+    const annotationObservable = from(this.postResourceRequest('_msearch', payload));
+    return lastValueFrom(
+      annotationObservable.pipe(
+        map((res: any) => {
+          const hits = res.responses[0].hits.hits ?? [];
+          return this.processHitsToAnnotationEvents(options.annotation, hits);
+        })
+      )
+    );
+  }
+
+  private prepareAnnotationRequest(options: { annotation: OpenSearchAnnotationQuery; range: TimeRange }) {
     const annotation = options.annotation;
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
     const queryString = annotation.query || annotation.target.query;
-    const tagsField = annotation.tagsField || 'tags';
-    const textField = annotation.textField || null;
 
     const dateRanges = [];
     const rangeStart: any = {};
@@ -302,78 +324,83 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
       header.index = this.indexPattern.getIndexList(options.range.from, options.range.to);
     }
 
-    const payload = JSON.stringify(header) + '\n' + JSON.stringify(data) + '\n';
+    return JSON.stringify(header) + '\n' + JSON.stringify(data) + '\n';
+  }
 
-    return this.postMultiSearch('_msearch', payload).then((res: any) => {
-      const list = [];
-      const hits = res.responses[0].hits.hits;
+  // Private method used in the `annotationQuery` to process Elasticsearch hits into AnnotationEvents
+  private processHitsToAnnotationEvents(annotation: OpenSearchAnnotationQuery, hits: Array<{ [key: string]: any }>) {
+    const timeField = annotation.timeField || '@timestamp';
+    const timeEndField = annotation.timeEndField || null;
+    const textField = annotation.textField || 'tags';
+    const tagsField = annotation.tagsField || null;
+    const list: AnnotationEvent[] = [];
+    const getFieldFromSource = (source: any, fieldName: any) => {
+      if (!fieldName) {
+        return;
+      }
 
-      const getFieldFromSource = (source: any, fieldName: any) => {
-        if (!fieldName) {
-          return;
+      const fieldNames = fieldName.split('.');
+      let fieldValue = source;
+
+      for (let i = 0; i < fieldNames.length; i++) {
+        fieldValue = fieldValue[fieldNames[i]];
+        if (!fieldValue) {
+          console.log('could not find field in annotation: ', fieldName);
+          return '';
         }
+      }
 
-        const fieldNames = fieldName.split('.');
-        let fieldValue = source;
+      return fieldValue;
+    };
 
-        for (let i = 0; i < fieldNames.length; i++) {
-          fieldValue = fieldValue[fieldNames[i]];
-          if (!fieldValue) {
-            console.log('could not find field in annotation: ', fieldName);
-            return '';
-          }
+    for (let i = 0; i < hits.length; i++) {
+      const source = hits[i]._source;
+      let time = getFieldFromSource(source, timeField);
+      if (typeof hits[i].fields !== 'undefined') {
+        const fields = hits[i].fields;
+        if (_.isString(fields[timeField]) || _.isNumber(fields[timeField])) {
+          time = fields[timeField];
         }
+      }
 
-        return fieldValue;
+      const event: {
+        annotation: any;
+        time: number;
+        timeEnd?: number;
+        text: string;
+        tags?: string[];
+      } = {
+        annotation: annotation,
+        time: toUtc(time).valueOf(),
+        text: getFieldFromSource(source, textField),
       };
 
-      for (let i = 0; i < hits.length; i++) {
-        const source = hits[i]._source;
-        let time = getFieldFromSource(source, timeField);
-        if (typeof hits[i].fields !== 'undefined') {
-          const fields = hits[i].fields;
-          if (_.isString(fields[timeField]) || _.isNumber(fields[timeField])) {
-            time = fields[timeField];
-          }
+      if (timeEndField) {
+        const timeEnd = getFieldFromSource(source, timeEndField);
+        if (timeEnd) {
+          event.timeEnd = toUtc(timeEnd).valueOf();
         }
-
-        const event: {
-          annotation: any;
-          time: number;
-          timeEnd?: number;
-          text: string;
-          tags: string | string[];
-        } = {
-          annotation: annotation,
-          time: toUtc(time).valueOf(),
-          text: getFieldFromSource(source, textField),
-          tags: getFieldFromSource(source, tagsField),
-        };
-
-        if (timeEndField) {
-          const timeEnd = getFieldFromSource(source, timeEndField);
-          if (timeEnd) {
-            event.timeEnd = toUtc(timeEnd).valueOf();
-          }
-        }
-
-        // legacy support for title field
-        if (annotation.titleField) {
-          const title = getFieldFromSource(source, annotation.titleField);
-          if (title) {
-            event.text = title + '\n' + event.text;
-          }
-        }
-
-        if (typeof event.tags === 'string') {
-          event.tags = event.tags.split(',');
-        }
-
-        list.push(event);
       }
-      return list;
-    });
+
+      // legacy support for title field
+      if (annotation.titleField) {
+        const title = getFieldFromSource(source, annotation.titleField);
+        if (title) {
+          event.text = title + '\n' + event.text;
+        }
+      }
+
+      let tags = getFieldFromSource(source, tagsField);
+      if (typeof tags === 'string') {
+        tags = tags.split(',');
+      }
+      event.tags = tags;
+
+      list.push(event);
+    }
+    return list;
   }
+
   // called when an ad hoc filter is added in Explore
   toggleQueryFilter(query: OpenSearchQuery, filter: ToggleFilterAction): OpenSearchQuery {
     if (query.queryType === QueryType.Lucene) {

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -335,8 +335,8 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
   private processHitsToAnnotationEvents(annotation: OpenSearchAnnotationQuery, hits: Array<{ [key: string]: any }>) {
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
-    const textField = annotation.textField || 'tags';
-    const tagsField = annotation.tagsField || null;
+    const tagsField = annotation.tagsField || 'tags';
+    const textField = annotation.textField || null;
     const list: AnnotationEvent[] = [];
     const getFieldFromSource = (source: any, fieldName: any) => {
       if (!fieldName) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { DataFrame, DataQuery, DataQueryResponse, DataSourceJsonData } from '@grafana/data';
-import { DataSourceRef } from '@grafana/schema';
 import {
   BucketAggregation,
   BucketAggregationType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { DataFrame, DataQuery, DataQueryResponse, DataSourceJsonData } from '@grafana/data';
+import { DataSourceRef } from '@grafana/schema';
 import {
   BucketAggregation,
   BucketAggregationType,
@@ -81,6 +82,19 @@ export interface OpenSearchQuery extends DataQuery {
   format?: PPLFormatType;
   luceneQueryType?: LuceneQueryType;
   serviceMap?: boolean;
+}
+
+export interface OpenSearchAnnotationQuery {
+  target: OpenSearchQuery;
+  timeField?: string;
+  titleField?: string;
+  timeEndField?: string;
+  query?: string;
+  datasource: DataSourceRef;
+  tagsField?: string;
+  textField?: string;
+  // @deprecated index is deprecated and will be removed in the future
+  index?: string;
 }
 
 export type DataLinkConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,6 @@ export interface OpenSearchAnnotationQuery {
   titleField?: string;
   timeEndField?: string;
   query?: string;
-  datasource: DataSourceRef;
   tagsField?: string;
   textField?: string;
   // @deprecated index is deprecated and will be removed in the future


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This migrates the annotation queries to run through the backend, which is required for pdc.

**Which issue(s) this PR fixes**:

Fixes #466 

**Special notes for your reviewer**:
This copies the [elasticsearch version of this work](https://github.com/grafana/grafana/pull/68075), including the shortcut of running the queries through the resourcehandler instead of having it run through the query endpoint and parsed on the backend, which would add some work. It also doesn't include work to support variables in the annotation queries that elasticsearch has, but we weren't supporting them to begin with.
