### PR TITLE
Fix: cast trim edges setting from a string to int

### DIFF
--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -1181,7 +1181,7 @@ func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
 		return
 	}
 
-	trimEdges, err := histogram.Settings.Get("trimEdges").Int()
+	trimEdges, err := castToInt(histogram.Settings.Get("trimEdges"))
 	if err != nil {
 		return
 	}
@@ -1189,10 +1189,8 @@ func (rp *responseParser) trimDatapoints(frames *data.Frames, target *Query) {
 	for _, f := range *frames {
 		if f.Rows() > trimEdges*2 {
 			for i := 0; i < trimEdges; i++ {
-				f.DeleteRow(i)
-			}
-			for i := f.Rows() - trimEdges; i < f.Rows(); i++ {
-				f.DeleteRow(i)
+				f.DeleteRow(0)
+				f.DeleteRow(f.Rows() - 1)
 			}
 		}
 	}
@@ -1332,6 +1330,25 @@ func (rp *responseParser) getMetricName(metric string) string {
 	}
 
 	return metric
+}
+
+func castToInt(j *simplejson.Json) (int, error) {
+	i, err := j.Int()
+	if err == nil {
+		return i, nil
+	}
+
+	s, err := j.String()
+	if err != nil {
+		return 0, err
+	}
+
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+
+	return v, nil
 }
 
 func castToFloat(j *simplejson.Json) *float64 {

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1000,7 +1000,7 @@ func Test_ResponseParser_test(t *testing.T) {
 		assert.EqualValues(t, 8, *seriesTwo.Fields[1].At(1).(*float64))
 	})
 
-	t.Run("With dropfirst and last aggregation", func(t *testing.T) {
+	t.Run("Trim edges trims `trimEdges` amount of data points from the beginning and ending of the time series", func(t *testing.T) {
 		targets := []tsdbQuery{{
 			refId: "A",
 			body: `{
@@ -1011,7 +1011,7 @@ func Test_ResponseParser_test(t *testing.T) {
 							"type": "date_histogram",
 							"field": "@timestamp",
 							"id": "2",
-							"settings": { "trimEdges": 1 }
+							"settings": { "trimEdges": 2 }
 						}
 					]
 				}`,
@@ -1025,7 +1025,7 @@ func Test_ResponseParser_test(t *testing.T) {
 					 {
 					   "1": { "value": 11 },
 					   "key": 1000,
-					   "doc_count": 369
+					   "doc_count": 100
 					 },
 					 {
 					   "1": { "value": 22 },
@@ -1035,6 +1035,26 @@ func Test_ResponseParser_test(t *testing.T) {
 					 {
 					   "1": { "value": 33 },
 					   "key": 3000,
+					   "doc_count": 300
+					 },
+					 {
+					   "1": { "value": 44 },
+					   "key": 4000,
+					   "doc_count": 400
+					 },
+					 {
+					   "1": { "value": 55 },
+					   "key": 5000,
+					   "doc_count": 500
+					 },
+					 {
+					   "1": { "value": 66 },
+					   "key": 6000,
+					   "doc_count": 600
+					 },
+					 {
+					   "1": { "value": 77 },
+					   "key": 7000,
 					   "doc_count": 200
 					 }
 				   ]
@@ -1056,18 +1076,26 @@ func Test_ResponseParser_test(t *testing.T) {
 		seriesOne := queryRes.Frames[0]
 		require.Len(t, seriesOne.Fields, 2)
 		assert.Equal(t, "Average", seriesOne.Fields[1].Config.DisplayNameFromDS)
-		require.Equal(t, 1, seriesOne.Fields[0].Len())
-		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
-		require.Equal(t, 1, seriesOne.Fields[1].Len())
-		assert.EqualValues(t, 22, *seriesOne.Fields[1].At(0).(*float64))
+		require.Equal(t, 3, seriesOne.Fields[0].Len())
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 3, 0, time.UTC), *seriesOne.Fields[0].At(0).(*time.Time))
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 4, 0, time.UTC), *seriesOne.Fields[0].At(1).(*time.Time))
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 5, 0, time.UTC), *seriesOne.Fields[0].At(2).(*time.Time))
+		require.Equal(t, 3, seriesOne.Fields[1].Len())
+		assert.EqualValues(t, 33, *seriesOne.Fields[1].At(0).(*float64))
+		assert.EqualValues(t, 44, *seriesOne.Fields[1].At(1).(*float64))
+		assert.EqualValues(t, 55, *seriesOne.Fields[1].At(2).(*float64))
 
 		seriesTwo := queryRes.Frames[1]
 		require.Len(t, seriesTwo.Fields, 2)
 		assert.Equal(t, "Count", seriesTwo.Fields[1].Config.DisplayNameFromDS)
-		require.Equal(t, 1, seriesTwo.Fields[0].Len())
-		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 2, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
-		require.Equal(t, 1, seriesTwo.Fields[1].Len())
-		assert.EqualValues(t, 200, *seriesTwo.Fields[1].At(0).(*float64))
+		require.Equal(t, 3, seriesTwo.Fields[0].Len())
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 3, 0, time.UTC), *seriesTwo.Fields[0].At(0).(*time.Time))
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 4, 0, time.UTC), *seriesTwo.Fields[0].At(1).(*time.Time))
+		assert.Equal(t, time.Date(1970, time.January, 1, 0, 0, 5, 0, time.UTC), *seriesTwo.Fields[0].At(2).(*time.Time))
+		require.Equal(t, 3, seriesTwo.Fields[1].Len())
+		assert.EqualValues(t, 300, *seriesTwo.Fields[1].At(0).(*float64))
+		assert.EqualValues(t, 400, *seriesTwo.Fields[1].At(1).(*float64))
+		assert.EqualValues(t, 500, *seriesTwo.Fields[1].At(2).(*float64))
 	})
 
 	t.Run("No group by time", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Trim edges is not working correctly when queries run through the backend flow. There's 2 different issues:

1. The `trimEdges` setting is a string, but is currently getting parsed as an int. This PR casts the setting to an int.
2. The code to delete the data points was skipping data points as it was deleting them so even if the `trimEdges` setting was cast to an int it didn't look like any data points were being trimmed.

**Which issue(s) this PR fixes**:

Fixes #544 

**Special notes for your reviewer**:
You can try it out with one of the provisioned data sources. Just set the `Trim Edges` setting to a number that is less than half the total number of data points for the time range you have. With the `Trim Edges` setting, you should see that the number of data points returned is reduced by the 2x the number set for `Trim Edges`. E.g. if there are 11 data points and you set `Trim Edges` to 2, then you should get back 7 data points.

<img width="834" alt="Screenshot 2025-01-27 at 1 18 40 PM" src="https://github.com/user-attachments/assets/5f2f90ee-8a58-4841-a045-695059828172" />
