### PR TITLE
Refactor OpenSearchDatasource error handling to use Promise.reject for error cases and update tests accordingly

### DIFF
--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -95,9 +95,10 @@ describe('OpenSearchDatasource', function (this: any) {
     });
 
     it('should error', async () => {
-      const result = await ctx.ds.testDatasource();
-      expect(result.status).toBe('error');
-      expect(result.message).toBe('No version set');
+      await expect(ctx.ds.testDatasource()).rejects.toMatchObject({
+        status: 'error',
+        message: 'No version set',
+      });
     });
   });
 


### PR DESCRIPTION
As part of the #proj-ds-config-success-improvements we are working on improving our data sources. We are gathering data now and this data source gives us false information about the success because how it returns health check. https://ops.grafana-ops.net/d/ds-health-check-errors/data-sources-health-check-errors?orgId=1&from=now-90d&to=now&timezone=utc&var-grafana_plugins=$__all

This PR fixes that by rejecting the promise when the query returns an error.