### PR TITLE
Opensearch: Replace error source http client with a new error source methods

### DIFF
--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	exphttpclient "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource/httpclient"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 )
 
@@ -38,7 +37,8 @@ func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstance
 	if err != nil {
 		return nil, fmt.Errorf("error reading settings: %w", err)
 	}
-
+	
+	httpClientProvider := httpclient.NewProvider()
 	httpClientOptions, err := ds.HTTPClientOptions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client options: %w", err)
@@ -46,8 +46,6 @@ func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstance
 	if settings.OauthPassThru {
 		httpClientOptions.ForwardHTTPHeaders = true
 	}
-	// set the default middlewares from httpclient
-	httpClientOptions.Middlewares = httpclient.DefaultMiddlewares()
 
 	if httpClientOptions.SigV4 != nil {
 		httpClientOptions.SigV4.Service = "es"
@@ -61,7 +59,7 @@ func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstance
 		)
 	}
 
-	httpClient, err := exphttpclient.New(httpClientOptions)
+	httpClient, err := httpClientProvider.New(httpClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -37,7 +37,7 @@ func NewDatasourceHttpClient(ctx context.Context, ds *backend.DataSourceInstance
 	if err != nil {
 		return nil, fmt.Errorf("error reading settings: %w", err)
 	}
-	
+
 	httpClientProvider := httpclient.NewProvider()
 	httpClientOptions, err := ds.HTTPClientOptions(ctx)
 	if err != nil {


### PR DESCRIPTION
We want to deprecate and get rid of `errorsource/httpclient` as a part of https://github.com/grafana/grafana-plugin-sdk-go/issues/1105, as error source middleware implemented in experimental error source httpclient is turning any 400+ response to error and hiding original message. 

 Instead of that we have introduced 2 methods developers can use:
 - `backend.ErrorSourceFromHTTPStatus` to get error source from http code
 - `backend.IsDownstreamHTTPError` to get error source from http error

In this PR we are removing `errorsource/httpclient` and instead just using those methods.