### PR TITLE
Add support for logs volumes

### DIFF
--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -2,7 +2,6 @@ import {
   AdHocVariableFilter,
   CoreApp,
   DataFrame,
-  DataQuery,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -2,6 +2,7 @@ import {
   AdHocVariableFilter,
   CoreApp,
   DataFrame,
+  DataQuery,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
@@ -11,6 +12,7 @@ import {
   FieldCache,
   MetricFindValue,
   MutableDataFrame,
+  SupplementaryQueryType,
   TimeRange,
   toUtc,
 } from '@grafana/data';
@@ -2216,6 +2218,79 @@ describe('OpenSearchDatasource', function (this: any) {
           datasourceName: 'OSds',
           datasourceUid: 'dsUid',
         },
+      });
+    });
+  });
+
+  describe('getSupplementaryQuery', () => {
+    let ds: OpenSearchDatasource;
+    beforeEach(() => {
+      createDatasource({
+        url: OPENSEARCH_MOCK_URL,
+        jsonData: {
+          database: '[asd-]YYYY.MM.DD',
+          interval: 'Daily',
+          version: '1.0.0',
+          dataLinks: [
+            {
+              field: 'geo.coordinates.lat',
+              url: 'someUrl',
+            },
+            {
+              field: 'geo.coordinates.lon',
+              url: 'query',
+              datasourceUid: 'dsUid',
+            },
+          ],
+        } as OpenSearchOptions,
+      } as DataSourceInstanceSettings<OpenSearchOptions>);
+      ds = ctx.ds;
+    });
+    it('does not return logs volume query for metric query', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume },
+          {
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            bucketAggs: [{ type: 'filters', settings: { filters: [{ query: 'foo', label: '' }] }, id: '1' }],
+            query: 'foo="bar"',
+          }
+        )
+      ).toEqual(undefined);
+    });
+    it('returns logs volume query for log query', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume },
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1' }],
+            query: 'foo="bar"',
+          }
+        )
+      ).toEqual({
+        bucketAggs: [
+          {
+            field: '@timestamp',
+            id: '3',
+            settings: {
+              interval: 'auto',
+              min_doc_count: '0',
+              trimEdges: '0',
+            },
+            type: 'date_histogram',
+          },
+        ],
+        metrics: [
+          {
+            id: '1',
+            type: 'count',
+          },
+        ],
+        query: 'foo="bar"',
+        refId: 'log-volume-A',
+        timeField: '@timestamp',
       });
     });
   });

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -147,7 +147,7 @@ export class OpenSearchDatasource
 
   /**
    * Private method used in the `getSupplementaryRequest` for DataSourceWithSupplementaryQueriesSupport, specifically for Logs volume queries.
-   * @returns An DataQueryRequest or undefined if no suitable queries are found.
+   * @returns A DataQueryRequest or undefined if no suitable queries are found.
    */
   private getLogsVolumeDataProvider(
     request: DataQueryRequest<OpenSearchQuery>


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

This add the LogsVolume feature (See https://grafana.com/developers/plugin-tools/tutorials/build-a-logs-data-source-plugin#show-full-range-logs-volume).

This allow the user to see all logs and not just those displayed in the Logs table view.


Here is a preview of the visualization in the Explore View :
![Explore View](https://github.com/user-attachments/assets/60a8da30-25a7-4e9e-af0d-5c0097110e1e)

**Which issue(s) this PR fixes**:

Fixes #352 

**Special notes for your reviewer**:

Code is mostly adapted from ElasticSearch Plugin + Grafana Logs Datasource plugin documentation. Logs present in the screenshot are linux events from https://github.com/logpai/loghub 
Tests are also adapted from ElasticSearch Plugin, let us know if more tests are required