### PR TITLE
fix: prevent hidden queries from being used as supplementary queries

### DIFF
--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -2292,6 +2292,19 @@ describe('OpenSearchDatasource', function (this: any) {
         timeField: '@timestamp',
       });
     });
+    it('does not return logs volume query for hidden log query', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume },
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1' }],
+            query: 'foo="bar"',
+            hide: true,
+          }
+        )
+      ).toEqual(undefined);
+    });
   });
 });
 

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -191,6 +191,10 @@ export class OpenSearchDatasource
    * @returns A supplemented ES query or undefined if unsupported.
    */
   getSupplementaryQuery(options: SupplementaryQueryOptions, query: OpenSearchQuery): OpenSearchQuery | undefined {
+    if (query.hide) {
+      return undefined;
+    }
+    
     let isQuerySuitable = false;
 
     switch (options.type) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/grafana/grafana/pull/99356, hidden queries should not be used for supplementary queries.