### PR TITLE
fix: parse geohash precision as string instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.22.2
+
+- fix: parse geohash precision as string instead of int in [#523](https://github.com/grafana/opensearch-datasource/pull/523)
+
 ## 2.22.1
+
 - Add error source, remove some impossible errors in [#514](https://github.com/grafana/opensearch-datasource/pull/514)
 
 ## 2.22.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,14 @@ sysctl -w vm.max_map_count=262144
 ### Add sample data
 
 1. Go to the kibana (http://localhost:5601)
-1. Login with `admin:admin`
+1. Login with `admin:my_%New%_passW0rd!@#`
 1. At the welcome screen click _Add data_ and switch to the _Sample data_ tab.
 1. Import _Sample web logs_ and any other by your choice.
 
 ## Data source configuration
 
 URL: https://localhost:9200
-Basic Auth: `admin:admin`
+Basic Auth: `admin:my_%New%_passW0rd!@#`
 Skip TLS Verify: `true`
 
 ## How to set up local development environment to work with traces in Open Search

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m' # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=my_%New%_passW0rd!@#'
     ulimits:
       memlock:
         soft: -1
@@ -50,6 +51,7 @@ services:
       - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true
       - 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m'
+      - 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=my_%New%_passW0rd!@#'
     ulimits:
       memlock:
         soft: -1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -351,7 +351,7 @@ type ExtendedBounds struct {
 // GeoHashGridAggregation represents a geo hash grid aggregation
 type GeoHashGridAggregation struct {
 	Field     string `json:"field"`
-	Precision int    `json:"precision"`
+	Precision string `json:"precision"`
 }
 
 // MetricAggregation represents a metric aggregation

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -696,7 +696,7 @@ func (b *aggBuilderImpl) TraceList() AggBuilder {
 func (b *aggBuilderImpl) GeoHashGrid(key, field string, fn func(a *GeoHashGridAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &GeoHashGridAggregation{
 		Field:     field,
-		Precision: 5,
+		Precision: "5",
 	}
 	aggDef := newAggDefinition(key, &AggContainer{
 		Type:        "geohash_grid",

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -449,7 +449,7 @@ func addFiltersAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg) client.Ag
 
 func addGeoHashGridAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg) client.AggBuilder {
 	aggBuilder.GeoHashGrid(bucketAgg.ID, bucketAgg.Field, func(a *client.GeoHashGridAggregation, b client.AggBuilder) {
-		a.Precision = bucketAgg.Settings.Get("precision").MustInt(3)
+		a.Precision = bucketAgg.Settings.Get("precision").MustString("3")
 		aggBuilder = b
 	})
 

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -426,7 +426,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			assert.Equal(t, "geohash_grid", firstLevel.Aggregation.Type)
 			ghGridAgg := firstLevel.Aggregation.Aggregation.(*client.GeoHashGridAggregation)
 			assert.Equal(t, "@location", ghGridAgg.Field)
-			assert.Equal(t, 3, ghGridAgg.Precision)
+			assert.Equal(t, "3", ghGridAgg.Precision)
 		})
 
 		t.Run("With moving average", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

This fixes an issue where the geohash precision isn't respected. This happens because on the backend it's expecting an int, but the query specifies this as a string. So the precision field always ends up being set to the default value of 3 because of the type mismatch. I think this was probably not noticed until the backend migration completed since the previous frontend flow wouldn't have hit the backend path.

Before (it's always 3 characters returned which doesn't match the precision defined in the query):
<img width="2037" alt="before" src="https://github.com/user-attachments/assets/75190865-bf4f-4530-8172-ea2a81849540" />

After:
<img width="2037" alt="after" src="https://github.com/user-attachments/assets/d727fcc7-0c85-4886-8f99-13f1b1261d33" />


**Which issue(s) this PR fixes**:

Fixes #520 

**Special notes for your reviewer**:

In addition to the actual fix, I updated the docker-compose file to include a new required setting for the opensearch nodes. It requires setting `OPENSEARCH_INITIAL_ADMIN_PASSWORD` otherwise the node doesn't start up. I just set it to be `my_%New%_passW0rd!@#` and also updated the `CONTRIBUTING.md` with it.

You can test out the fix by running `yarn server` going to http://localhost:5601, adding sample flight data and running the query shown in the screenshot above.

I also prepared the release in this same PR to hopefully get this out before the freeze.
