### PR TITLE
Update provisioning to work with docker

### DIFF
--- a/provisioning/datasources/aws-opensearch.yaml
+++ b/provisioning/datasources/aws-opensearch.yaml
@@ -8,7 +8,7 @@ datasources:
   - name: AWS OpenSearch
     type: grafana-opensearch-datasource
     access: proxy
-    url: http://localhost:9200/
+    url: https://host.docker.internal:9200/
     basicAuth: true
     basicAuthUser: 'admin'
     jsonData:


### PR DESCRIPTION
When trying to run `yarn server`, the provisioned opensearch data source wasn't connecting. I needed to update the configuration for the provisioned data source so that it could connect to the opensearch node in docker. You can test by running, `yarn server` then going to the provisioned data source and clicking `Test`. Before this change, it would just error.