### PR TITLE
Fix: build each query response separately

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -78,9 +78,6 @@ func (rp *responseParser) parseResponse() (*backend.QueryDataResponse, error) {
 		return result, nil
 	}
 
-	queryRes := backend.DataResponse{
-		Frames: data.Frames{},
-	}
 	var serviceMapResponse []interface{}
 	var statsResponse []interface{}
 	var statsResponseIndex int
@@ -91,6 +88,9 @@ func (rp *responseParser) parseResponse() (*backend.QueryDataResponse, error) {
 		// grab the associated query
 		target := rp.Targets[i]
 
+		queryRes := backend.DataResponse{
+			Frames: data.Frames{},
+		}
 		var queryType string
 		if target.luceneQueryType == luceneQueryTypeTraces {
 			queryType = luceneQueryTypeTraces


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
When multiple queries are run through the backend flow, it would re-use the same `queryRes` when building the response. This would cause earlier queries' responses to be prepended to subsequent queries' responses. See the next screenshot, where there are 2 queries and both of them have different aliases. In the panel you can see there are 3 series returned and each one is labeled with `alias2`.

<img width="1691" alt="before" src="https://github.com/user-attachments/assets/8b8360e7-f548-4897-b9f7-400f38d14573">

With this PR, each query's response is built separately. Here is a screenshot of with the fix. There are now 2 series as expected and they and the alias is set correctly now.
<img width="1691" alt="after" src="https://github.com/user-attachments/assets/186c9fe4-ee2d-4e5a-81b1-055ee2f0fb3d">

**Which issue(s) this PR fixes**:

Fixes 

**Special notes for your reviewer**:
