### PR TITLE
Fix: Revert to using resource handler for health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.21.4
+
+- Fix: Revert to using resource handler for health check
+
 ## 2.21.3
 
 - Upgrade grafana-plugin-sdk-go (deps): Bump github.com/grafana/grafana-plugin-sdk-go from 0.258.0 to 0.259.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -494,10 +494,7 @@ export class OpenSearchDatasource extends DataSourceWithBackend<OpenSearchQuery,
 
   testDatasource() {
     // @ts-ignore-next-line
-    const { openSearchBackendFlowEnabled } = config.featureToggles;
-    if (openSearchBackendFlowEnabled) {
-      return this.callHealthCheck();
-    }
+    // TODO: run through backend health check
 
     if (!this.flavor || !valid(this.version)) {
       return Promise.resolve({


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Temporarily reverts to using the resource handler for the health check to fix confusing errors while using a wildcard index.

**Which issue(s) this PR fixes**:

Related to #500 

**Special notes for your reviewer**:
This is a quick fix for now, and we can revisit making the health check work properly when we have a little more time.
