### PR TITLE
Fix interval parsing

### DIFF
--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -292,10 +292,10 @@ func newAggDefinition(key string, aggregation *AggContainer) *aggDefinition {
 
 // HistogramAgg represents a histogram aggregation
 type HistogramAgg struct {
-	Interval    int    `json:"interval,omitempty"`
-	Field       string `json:"field"`
-	MinDocCount int    `json:"min_doc_count"`
-	Missing     *int   `json:"missing,omitempty"`
+	Interval    float64 `json:"interval,omitempty"`
+	Field       string  `json:"field"`
+	MinDocCount int     `json:"min_doc_count"`
+	Missing     *int    `json:"missing,omitempty"`
 }
 
 // DateHistogramAgg represents a date histogram aggregation

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -367,7 +367,7 @@ func addDateHistogramAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg, tim
 
 func addHistogramAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg) client.AggBuilder {
 	aggBuilder.Histogram(bucketAgg.ID, bucketAgg.Field, func(a *client.HistogramAgg, b client.AggBuilder) {
-		a.Interval = bucketAgg.Settings.Get("interval").MustInt(1000)
+		a.Interval = stringToFloatWithDefaultValue(bucketAgg.Settings.Get("interval").MustString(), 1000)
 		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
 
 		if missing, err := bucketAgg.Settings.Get("missing").Int(); err == nil {
@@ -454,4 +454,16 @@ func addGeoHashGridAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg) clien
 	})
 
 	return aggBuilder
+}
+
+func stringToFloatWithDefaultValue(valueStr string, defaultValue float64) float64 {
+	value, err := strconv.ParseFloat(valueStr, 64)
+	if err != nil {
+		value = defaultValue
+	}
+	// <=0 is not a valid value and in this case we default to defaultValue
+	if value <= 0 {
+		value = defaultValue
+	}
+	return value
 }

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -386,7 +386,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 						"id": "3",
 						"type": "histogram",
 						"field": "bytes",
-						"settings": { "interval": 10, "min_doc_count": 2, "missing": 5 }
+						"settings": { "interval": "10", "min_doc_count": 2, "missing": 5 }
 					}
 				],
 				"metrics": [{"type": "count", "id": "1" }]
@@ -399,7 +399,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			assert.Equal(t, "histogram", firstLevel.Aggregation.Type)
 			hAgg := firstLevel.Aggregation.Aggregation.(*client.HistogramAgg)
 			assert.Equal(t, "bytes", hAgg.Field)
-			assert.Equal(t, 10, hAgg.Interval)
+			assert.Equal(t, float64(10), hAgg.Interval)
 			assert.Equal(t, 2, hAgg.MinDocCount)
 			assert.Equal(t, 5, *hAgg.Missing)
 		})

--- a/pkg/opensearch/snapshot_tests/lucene_metric_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_metric_test.go
@@ -69,6 +69,101 @@ func Test_metric_max_group_by_terms_response(t *testing.T) {
 	experimental.CheckGoldenJSONResponse(t, "testdata", "lucene_metric_max_group_by_terms.expected_result_generated_snapshot.golden", &responseForRefIdA, false)
 }
 
+func Test_metric_sum_group_by_histogram_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_metric_sum_group_by_histogram.query_input.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":500,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+func Test_metric_sum_group_by_histogram_decimal_interval_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_metric_sum_group_by_histogram_decimal_interval.query_input.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":5.5,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+
+func Test_metric_sum_group_by_histogram_invalid_interval_request(t *testing.T) {
+	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_metric_sum_group_by_histogram_invalid_interval.query_input.json")
+	require.NoError(t, err)
+	var interceptedRequest []byte
+	openSearchDatasource := opensearch.OpenSearchDatasource{
+		HttpClient: &http.Client{
+			// we don't assert the response in this test
+			Transport: &queryDataTestRoundTripper{body: []byte(`{"responses":[]}`), statusCode: 200, requestCallback: func(req *http.Request) error {
+				interceptedRequest, err = io.ReadAll(req.Body)
+				if err != nil {
+					return err
+				}
+				defer req.Body.Close()
+				return nil
+			}},
+		},
+	}
+
+	_, err = openSearchDatasource.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: newTestDsSettings()},
+		Headers:       nil,
+		Queries:       queries,
+	})
+	require.NoError(t, err)
+
+	// assert request's header and query
+	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":1000,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+`
+	assert.Equal(t, expectedRequest, string(interceptedRequest))
+}
+
 func Test_metric_sum_group_by_date_histogram_request(t *testing.T) {
 	queries, err := setUpDataQueriesFromFileWithFixedTimeRange(t, "testdata/lucene_metric_sum_group_by_date_histogram.query_input.json")
 	require.NoError(t, err)

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram.query_input.json
@@ -1,0 +1,36 @@
+[
+  {
+    "alias": "distanceKms",
+    "bucketAggs": [
+      {
+        "field": "timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "500",
+          "min_doc_count": "0"
+        },
+        "type": "histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "cdba6469-80b4-49c5-84ad-d236738e8b91"
+    },
+    "format": "table",
+    "hide": false,
+    "metrics": [
+      {
+        "field": "DistanceKilometers",
+        "id": "1",
+        "type": "sum"
+      }
+    ],
+    "query": "*",
+    "queryType": "lucene",
+    "refId": "A",
+    "timeField": "timestamp",
+    "datasourceId": 2397,
+    "intervalMs": 1800000,
+    "maxDataPoints": 950
+  }
+]

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram_decimal_interval.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram_decimal_interval.query_input.json
@@ -1,0 +1,36 @@
+[
+  {
+    "alias": "distanceKms",
+    "bucketAggs": [
+      {
+        "field": "timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "5.5",
+          "min_doc_count": "0"
+        },
+        "type": "histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "cdba6469-80b4-49c5-84ad-d236738e8b91"
+    },
+    "format": "table",
+    "hide": false,
+    "metrics": [
+      {
+        "field": "DistanceKilometers",
+        "id": "1",
+        "type": "sum"
+      }
+    ],
+    "query": "*",
+    "queryType": "lucene",
+    "refId": "A",
+    "timeField": "timestamp",
+    "datasourceId": 2397,
+    "intervalMs": 1800000,
+    "maxDataPoints": 950
+  }
+]

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram_invalid_interval.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_metric_sum_group_by_histogram_invalid_interval.query_input.json
@@ -1,0 +1,36 @@
+[
+  {
+    "alias": "distanceKms",
+    "bucketAggs": [
+      {
+        "field": "timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "-10",
+          "min_doc_count": "0"
+        },
+        "type": "histogram"
+      }
+    ],
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "cdba6469-80b4-49c5-84ad-d236738e8b91"
+    },
+    "format": "table",
+    "hide": false,
+    "metrics": [
+      {
+        "field": "DistanceKilometers",
+        "id": "1",
+        "type": "sum"
+      }
+    ],
+    "query": "*",
+    "queryType": "lucene",
+    "refId": "A",
+    "timeField": "timestamp",
+    "datasourceId": 2397,
+    "intervalMs": 1800000,
+    "maxDataPoints": 950
+  }
+]


### PR DESCRIPTION
There's a bug when parsing the interval for histogram aggregation. Since it's an input field, it always comes from frontend as string, so in our code it always gets set as default. This adds a parsing function that parses string to float64 and allows decimal numbers

![Screenshot 2025-01-23 at 15 28 59](https://github.com/user-attachments/assets/33d01891-1456-435f-985b-ca54c91200b0)
