### PR TITLE
Support ordering by percentiles and extended stats

### DIFF
--- a/pkg/opensearch/snapshot_tests/testdata/lucene_metric_percentiles_group_by_terms_orderby_percentiles.query_input.json
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_metric_percentiles_group_by_terms_orderby_percentiles.query_input.json
@@ -1,0 +1,49 @@
+[
+  {
+    "refId": "A",
+    "datasource": {
+      "type": "grafana-opensearch-datasource",
+      "uid": "c338efe8-de17-465c-ba45-9d1fdfca372c"
+    },
+    "query": "*",
+    "queryType": "lucene",
+    "luceneQueryType": "Metric",
+    "alias": "",
+    "metrics": [
+      {
+        "id": "1",
+        "type": "percentiles",
+        "settings": {
+          "percents": ["50"]
+        },
+        "field": "AvgTicketPrice"
+      }
+    ],
+    "bucketAggs": [
+      {
+        "id": "3",
+        "type": "terms",
+        "settings": {
+          "min_doc_count": "1",
+          "size": "10",
+          "order": "desc",
+          "orderBy": "1[50.0]"
+        },
+        "field": "dayOfWeek"
+      },
+      {
+        "type": "date_histogram",
+        "id": "2",
+        "settings": {
+          "interval": "auto"
+        },
+        "field": "timestamp"
+      }
+    ],
+    "format": "table",
+    "timeField": "timestamp",
+    "datasourceId": 11108,
+    "intervalMs": 900000,
+    "maxDataPoints": 788
+  }
+]

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -4,11 +4,16 @@ import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { SettingsEditorContainer } from '../../SettingsEditorContainer';
 import { changeBucketAggregationSetting } from '../state/actions';
 import { BucketAggregation } from '../aggregations';
-import { bucketAggregationConfig, intervalOptions, orderByOptions, orderOptions, sizeOptions } from '../utils';
+import {
+  bucketAggregationConfig,
+  createOrderByOptionsFromMetrics,
+  intervalOptions,
+  orderOptions,
+  sizeOptions,
+} from '../utils';
 import { FiltersSettingsEditor } from './FiltersSettingsEditor';
 import { useDescription } from './useDescription';
 import { useQuery } from '../../OpenSearchQueryContext';
-import { describeMetric } from '../../../../utils';
 
 const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
   labelWidth: 16,
@@ -22,8 +27,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
   const dispatch = useDispatch();
   const { metrics } = useQuery();
   const settingsDescription = useDescription(bucketAgg);
-
-  const orderBy = [...orderByOptions, ...(metrics || []).map((m) => ({ label: describeMetric(m), value: m.id }))];
+  const orderBy = createOrderByOptionsFromMetrics(metrics);
 
   return (
     <SettingsEditorContainer label={settingsDescription}>

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/useDescription.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/useDescription.ts
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { describeMetric } from '../../../../utils';
+import { convertOrderByToMetricId, describeMetric } from '../../../../utils';
 import { useQuery } from '../../OpenSearchQueryContext';
 import { BucketAggregation } from '../aggregations';
 import { bucketAggregationConfig, orderByOptions, orderOptions } from '../utils';
@@ -35,7 +35,7 @@ export const useDescription = (bucketAgg: BucketAggregation): string => {
       if (orderByOption) {
         description += orderByOption.label;
       } else {
-        const metric = metrics?.find((m) => m.id === orderBy);
+        const metric = metrics?.find((m) => m.id === convertOrderByToMetricId(orderBy));
         if (metric) {
           description += describeMetric(metric);
         } else {

--- a/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -1,6 +1,13 @@
 import { SelectableValue } from '@grafana/data';
 import { BucketsConfiguration } from '../../../types';
 import { defaultFilter } from './SettingsEditor/FiltersSettingsEditor/utils';
+import { describeMetric } from 'utils';
+import {
+  ExtendedStatMetaType,
+  ExtendedStats,
+  MetricAggregation,
+  Percentiles,
+} from '../MetricAggregationsEditor/aggregations';
 
 export const bucketAggregationConfig: BucketsConfiguration = {
   terms: {
@@ -62,7 +69,9 @@ export const sizeOptions = [
   { label: '20', value: '20' },
 ];
 
-export const orderByOptions = [
+type OrderByOption = SelectableValue<string>;
+
+export const orderByOptions: OrderByOption[] = [
   { label: 'Term value', value: '_term' },
   { label: 'Doc Count', value: '_count' },
 ];
@@ -77,3 +86,58 @@ export const intervalOptions = [
   { label: '1h', value: '1h' },
   { label: '1d', value: '1d' },
 ];
+
+/**
+ * This returns the valid options for each of the enabled extended stat
+ */
+function createOrderByOptionsForExtendedStats(metric: ExtendedStats): OrderByOption[] {
+  if (!metric.meta) {
+    return [];
+  }
+  const metaKeys = Object.keys(metric.meta) as ExtendedStatMetaType[];
+  return metaKeys
+    .filter((key) => metric.meta?.[key])
+    .map((key) => {
+      let method = key as string;
+      // The bucket path for std_deviation_bounds.lower and std_deviation_bounds.upper
+      // is accessed via std_lower and std_upper, respectively.
+      if (key === 'std_deviation_bounds_lower') {
+        method = 'std_lower';
+      }
+      if (key === 'std_deviation_bounds_upper') {
+        method = 'std_upper';
+      }
+      return { label: `${describeMetric(metric)} (${method})`, value: `${metric.id}[${method}]` };
+    });
+}
+
+/**
+ * This returns the valid options for each of the percents listed in the percentile settings
+ */
+function createOrderByOptionsForPercentiles(metric: Percentiles): OrderByOption[] {
+  if (!metric.settings?.percents) {
+    return [];
+  }
+  return metric.settings.percents.map((percent) => {
+    // The bucket path for percentile numbers is appended with a `.0` if the number is whole
+    // otherwise you have to use the actual value.
+    const percentString = /^\d+\.\d+/.test(`${percent}`) ? percent : `${percent}.0`;
+    return { label: `${describeMetric(metric)} (${percent})`, value: `${metric.id}[${percentString}]` };
+  });
+}
+
+/**
+ * This creates all the valid order by options based on the metrics
+ */
+export const createOrderByOptionsFromMetrics = (metrics: MetricAggregation[] = []): OrderByOption[] => {
+  const metricOptions = metrics.flatMap((metric) => {
+    if (metric.type === 'extended_stats') {
+      return createOrderByOptionsForExtendedStats(metric);
+    } else if (metric.type === 'percentiles') {
+      return createOrderByOptionsForPercentiles(metric);
+    } else {
+      return { label: describeMetric(metric), value: metric.id };
+    }
+  });
+  return [...orderByOptions, ...metricOptions];
+};

--- a/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -113,7 +113,7 @@ export interface ExtendedStats extends MetricAggregationWithField, MetricAggrega
   };
 }
 
-interface Percentiles extends MetricAggregationWithField, MetricAggregationWithInlineScript {
+export interface Percentiles extends MetricAggregationWithField, MetricAggregationWithInlineScript {
   type: 'percentiles';
   settings?: {
     percents?: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,3 +262,12 @@ export const isTimeSeriesQuery = (query: OpenSearchQuery): boolean => {
     query?.bucketAggs?.slice(-1)[0]?.type === 'date_histogram'
   );
 };
+/**
+ *  This function converts an order by string to the correct metric id For example,
+ *  if the user uses the standard deviation extended stat for the order by,
+ *  the value would be "1[std_deviation]" and this would return "1"
+ */
+export const convertOrderByToMetricId = (orderBy: string): string | undefined => {
+  const metricIdMatches = orderBy.match(/^(\d+)/);
+  return metricIdMatches?.[1];
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
Fixes https://github.com/grafana/opensearch-datasource/issues/341 where orderBy wasn't correctly displayed in FE and processed in BE. See also https://github.com/grafana/grafana/pull/28910
This 
- displays correct order by options in Terms bucket aggregation
- builds the correct query where metricID is {metricID}[percentage/stat id], for example `1[std_deviation]`
<img width="1000" alt="Screenshot 2025-05-06 at 11 18 15" src="https://github.com/user-attachments/assets/b7567512-cebd-4748-92eb-d9a06483f32c" />

**Which issue(s) this PR fixes**:
https://github.com/grafana/opensearch-datasource/issues/341
Fixes #

**Special notes for your reviewer**:
