### PR TITLE
Update ppl endpoint for opensearch

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -553,7 +553,12 @@ func (c *baseClientImpl) ExecutePPLQuery(ctx context.Context, r *PPLRequest) (*P
 	clientLog.Debug("Executing PPL")
 
 	req := createPPLRequest(r)
-	clientRes, err := c.executePPLRequest(ctx, "_opendistro/_ppl", req)
+
+	pplUrl := "_plugins/_ppl"
+	if c.GetFlavor() == Elasticsearch {
+		pplUrl = "_opendistro/_ppl"
+	}
+	clientRes, err := c.executePPLRequest(ctx, pplUrl, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Updates the ppl endpoint to then newer _plugins endpoint.
The _opendistro endpoint was deprecated ([link](https://github.com/opensearch-project/security/issues/3271)) , and opensearch has supported the _plugin endpoint since 1.0.0 ([link](https://opensearch.org/docs/1.0/search-plugins/ppl/endpoint/))

**Which issue(s) this PR fixes**:

Fixes #499

**Special notes for your reviewer**:
I decided not to update the frontend query code since we're planning to remove it, but I can if we think it would make sense
