### PR TITLE
Query Editor: UI improvements and Lucene query type selection improvements

### DIFF
--- a/src/__mocks__/OpenSearchDatasource.ts
+++ b/src/__mocks__/OpenSearchDatasource.ts
@@ -31,8 +31,8 @@ export const OpenSearchSettings: DataSourceInstanceSettings<OpenSearchOptions> =
     defaultRegion: 'us-west-1',
     database: '',
     timeField: '',
-    version: '',
-    flavor: Flavor.Elasticsearch,
+    version: '2.13.0',
+    flavor: Flavor.OpenSearch,
     timeInterval: '',
   },
   id: 0,
@@ -41,7 +41,7 @@ export const OpenSearchSettings: DataSourceInstanceSettings<OpenSearchOptions> =
   name: 'OpenSearch Test Datasource',
   meta,
   access: 'direct',
-  readOnly: false
+  readOnly: false,
 };
 export function setupMockedDataSource(
   customInstanceSettings: DataSourceInstanceSettings<OpenSearchOptions> = OpenSearchSettings

--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.test.tsx
@@ -1,8 +1,8 @@
+import React from 'react';
 import { DataSourcePluginMeta } from '@grafana/data';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OpenSearchDatasource } from 'opensearchDatasource';
-import React from 'react';
 import { Flavor, LuceneQueryType, OpenSearchQuery } from 'types';
 import { OpenSearchProvider } from '../OpenSearchQueryContext';
 import { LuceneQueryEditor } from './LuceneQueryEditor';
@@ -50,10 +50,14 @@ const createMockDatasource = () =>
   });
 
 describe('LuceneQueryEditor', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockOnChange = createMockOnChange();
+  const mockDatasource = createMockDatasource();
   it('renders a metric aggregations editor when the query is a metrics query', async () => {
     const mockQuery = createMockQuery();
-    const mockOnChange = createMockOnChange();
-    const mockDatasource = createMockDatasource();
 
     render(
       <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
@@ -61,14 +65,12 @@ describe('LuceneQueryEditor', () => {
       </OpenSearchProvider>
     );
 
-    expect(screen.queryByText('Metric')).toBeInTheDocument();
-    expect(screen.queryByText('Traces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Metric (1)')).toBeInTheDocument();
+    expect(screen.queryByText('Service Map')).not.toBeInTheDocument();
   });
 
   it('renders the traces query editor when traces is selected', async () => {
     const mockQuery = createMockQuery();
-    const mockOnChange = createMockOnChange();
-    const mockDatasource = createMockDatasource();
 
     render(
       <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
@@ -76,13 +78,10 @@ describe('LuceneQueryEditor', () => {
       </OpenSearchProvider>
     );
 
-    expect(screen.queryByText('Metric')).toBeInTheDocument();
-    expect(screen.queryByText('Traces')).not.toBeInTheDocument();
+    expect(screen.getByText('Metric (1)')).toBeInTheDocument();
+    expect(screen.queryByText('Service Map')).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Metric'));
-    expect(screen.queryByText('Traces')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Traces'));
-
     expect(mockOnChange).toHaveBeenCalledTimes(1);
     expect(mockOnChange.mock.calls[0][0].luceneQueryType).toBe('Traces');
   });
@@ -90,8 +89,6 @@ describe('LuceneQueryEditor', () => {
   it('renders the size field when traces is selected', async () => {
     const mockQuery = createMockQuery();
     mockQuery.luceneQueryType = LuceneQueryType.Traces;
-    const mockOnChange = createMockOnChange();
-    const mockDatasource = createMockDatasource();
 
     render(
       <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
@@ -112,8 +109,6 @@ describe('LuceneQueryEditor', () => {
     const mockQuery = createMockQuery({
       luceneQueryType: LuceneQueryType.Traces,
     });
-    const mockOnChange = createMockOnChange();
-    const mockDatasource = createMockDatasource();
 
     render(
       <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
@@ -121,17 +116,14 @@ describe('LuceneQueryEditor', () => {
       </OpenSearchProvider>
     );
 
-    expect(screen.queryByText('Service Map')).toBeInTheDocument();
-    expect(screen.queryByText('Size')).toBeInTheDocument();
-    jest.clearAllMocks();
+    expect(screen.getByText('Service Map')).toBeInTheDocument();
+    expect(screen.getByText('Size')).toBeInTheDocument();
   });
   it('does not render the size input if service map is selected', async () => {
     const mockQuery = createMockQuery({
       luceneQueryType: LuceneQueryType.Traces,
       serviceMap: true,
     });
-    const mockOnChange = createMockOnChange();
-    const mockDatasource = createMockDatasource();
 
     render(
       <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
@@ -139,9 +131,103 @@ describe('LuceneQueryEditor', () => {
       </OpenSearchProvider>
     );
 
-    expect(screen.queryByText('Service Map')).toBeInTheDocument();
+    expect(screen.getByText('Service Map')).toBeInTheDocument();
     // Size should not be rendered if service map is selected
     expect(screen.queryByText('Size')).not.toBeInTheDocument();
-    jest.clearAllMocks();
+  });
+
+  it('should render the size field if Logs query is selected', async () => {
+    const mockQuery = createMockQuery({
+      luceneQueryType: LuceneQueryType.Logs,
+      metrics: [{ type: 'logs', id: 'abc' }],
+    });
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+    await userEvent.click(screen.getByTestId('settings-button'));
+    expect(screen.getByText('Size')).toBeInTheDocument();
+  });
+
+  it('should render raw data setting if Raw Data query is selected', async () => {
+    const mockQuery = createMockQuery({
+      luceneQueryType: LuceneQueryType.RawData,
+      metrics: [{ type: 'raw_data', id: 'abc', settings: { useTimeRange: true } }],
+    });
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+    await userEvent.click(screen.getByTestId('settings-button'));
+    expect(screen.getByText('Size')).toBeInTheDocument();
+    expect(screen.getByText('Use time range')).toBeInTheDocument();
+    expect(screen.getByText('Order')).toBeInTheDocument();
+  });
+
+  it('should not render order setting if Raw Data query is selected and useTimeRange is false', async () => {
+    const mockQuery = createMockQuery({
+      luceneQueryType: LuceneQueryType.RawData,
+      metrics: [{ type: 'raw_data', id: 'abc', settings: { useTimeRange: false } }],
+    });
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    await userEvent.click(screen.getByTestId('settings-button'));
+    expect(screen.getByText('Size')).toBeInTheDocument();
+    expect(screen.getByText('Use time range')).toBeInTheDocument();
+    expect(screen.queryByText('Order')).not.toBeInTheDocument();
+  });
+
+  it('Should NOT show Bucket Aggregations Editor if query contains a "singleMetric" metric', () => {
+    const mockQuery: OpenSearchQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [
+        {
+          id: '1',
+          type: 'logs',
+        },
+      ],
+      // Even if present, this shouldn't be shown in the UI
+      bucketAggs: [{ id: '2', type: 'date_histogram' }],
+    };
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    expect(screen.queryByLabelText('Group By')).not.toBeInTheDocument();
+  });
+
+  it('Should show Bucket Aggregations Editor if query does NOT contains a "singleMetric" metric', () => {
+    const mockQuery: OpenSearchQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [
+        {
+          id: '1',
+          type: 'avg',
+        },
+      ],
+      bucketAggs: [{ id: '2', type: 'date_histogram' }],
+    };
+
+    render(
+      <OpenSearchProvider query={mockQuery} onChange={mockOnChange} datasource={mockDatasource}>
+        <LuceneQueryEditor query={mockQuery} onChange={mockOnChange} />
+      </OpenSearchProvider>
+    );
+
+    expect(screen.getByText('Group By')).toBeInTheDocument();
   });
 });

--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryEditor.tsx
@@ -29,6 +29,7 @@ export const LuceneQueryEditor = (props: LuceneQueryEditorProps) => {
         <EditorRow>
           <InlineField label="Service Map" tooltip={'Request and display service map data for trace(s)'}>
             <InlineSwitch
+              transparent
               value={props.query.serviceMap || false}
               onChange={(event) => {
                 const newVal = event.currentTarget.checked;

--- a/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryTypeSelector.tsx
+++ b/src/components/QueryEditor/LuceneQueryEditor/LuceneQueryTypeSelector.tsx
@@ -1,0 +1,74 @@
+import { SelectableValue } from '@grafana/data';
+import { RadioButtonGroup } from '@grafana/ui';
+
+import React from 'react';
+import { MetricAggregation } from '../MetricAggregationsEditor/aggregations';
+import { LuceneQueryType, OpenSearchQuery } from 'types';
+import { useQuery } from '../OpenSearchQueryContext';
+import { useDispatch } from 'hooks/useStatelessReducer';
+import { metricAggregationConfig } from '../MetricAggregationsEditor/utils';
+import { updateLuceneTypeAndMetrics } from './state';
+import { getNewMetrics } from '../MetricAggregationsEditor/state/reducer';
+
+const OPTIONS: Array<SelectableValue<LuceneQueryType>> = [
+  { value: LuceneQueryType.Metric, label: 'Metric' },
+  { value: LuceneQueryType.Logs, label: 'Logs' },
+  { value: LuceneQueryType.RawData, label: 'Raw Data' },
+  { value: LuceneQueryType.RawDocument, label: 'Raw Document' },
+  { value: LuceneQueryType.Traces, label: 'Traces' },
+];
+
+function queryTypeToMetricType(type: LuceneQueryType): MetricAggregation['type'] {
+  switch (type) {
+    case LuceneQueryType.Logs:
+      return 'logs';
+    case LuceneQueryType.Metric:
+      return 'count';
+    case LuceneQueryType.RawData:
+      return 'raw_data';
+    case LuceneQueryType.RawDocument:
+      return 'raw_document';
+    default:
+      // should never happen
+      throw new Error(`Query type ${type} does not have a corresponding metric aggregation`);
+  }
+}
+
+export const LuceneQueryTypeSelector = (props: { onChange: (query: OpenSearchQuery) => void }) => {
+  const query = useQuery();
+  const dispatch = useDispatch();
+
+  const firstMetric = query.metrics?.[0];
+
+  if (firstMetric == null) {
+    // not sure if this can really happen, but we should handle it anyway
+    return null;
+  }
+
+  const queryType =
+    query.luceneQueryType === LuceneQueryType.Traces
+      ? LuceneQueryType.Traces
+      : metricAggregationConfig[firstMetric.type].impliedLuceneQueryType;
+
+  const onChangeQueryType = (newQueryType: LuceneQueryType) => {
+    if (newQueryType !== LuceneQueryType.Traces) {
+      dispatch(
+        updateLuceneTypeAndMetrics({
+          luceneQueryType: newQueryType,
+          metrics: getNewMetrics(query.metrics || [], firstMetric.id, queryTypeToMetricType(newQueryType)),
+        })
+      );
+    } else {
+      props.onChange({ ...query, luceneQueryType: newQueryType });
+    }
+  };
+
+  return (
+    <RadioButtonGroup<LuceneQueryType>
+      fullWidth={false}
+      options={OPTIONS}
+      value={queryType}
+      onChange={onChangeQueryType}
+    />
+  );
+};

--- a/src/components/QueryEditor/LuceneQueryEditor/state.test.ts
+++ b/src/components/QueryEditor/LuceneQueryEditor/state.test.ts
@@ -1,0 +1,43 @@
+import { LuceneQueryType, OpenSearchQuery } from 'types';
+import { initQuery } from '../state';
+import { luceneQueryTypeReducer, updateLuceneTypeAndMetrics } from './state';
+import { reducerTester } from 'reducerTester';
+
+describe('Lucene Query Type Reducer', () => {
+  describe('On Init', () => {
+    it('Should maintain the previous query type if present', () => {
+      const initialType: LuceneQueryType = LuceneQueryType.Logs;
+      reducerTester<OpenSearchQuery['luceneQueryType']>()
+        .givenReducer(luceneQueryTypeReducer, initialType)
+        .whenActionIsDispatched(initQuery())
+        .thenStateShouldEqual(initialType);
+    });
+
+    it('Should set lucene type to Metric if it is not already set', () => {
+      const initialType: OpenSearchQuery['luceneQueryType'] = undefined;
+      const expectedType = LuceneQueryType.Metric;
+
+      reducerTester<OpenSearchQuery['luceneQueryType']>()
+        .givenReducer(luceneQueryTypeReducer, initialType)
+        .whenActionIsDispatched(initQuery())
+        .thenStateShouldEqual(expectedType);
+    });
+  });
+
+  it('Should correctly set lucene query type', () => {
+    const initialType: LuceneQueryType = LuceneQueryType.Traces;
+    reducerTester<OpenSearchQuery['luceneQueryType']>()
+      .givenReducer(luceneQueryTypeReducer, initialType)
+      .whenActionIsDispatched(updateLuceneTypeAndMetrics({ luceneQueryType: LuceneQueryType.Logs, metrics: [] }))
+      .thenStateShouldEqual(LuceneQueryType.Logs);
+  });
+
+  it('Should not change state with other action types', () => {
+    const initialType: LuceneQueryType = LuceneQueryType.Traces;
+
+    reducerTester<OpenSearchQuery['luceneQueryType']>()
+      .givenReducer(luceneQueryTypeReducer, initialType)
+      .whenActionIsDispatched({ type: 'THIS ACTION SHOULD NOT HAVE ANY EFFECT IN THIS REDUCER' })
+      .thenStateShouldEqual(initialType);
+  });
+});

--- a/src/components/QueryEditor/LuceneQueryEditor/state.ts
+++ b/src/components/QueryEditor/LuceneQueryEditor/state.ts
@@ -1,0 +1,21 @@
+import { type Action, createAction } from '@reduxjs/toolkit';
+import { initQuery } from '../state';
+import { LuceneQueryType, OpenSearchQuery } from 'types';
+
+export const UPDATE_LUCENE_TYPE_AND_METRICS = 'update_lucene_type_and_metrics';
+
+export const updateLuceneTypeAndMetrics = createAction<{
+  metrics: OpenSearchQuery['metrics'];
+  luceneQueryType: OpenSearchQuery['luceneQueryType'];
+}>(UPDATE_LUCENE_TYPE_AND_METRICS);
+
+export const luceneQueryTypeReducer = (prevQueryType: OpenSearchQuery['luceneQueryType'], action: Action) => {
+  if (updateLuceneTypeAndMetrics.match(action)) {
+    return action.payload.luceneQueryType;
+  }
+  if (initQuery.match(action)) {
+    return prevQueryType || LuceneQueryType.Metric;
+  }
+
+  return prevQueryType;
+};

--- a/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { PropsWithChildren } from 'react';
+
+import { OpenSearchQuery } from '../../../types';
+import { OpenSearchProvider } from '../OpenSearchQueryContext';
+
+import { MetricEditor } from './MetricEditor';
+import { setupMockedDataSource } from '__mocks__/OpenSearchDatasource';
+import { MetricAggregation } from './aggregations';
+
+describe('Metric Editor', () => {
+  it('Should not list special metrics', async () => {
+    const count: MetricAggregation = {
+      id: '1',
+      type: 'count',
+    };
+
+    const mockQuery: OpenSearchQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [count],
+      bucketAggs: [],
+    };
+
+    const wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <OpenSearchProvider query={mockQuery} onChange={jest.fn()} datasource={setupMockedDataSource()}>
+        {children}
+      </OpenSearchProvider>
+    );
+
+    render(<MetricEditor value={count} />, { wrapper });
+    await userEvent.click(screen.getByText('Count'));
+
+    // we check if the list-of-options is visible by
+    // checking for an item to exist
+    expect(screen.getByText('Extended Stats')).toBeInTheDocument();
+
+    // now we make sure that special metric aren't shown
+    expect(screen.queryByText('Logs')).toBeNull();
+    expect(screen.queryByText('Raw Data')).toBeNull();
+    expect(screen.queryByText('Raw Document')).toBeNull();
+  });
+});

--- a/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -52,8 +52,10 @@ const getTypeOptions = (
 
   return (
     Object.entries(metricAggregationConfig)
+      // Don't show entries that are already controlled by LuceneQueryTypeSelector
+      .filter(([_, config]) => !config.isSingleMetric)
       // Only showing metrics type supported by the configured version of OpenSearch
-      .filter(([_, { versionRange }]) => satisfies(version, versionRange?.[flavor] || '*'))
+      .filter(([key, { versionRange }]) => satisfies(version, versionRange?.[flavor] || '*'))
       // Filtering out Pipeline Aggregations if there's no basic metric selected before
       .filter(([_, config]) => includePipelineAggregations || !config.isPipelineAgg)
       .map(([key, { label }]) => ({

--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -1,4 +1,4 @@
-import { InlineField, Input, Switch, Select } from '@grafana/ui';
+import { InlineField, Input, Switch, Select, InlineSwitch } from '@grafana/ui';
 import React, { ComponentProps, useState } from 'react';
 import { extendedStats } from '../../../../query_def';
 import { useDispatch } from '../../../../hooks/useStatelessReducer';
@@ -106,7 +106,7 @@ export const SettingsEditor = ({ metric, previousMetrics }: Props) => {
             />
           </InlineField>
           <InlineField label="Use time range" {...inlineFieldProps}>
-            <Switch
+            <InlineSwitch
               id={`OS-query-${query.refId}_metric-${metric.id}-use-time-range`}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 dispatch(changeMetricSetting({ metric, settingName: 'useTimeRange', newValue: e.target.checked }))

--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -53,37 +53,6 @@ export const SettingsEditor = ({ metric, previousMetrics }: Props) => {
         <BucketScriptSettingsEditor value={metric} previousMetrics={previousMetrics} />
       )}
 
-      {(metric.type === 'raw_data' || metric.type === 'raw_document') && (
-        <>
-          <InlineField label="Size" {...inlineFieldProps}>
-            <Input
-              id={`ES-query-${query.refId}_metric-${metric.id}-size`}
-              onBlur={(e) => dispatch(changeMetricSetting({ metric, settingName: 'size', newValue: e.target.value }))}
-              defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
-            />
-          </InlineField>
-          <InlineField label="Use time range" {...inlineFieldProps}>
-            <Switch
-              id={`ES-query-${query.refId}_metric-${metric.id}-use-time-range`}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                dispatch(changeMetricSetting({ metric, settingName: 'useTimeRange', newValue: e.target.checked }))
-              }
-              value={metric.settings?.useTimeRange}
-            />
-          </InlineField>
-          {metric.settings?.useTimeRange && (
-            <InlineField label="Order" htmlFor={`ES-query-${query.refId}_metric-${metric.id}-order`}>
-              <Select
-                inputId={`ES-query-${query.refId}_metric-${metric.id}-order`}
-                options={orderOptions}
-                onChange={(e) => dispatch(changeMetricSetting({ metric, settingName: 'order', newValue: e.value }))}
-                value={metric.settings?.order || 'desc'}
-              />
-            </InlineField>
-          )}
-        </>
-      )}
-
       {metric.type === 'cardinality' && (
         <SettingField label="Precision Threshold" metric={metric} settingName="precision_threshold" />
       )}
@@ -125,6 +94,48 @@ export const SettingsEditor = ({ metric, previousMetrics }: Props) => {
             placeholder="1,5,25,50,75,95,99"
           />
         </InlineField>
+      )}
+
+      {(metric.type === 'raw_data' || metric.type === 'raw_document') && (
+        <>
+          <InlineField label="Size" {...inlineFieldProps}>
+            <Input
+              id={`OS-query-${query.refId}_metric-${metric.id}-size`}
+              onBlur={(e) => dispatch(changeMetricSetting({ metric, settingName: 'size', newValue: e.target.value }))}
+              defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
+            />
+          </InlineField>
+          <InlineField label="Use time range" {...inlineFieldProps}>
+            <Switch
+              id={`OS-query-${query.refId}_metric-${metric.id}-use-time-range`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                dispatch(changeMetricSetting({ metric, settingName: 'useTimeRange', newValue: e.target.checked }))
+              }
+              value={metric.settings?.useTimeRange}
+            />
+          </InlineField>
+          {metric.settings?.useTimeRange && (
+            <InlineField label="Order" htmlFor={`OS-query-${query.refId}_metric-${metric.id}-order`}>
+              <Select
+                inputId={`OS-query-${query.refId}_metric-${metric.id}-order`}
+                options={orderOptions}
+                onChange={(e) => dispatch(changeMetricSetting({ metric, settingName: 'order', newValue: e.value }))}
+                value={metric.settings?.order || 'desc'}
+              />
+            </InlineField>
+          )}
+        </>
+      )}
+      {metric.type === 'logs' && (
+        <>
+          <InlineField label="Size" {...inlineFieldProps}>
+            <Input
+              id={`OS-query-${query.refId}_metric-${metric.id}-size`}
+              onBlur={(e) => dispatch(changeMetricSetting({ metric, settingName: 'size', newValue: e.target.value }))}
+              defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
+            />
+          </InlineField>
+        </>
       )}
 
       {isMetricAggregationWithInlineScript(metric) && (

--- a/src/components/QueryEditor/MetricAggregationsEditor/SpecialMetricAggregationsRow.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SpecialMetricAggregationsRow.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { InlineFieldRow, InlineLabel, InlineSegmentGroup } from '@grafana/ui';
+
+import { SettingsEditor } from './SettingsEditor';
+import { MetricAggregation } from './aggregations';
+
+type Props = {
+  name: string;
+  metric: MetricAggregation;
+  info?: string;
+};
+
+export const SpecialMetricAggregationsRow = ({ name, metric, info }: Props) => {
+  // this widget is only used in scenarios when there is only a single
+  // metric, so the array of "previousMetrics" (meaning all the metrics
+  // before the current metric), is an empty-array
+  const previousMetrics: MetricAggregation[] = [];
+
+  return (
+    <InlineFieldRow>
+      <InlineSegmentGroup>
+        <InlineLabel width={17} as="div">
+          <span>{name}</span>
+        </InlineLabel>
+      </InlineSegmentGroup>
+      <SettingsEditor metric={metric} previousMetrics={previousMetrics} />
+      {info != null && (
+        <InlineSegmentGroup>
+          <InlineLabel>{info}</InlineLabel>
+        </InlineSegmentGroup>
+      )}
+    </InlineFieldRow>
+  );
+};

--- a/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -150,6 +150,9 @@ interface RawData extends BaseMetricAggregation {
 
 interface Logs extends BaseMetricAggregation {
   type: 'logs';
+  settings?: {
+    size?: string;
+  };
 }
 
 export interface BasePipelineMetricAggregation extends MetricAggregationWithField {
@@ -282,7 +285,8 @@ export type MetricAggregationWithSettings =
   | Sum
   | Average
   | MovingAverage
-  | MovingFunction;
+  | MovingFunction
+  | Logs;
 
 export type MetricAggregationWithMeta = ExtendedStats;
 

--- a/src/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -7,6 +7,7 @@ import { MetricAggregation } from './aggregations';
 import { useQuery } from '../OpenSearchQueryContext';
 import { QueryEditorRow } from '../QueryEditorRow';
 import { IconButton } from '../../IconButton';
+import { SpecialMetricAggregationsRow } from './SpecialMetricAggregationsRow';
 
 interface Props {
   nextId: MetricAggregation['id'];
@@ -19,22 +20,35 @@ export const MetricAggregationsEditor = ({ nextId }: Props) => {
 
   return (
     <>
-      {metrics?.map((metric, index) => (
-        <QueryEditorRow
-          key={metric.id}
-          label={`Metric (${metric.id})`}
-          hidden={metric.hide}
-          onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}
-          onRemoveClick={() => dispatch(removeMetric(metric.id))}
-          disableRemove={!(totalMetrics > 1)}
-        >
-          <MetricEditor value={metric} />
+      {metrics?.map((metric, index) => {
+        switch (metric.type) {
+          case 'logs':
+            return <SpecialMetricAggregationsRow key={`${metric.type}-${metric.id}`} name="Logs" metric={metric} />;
+          case 'raw_data':
+            return <SpecialMetricAggregationsRow key={`${metric.type}-${metric.id}`} name="Raw Data" metric={metric} />;
+          case 'raw_document':
+            return (
+              <SpecialMetricAggregationsRow key={`${metric.type}-${metric.id}`} name="Raw Document" metric={metric} />
+            );
+          default:
+            return (
+              <QueryEditorRow
+                key={metric.id}
+                label={`Metric (${metric.id})`}
+                hidden={metric.hide}
+                onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}
+                onRemoveClick={() => dispatch(removeMetric(metric.id))}
+                disableRemove={!(totalMetrics > 1)}
+              >
+                <MetricEditor value={metric} />
 
-          {!metricAggregationConfig[metric.type].isSingleMetric && index === 0 && (
-            <IconButton iconName="plus" onClick={() => dispatch(addMetric(nextId))} label="add" />
-          )}
-        </QueryEditorRow>
-      ))}
+                {!metricAggregationConfig[metric.type].isSingleMetric && index === 0 && (
+                  <IconButton iconName="plus" onClick={() => dispatch(addMetric(nextId))} label="add" />
+                )}
+              </QueryEditorRow>
+            );
+        }
+      })}
     </>
   );
 };

--- a/src/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
@@ -13,7 +13,8 @@ import {
 import { Derivative, ExtendedStats, MetricAggregation } from '../aggregations';
 import { defaultMetricAgg } from '../../../../query_def';
 import { metricAggregationConfig } from '../utils';
-import { OpenSearchQuery } from 'types';
+import { LuceneQueryType, OpenSearchQuery } from 'types';
+import { updateLuceneTypeAndMetrics } from 'components/QueryEditor/LuceneQueryEditor/state';
 
 describe('Metric Aggregations Reducer', () => {
   it('should correctly add new aggregations', () => {
@@ -209,6 +210,29 @@ describe('Metric Aggregations Reducer', () => {
         changeMetricAttribute({ metric: firstAggregation, attribute: 'hide', newValue: expectedHide })
       )
       .thenStateShouldEqual([{ ...firstAggregation, hide: expectedHide }, secondAggregation]);
+  });
+
+  it('should update metrics when lucene type is updated', () => {
+    const metrics: MetricAggregation[] = [
+      {
+        id: '1',
+        type: 'count',
+      },
+    ];
+    const newMetrics: MetricAggregation[] = [
+      {
+        id: '1',
+        type: 'avg',
+        field: 'ticketPrice',
+      },
+    ];
+
+    reducerTester<OpenSearchQuery['metrics']>()
+      .givenReducer(reducer, metrics)
+      .whenActionIsDispatched(
+        updateLuceneTypeAndMetrics({ luceneQueryType: LuceneQueryType.Metric, metrics: newMetrics })
+      )
+      .thenStateShouldEqual(newMetrics);
   });
 
   it('Should not change state with other action types', () => {

--- a/src/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
@@ -15,6 +15,7 @@ import {
   changeMetricSetting,
   changeMetricMeta,
 } from './actions';
+import { updateLuceneTypeAndMetrics } from 'components/QueryEditor/LuceneQueryEditor/state';
 
 export const reducer = (state: OpenSearchQuery['metrics'], action: Action): OpenSearchQuery['metrics'] => {
   if (addMetric.match(action)) {
@@ -32,31 +33,11 @@ export const reducer = (state: OpenSearchQuery['metrics'], action: Action): Open
   }
 
   if (changeMetricType.match(action)) {
-    return state
-      ?.filter((metric) =>
-        // When the new metric type is `isSingleMetric` we remove all other metrics from the query
-        // leaving only the current one.
-        !!metricAggregationConfig[action.payload.type].isSingleMetric ? metric.id === action.payload.id : true
-      )
-      .map((metric) => {
-        if (metric.id !== action.payload.id) {
-          return metric;
-        }
-
-        /*
-        TODO: The previous version of the query editor was keeping some of the old metric's configurations
-        in the new selected one (such as field or some settings).
-        It the future would be nice to have the same behavior but it's hard without a proper definition,
-        as Elasticsearch will error sometimes if some settings are not compatible.
-      */
-        return {
-          id: metric.id,
-          type: action.payload.type,
-          ...metricAggregationConfig[action.payload.type].defaults,
-        } as MetricAggregation;
-      });
+    return getNewMetrics(state || [], action.payload.id, action.payload.type);
   }
-
+  if (updateLuceneTypeAndMetrics.match(action)) {
+    return action.payload.metrics;
+  }
   if (changeMetricField.match(action)) {
     return state?.map((metric) => {
       if (metric.id !== action.payload.id) {
@@ -153,4 +134,34 @@ export const reducer = (state: OpenSearchQuery['metrics'], action: Action): Open
   }
 
   return state;
+};
+
+export const getNewMetrics = (
+  currentMetrics: MetricAggregation[],
+  metricId: string,
+  metricType: MetricAggregation['type']
+) => {
+  return currentMetrics
+    ?.filter((metric) =>
+      // When the new metric type is `isSingleMetric` we remove all other metrics from the query
+      // leaving only the current one.
+      !!metricAggregationConfig[metricType].isSingleMetric ? metric.id === metricId : true
+    )
+    .map((metric) => {
+      if (metric.id !== metricId) {
+        return metric;
+      }
+
+      /*
+        TODO: The previous version of the query editor was keeping some of the old metric's configurations
+        in the new selected one (such as field or some settings).
+        It the future would be nice to have the same behavior but it's hard without a proper definition,
+        as OpenSearch will error sometimes if some settings are not compatible.
+      */
+      return {
+        id: metric.id,
+        type: metricType,
+        ...metricAggregationConfig[metricType].defaults,
+      } as MetricAggregation;
+    });
 };

--- a/src/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { Flavor, MetricsConfiguration } from '../../../types';
+import { Flavor, LuceneQueryType, MetricsConfiguration } from '../../../types';
 import {
   isMetricAggregationWithField,
   isPipelineAggregationWithMultipleBucketPaths,
@@ -11,6 +11,7 @@ import { defaultPipelineVariable } from './SettingsEditor/BucketScriptSettingsEd
 export const metricAggregationConfig: MetricsConfiguration = {
   count: {
     label: 'Count',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: false,
     isPipelineAgg: false,
     supportsMissing: false,
@@ -22,6 +23,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   avg: {
     label: 'Average',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsInlineScript: true,
     supportsMissing: true,
@@ -33,6 +35,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   sum: {
     label: 'Sum',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsInlineScript: true,
     supportsMissing: true,
@@ -44,6 +47,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   max: {
     label: 'Max',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsInlineScript: true,
     supportsMissing: true,
@@ -55,6 +59,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   min: {
     label: 'Min',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsInlineScript: true,
     supportsMissing: true,
@@ -66,6 +71,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   extended_stats: {
     label: 'Extended Stats',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsMissing: true,
     supportsInlineScript: true,
@@ -82,6 +88,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   percentiles: {
     label: 'Percentiles',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsMissing: true,
     supportsInlineScript: true,
@@ -97,6 +104,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   cardinality: {
     label: 'Unique Count',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     supportsMissing: true,
     isPipelineAgg: false,
@@ -108,6 +116,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   moving_avg: {
     label: 'Moving Average',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     isPipelineAgg: true,
     supportsMissing: false,
@@ -124,6 +133,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   moving_fn: {
     label: 'Moving Function',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     isPipelineAgg: true,
     supportsMultipleBucketPaths: false,
@@ -138,6 +148,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   derivative: {
     label: 'Derivative',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     isPipelineAgg: true,
     supportsMissing: false,
@@ -149,6 +160,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   cumulative_sum: {
     label: 'Cumulative Sum',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: true,
     isPipelineAgg: true,
     supportsMissing: false,
@@ -160,6 +172,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   bucket_script: {
     label: 'Bucket Script',
+    impliedLuceneQueryType: LuceneQueryType.Metric,
     requiresField: false,
     isPipelineAgg: true,
     supportsMissing: false,
@@ -173,6 +186,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   raw_document: {
     label: 'Raw Document (legacy)',
+    impliedLuceneQueryType: LuceneQueryType.RawDocument,
     requiresField: false,
     isSingleMetric: true,
     isPipelineAgg: false,
@@ -191,6 +205,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   raw_data: {
     label: 'Raw Data',
+    impliedLuceneQueryType: LuceneQueryType.RawData,
     requiresField: false,
     isSingleMetric: true,
     isPipelineAgg: false,
@@ -209,11 +224,13 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   logs: {
     label: 'Logs',
+    impliedLuceneQueryType: LuceneQueryType.Logs,
+    isSingleMetric: true,
+    hasSettings: true,
     requiresField: false,
     isPipelineAgg: false,
     supportsMissing: false,
     supportsMultipleBucketPaths: false,
-    hasSettings: false,
     supportsInlineScript: false,
     hasMeta: false,
     defaults: {},
@@ -250,16 +267,16 @@ export const pipelineOptions: PipelineOptions = {
  * @param metrics
  */
 export const getChildren = (metric: MetricAggregation, metrics: MetricAggregation[]): MetricAggregation[] => {
-  const children = metrics.filter(m => {
+  const children = metrics.filter((m) => {
     // TODO: Check this.
     if (isPipelineAggregationWithMultipleBucketPaths(m)) {
-      return m.pipelineVariables?.some(pv => pv.pipelineAgg === metric.id);
+      return m.pipelineVariables?.some((pv) => pv.pipelineAgg === metric.id);
     }
 
     return isMetricAggregationWithField(m) && metric.id === m.field;
   });
 
-  return [...children, ...children.flatMap(child => getChildren(child, metrics))];
+  return [...children, ...children.flatMap((child) => getChildren(child, metrics))];
 };
 
 export const orderOptions: Array<SelectableValue<string>> = [

--- a/src/components/QueryEditor/OpenSearchQueryContext.tsx
+++ b/src/components/QueryEditor/OpenSearchQueryContext.tsx
@@ -8,6 +8,7 @@ import { createReducer as createBucketAggsReducer } from './BucketAggregationsEd
 import { queryTypeReducer } from './QueryTypeEditor/state';
 import { formatReducer } from './PPLFormatEditor/state';
 import { aliasPatternReducer, queryReducer, initQuery } from './state';
+import { luceneQueryTypeReducer } from './LuceneQueryEditor/state';
 
 const DatasourceContext = createContext<OpenSearchDatasource | undefined>(undefined);
 const QueryContext = createContext<OpenSearchQuery | undefined>(undefined);
@@ -20,10 +21,11 @@ interface Props {
 
 export const OpenSearchProvider = ({ children, onChange, query, datasource }: PropsWithChildren<Props>) => {
   const reducer = combineReducers<
-    Pick<OpenSearchQuery, 'query' | 'alias' | 'metrics' | 'bucketAggs' | 'queryType' | 'format'>
+    Pick<OpenSearchQuery, 'query' | 'alias' | 'metrics' | 'bucketAggs' | 'queryType' | 'format' | 'luceneQueryType'>
   >({
     query: queryReducer,
     queryType: queryTypeReducer,
+    luceneQueryType: luceneQueryTypeReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
     bucketAggs: createBucketAggsReducer(datasource.timeField),

--- a/src/components/QueryEditor/SettingsEditorContainer.tsx
+++ b/src/components/QueryEditor/SettingsEditorContainer.tsx
@@ -19,9 +19,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme, hidden: boolean) => {
     button: css`
       justify-content: start;
       ${hidden &&
-        css`
-          color: ${theme.colors.textFaint};
-        `}
+      css`
+        color: ${theme.colors.textFaint};
+      `}
     `,
   };
 });
@@ -40,6 +40,7 @@ export const SettingsEditorContainer = ({ label, children, hidden = false }: Pro
     <InlineSegmentGroup>
       <div className={cx(styles.wrapper)}>
         <button
+          data-testid="settings-button"
           className={cx('gf-form-label query-part', styles.button, segmentStyles)}
           onClick={() => setOpen(!open)}
           aria-expanded={open}

--- a/src/components/QueryEditor/index.test.tsx
+++ b/src/components/QueryEditor/index.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { LuceneQueryType, OpenSearchQuery, QueryType } from '../../types';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryEditor } from '.';
 import { OpenSearchDatasource } from '../../opensearchDatasource';
 
 const mockDatasource = {
   getSupportedQueryTypes: () => [QueryType.Lucene, QueryType.PPL],
 } as OpenSearchDatasource;
+const mockOnChange = jest.fn();
+const mockRunQuery = jest.fn();
 
 // Slate seems to cause an error without this, getSelection is not present in the current jsDom version.
 (window as any).getSelection = () => {};
@@ -22,7 +24,7 @@ describe('QueryEditorForm', () => {
       bucketAggs: [{ type: 'date_histogram', id: '1' }],
     };
 
-    render(<QueryEditor query={query} onChange={q => (query = q)} onRunQuery={() => {}} datasource={mockDatasource} />);
+    render(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockRunQuery} datasource={mockDatasource} />);
 
     expect(screen.getByText('Lucene')).toBeInTheDocument();
     expect(screen.queryByText('PPL')).not.toBeInTheDocument();
@@ -37,22 +39,127 @@ describe('QueryEditorForm', () => {
       bucketAggs: [{ type: 'date_histogram', id: '1' }],
     };
 
-    render(<QueryEditor query={query} onChange={q => (query = q)} onRunQuery={() => {}} datasource={mockDatasource} />);
+    render(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockRunQuery} datasource={mockDatasource} />);
 
     expect(screen.getByText('PPL')).toBeInTheDocument();
     expect(screen.queryByText('Lucene')).not.toBeInTheDocument();
   });
 
-  it('should hide Alias field when querying traces', async () => {
-    let query: OpenSearchQuery = {
-      refId: 'A',
-      query: '',
-      queryType: QueryType.Lucene,
-      luceneQueryType: LuceneQueryType.Traces,
-      metrics: [{ type: 'count', id: '2' }],
-      bucketAggs: [{ type: 'date_histogram', id: '1' }],
-    };
-    render(<QueryEditor query={query} onChange={() => {}} onRunQuery={() => {}} datasource={mockDatasource} />);
-    expect(screen.queryByText('Alias')).not.toBeInTheDocument();
+  describe('Alias field', () => {
+    it('Should correctly render and trigger changes on blur', () => {
+      const alias = '{{metric}}';
+      const query: OpenSearchQuery = {
+        refId: 'A',
+        query: '',
+        alias,
+        metrics: [
+          {
+            id: '1',
+            type: 'count',
+          },
+        ],
+        bucketAggs: [
+          {
+            type: 'date_histogram',
+            id: '2',
+          },
+        ],
+      };
+
+      render(
+        <QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockRunQuery} datasource={mockDatasource} />
+      );
+
+      let aliasField = screen.getByLabelText('Alias') as HTMLInputElement;
+
+      // The Query should have an alias field
+      expect(aliasField).toBeInTheDocument();
+
+      // its value should match the one in the query
+      expect(aliasField.value).toBe(alias);
+
+      // We change value and trigger a blur event to trigger an update
+      const newAlias = 'new alias';
+      fireEvent.change(aliasField, { target: { value: newAlias } });
+      fireEvent.blur(aliasField);
+
+      // the onChange handler should have been called correctly, and the resulting
+      // query state should match what expected
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange.mock.calls[0][0].alias).toBe(newAlias);
+    });
+    it('Should not be shown if query is Lucene Traces', () => {
+      const query: OpenSearchQuery = {
+        refId: 'A',
+        query: '',
+        luceneQueryType: LuceneQueryType.Traces,
+        metrics: [
+          {
+            id: '1',
+            type: 'avg',
+          },
+        ],
+        bucketAggs: [{ id: '2', type: 'terms' }],
+      };
+
+      render(
+        <QueryEditor query={query} datasource={mockDatasource} onChange={mockOnChange} onRunQuery={mockRunQuery} />
+      );
+
+      expect(screen.queryByLabelText('Alias')).toBeNull();
+    });
+    it('Should not be shown if query is PPL', () => {
+      const query: OpenSearchQuery = {
+        refId: 'A',
+        query: '',
+        queryType: QueryType.PPL,
+      };
+
+      render(
+        <QueryEditor query={query} datasource={mockDatasource} onChange={mockOnChange} onRunQuery={mockRunQuery} />
+      );
+
+      expect(screen.queryByLabelText('Alias')).toBeNull();
+    });
+
+    it('Should not be shown if last bucket aggregation is not Date Histogram', () => {
+      const query: OpenSearchQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [
+          {
+            id: '1',
+            type: 'avg',
+          },
+        ],
+        bucketAggs: [{ id: '2', type: 'terms' }],
+      };
+
+      render(
+        <QueryEditor query={query} datasource={mockDatasource} onChange={mockOnChange} onRunQuery={mockRunQuery} />
+      );
+
+      expect(screen.queryByLabelText('Alias')).toBeNull();
+    });
+
+    it('Should be shown if last bucket aggregation is Date Histogram', () => {
+      const query: OpenSearchQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [
+          {
+            id: '1',
+            type: 'avg',
+          },
+        ],
+        bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      };
+
+      render(
+        <QueryEditor query={query} datasource={mockDatasource} onChange={mockOnChange} onRunQuery={mockRunQuery} />
+      );
+
+      expect(screen.getByLabelText('Alias')).toBeEnabled();
+    });
   });
 });

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { OpenSearchDatasource } from '../../opensearchDatasource';
-import { LuceneQueryType, OpenSearchOptions, OpenSearchQuery, QueryType } from '../../types';
+import { OpenSearchOptions, OpenSearchQuery, QueryType } from '../../types';
 import { OpenSearchProvider } from './OpenSearchQueryContext';
 import { InlineField, InlineFieldRow, Input, QueryField } from '@grafana/ui';
 import { changeAliasPattern, changeQuery } from './state';
@@ -10,6 +10,7 @@ import { useDispatch } from '../../hooks/useStatelessReducer';
 import { css } from '@emotion/css';
 import { PPLFormatEditor } from './PPLFormatEditor';
 import { LuceneQueryEditor } from './LuceneQueryEditor/LuceneQueryEditor';
+import { isTimeSeriesQuery } from 'utils';
 
 export type OpenSearchQueryEditorProps = QueryEditorProps<OpenSearchDatasource, OpenSearchQuery, OpenSearchOptions>;
 
@@ -50,9 +51,15 @@ export const QueryEditorForm = ({ value, onChange }: Props) => {
             />
           </div>
         </InlineField>
-        {value.queryType !== QueryType.PPL && value.luceneQueryType !== LuceneQueryType.Traces && (
-          <InlineField label="Alias" labelWidth={15}>
+        {isTimeSeriesQuery(value) && (
+          <InlineField
+            label="Alias"
+            tooltip="Aliasing only works for timeseries queries (when the last group is 'Date Histogram'). For all other query types this field is ignored."
+            labelWidth={15}
+            htmlFor="alias-input"
+          >
             <Input
+              id="alias-input"
               placeholder="Alias Pattern"
               onBlur={(e) => dispatch(changeAliasPattern(e.currentTarget.value))}
               defaultValue={value.alias}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface OpenSearchOptions extends DataSourceJsonData {
 
 interface MetricConfiguration<T extends MetricAggregationType> {
   label: string;
+  impliedLuceneQueryType: LuceneQueryType;
   requiresField: boolean;
   supportsInlineScript: boolean;
   supportsMissing: boolean;
@@ -117,6 +118,9 @@ export enum Flavor {
 export enum LuceneQueryType {
   Traces = 'Traces',
   Metric = 'Metric',
+  Logs = 'Logs',
+  RawData = 'RawData',
+  RawDocument = 'RawDocument',
 }
 
 export type AggsForTraces = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   MetricAggregation,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
-import { DataLinkConfig, LuceneQueryType, QueryType } from './types';
+import { DataLinkConfig, LuceneQueryType, OpenSearchQuery, QueryType } from './types';
 import { DataFrame, DataLink, DataQueryResponse, FieldType, MutableDataFrame } from '@grafana/data';
 import { defaultBucketAgg, defaultMetricAgg } from './query_def';
 
@@ -254,3 +254,11 @@ function generateDataLink(linkConfig: DataLinkConfig): DataLink {
     };
   }
 }
+
+// To be considered a time series query, the last bucked aggregation must be a Date Histogram
+export const isTimeSeriesQuery = (query: OpenSearchQuery): boolean => {
+  return (
+    (!query.luceneQueryType || query.luceneQueryType === LuceneQueryType.Metric) &&
+    query?.bucketAggs?.slice(-1)[0]?.type === 'date_histogram'
+  );
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Our current editor hides Logs, Raw Data and Raw Document under Metrics dropdown, which isn't very intuitive. This refactor the editor to add a few new things: 
1. Adds Lucene Query Selector component, which will update luceneQueryType and metrics values, depending on the selection(logs, raw data, raw document - traces isn't included as a metric in the current query model). N.B. this doesn't change the query model, so even after this Logs and Raw Document queries will have their respective metrics. This is to not to have to deal with migrations, which would be a much bigger feature and should be done separately from this. 
2. Improves display for Alias field - it is only supported with time series queries, i.e. queries with date histogram bucket aggregation
3. Adds an option Size in Logs ,which already exists in the backend, but it seems we have never sent it in the frontend query object. 
<img width="1172" alt="Screenshot 2025-03-07 at 15 41 01" src="https://github.com/user-attachments/assets/4d6a0c74-1be1-4aa2-9cea-70e0c2023a37" />

<img width="1174" alt="Screenshot 2025-03-07 at 15 41 12" src="https://github.com/user-attachments/assets/3cdf4848-79ca-4184-98c3-4b008bc5cc60" />

<img width="918" alt="Screenshot 2025-03-07 at 15 42 10" src="https://github.com/user-attachments/assets/5a0ae712-71a3-403e-ac62-176945e169dc" />

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**: