### PR TITLE
Pass context in Lucene and PPL query requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.21.5
+
+- Fix: Pass context in Query Data requests
+
 ## 2.21.4
 
 - Fix: Revert to using resource handler for health check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## 2.21.5
 
-- Fix: Pass context in Query Data requests
+- Fix: Pass context in Query Data requests in [#507](https://github.com/grafana/opensearch-datasource/pull/507)
 
 ## 2.21.4
 
-- Fix: Revert to using resource handler for health check
+- Fix: Revert to using resource handler for health check in [#503](https://github.com/grafana/opensearch-datasource/pull/503)
 
 ## 2.21.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.21.4",
+  "version": "2.21.5",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/opensearch/client/client.go
+++ b/pkg/opensearch/client/client.go
@@ -263,9 +263,9 @@ func (c *baseClientImpl) executeRequest(ctx context.Context, method, uriPath, ur
 
 	var req *http.Request
 	if method == http.MethodPost {
-		req, err = http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(body))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewBuffer(body))
 	} else {
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	}
 	if err != nil {
 		return nil, err
@@ -488,9 +488,9 @@ func (c *baseClientImpl) executePPLQueryRequest(ctx context.Context, method, uri
 
 	var req *http.Request
 	if method == http.MethodPost {
-		req, err = http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(body))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewBuffer(body))
 	} else {
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

We had a bug report that oauth authorization headers weren't being passed if `Forward OAuth Identity` was selected. Resource requests were passing them fine, but query requests failed. It seems like not passing the context made it so that the appropriate headers weren't being applied [in plugin-sdk](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/http_headers.go#L125). 
User provided us with a docker-compose file where it was clear the the Authorization header was empty: 

<img width="919" alt="Screenshot 2024-11-18 at 20 58 08" src="https://github.com/user-attachments/assets/6d52ebc1-c268-488d-a221-cbb57b5e83a8">

After this fix: 
<img width="922" alt="Screenshot 2024-11-18 at 20 51 32" src="https://github.com/user-attachments/assets/ad7e1ab0-dcbe-487b-b087-3b7d15e1fcaf">


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/opensearch-datasource/issues/487

**Special notes for your reviewer**:
