### PR TITLE
Forward PPL response errors

### DIFF
--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -3,10 +3,9 @@ package opensearch
 import (
 	"context"
 	"fmt"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
-	client "github.com/grafana/opensearch-datasource/pkg/opensearch/client"
+	"github.com/grafana/opensearch-datasource/pkg/opensearch/client"
 )
 
 type pplHandler struct {
@@ -52,11 +51,21 @@ func (h *pplHandler) executeQueries(ctx context.Context) (*backend.QueryDataResp
 			return errorsource.AddErrorToResponse(refID, result, err), nil
 		}
 		if res.Status >= 400 {
-			errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code: %d", res.Status), false)
-			if res.Error != nil && res.Error["reason"] != "" && res.Error["details"] != "" {
-				errWithSource = errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("Received an error response %d: %v, %v", res.Status, res.Error["reason"], res.Error["details"]), false)
+			details := "(no details)"
+			if res.Error["reason"] != "" && res.Error["details"] != "" {
+				details = fmt.Sprintf("%v, %v", res.Error["reason"], res.Error["details"])
 			}
-			return errorsource.AddErrorToResponse(refID, result, errWithSource), nil
+			err = fmt.Errorf("ExecutePPLQuery received unexpected status code %d: %s", res.Status, details)
+			if backend.ErrorSourceFromHTTPStatus(res.Status) == backend.ErrorSourceDownstream {
+				err = backend.DownstreamError(err)
+			} else {
+				err = backend.PluginError(err)
+			}
+			return &backend.QueryDataResponse{
+				Responses: backend.Responses{
+					refID: backend.ErrorResponseWithErrorSource(err),
+				},
+			}, nil
 		}
 
 		query := h.queries[refID]

--- a/pkg/opensearch/ppl_handler.go
+++ b/pkg/opensearch/ppl_handler.go
@@ -53,6 +53,9 @@ func (h *pplHandler) executeQueries(ctx context.Context) (*backend.QueryDataResp
 		}
 		if res.Status >= 400 {
 			errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code: %d", res.Status), false)
+			if res.Error != nil && res.Error["reason"] != "" && res.Error["details"] != "" {
+				errWithSource = errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("Received an error response %d: %v, %v", res.Status, res.Error["reason"], res.Error["details"]), false)
+			}
 			return errorsource.AddErrorToResponse(refID, result, errWithSource), nil
 		}
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

It seems like PPL response errors aren't being forwarded to the user, if the Error object is defined in the response. It has this structure: 
<img width="233" alt="Screenshot 2025-03-07 at 10 40 04" src="https://github.com/user-attachments/assets/c3733ade-1627-4d86-a74f-647f393779d8" />
Before:
<img width="825" alt="Screenshot 2025-03-07 at 10 47 35" src="https://github.com/user-attachments/assets/227fdd8a-fe11-4567-ab60-fc48058cc12f" />
After:
<img width="1540" alt="Screenshot 2025-03-07 at 10 46 18" src="https://github.com/user-attachments/assets/cf763ce3-bc6d-4d05-82dd-5979f895829f" />

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
