### PR TITLE
Add total hits to metadata

### DIFF
--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -69,9 +69,15 @@ func (r *SearchRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(root)
 }
 
+type SearchResponseHitsTotal struct {
+	Value    int    `json:"value"`
+	Relation string `json:"relation"`
+}
+
 // SearchResponseHits represents search response hits
 type SearchResponseHits struct {
-	Hits []map[string]interface{}
+	Hits  []map[string]interface{}
+	Total *SearchResponseHitsTotal `json:"total"`
 }
 
 // SearchResponse represents a search response

--- a/pkg/opensearch/response_parser.go
+++ b/pkg/opensearch/response_parser.go
@@ -533,10 +533,25 @@ func processLogsResponse(res *client.SearchResponse, configuredFields client.Con
 	fields := processDocsToDataFrameFields(docs, sortedPropNames, true)
 
 	frame := data.NewFrame("", fields...)
+
+	var totalHits int
+	if res.Hits != nil && res.Hits.Total != nil {
+		totalHits = res.Hits.Total.Value
+	}
+
 	if frame.Meta == nil {
 		frame.Meta = &data.FrameMeta{}
 	}
 	frame.Meta.PreferredVisualization = data.VisTypeLogs
+
+	if totalHits > 0 {
+		if frame.Meta.Custom == nil {
+			frame.Meta.Custom = make(map[string]interface{})
+		}
+		if customMeta, ok := frame.Meta.Custom.(map[string]interface{}); ok {
+			customMeta["total"] = totalHits
+		}
+	}
 
 	queryRes.Frames = append(queryRes.Frames, data.Frames{frame}...)
 	return queryRes

--- a/pkg/opensearch/response_parser_test.go
+++ b/pkg/opensearch/response_parser_test.go
@@ -1746,7 +1746,7 @@ func TestProcessLogsResponse_log_query_with_nested_fields(t *testing.T) {
 				nil, // Correctly detects type even if first value is null
 				utils.Pointer("def"),
 			}).SetConfig(&data.FieldConfig{Filterable: utils.Pointer(true)}),
-	).SetMeta(&data.FrameMeta{PreferredVisualization: "logs"})
+	).SetMeta(&data.FrameMeta{PreferredVisualization: "logs", Custom: map[string]interface{}{"total": 109}})
 	if diff := cmp.Diff(expectedFrame, result.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
 		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
@@ -2322,7 +2322,7 @@ func TestProcessRawDocumentResponse(t *testing.T) {
 			"responses": [
 				{
 				"hits": {
-					"total": 100,
+					"total": {"value": 100, "relation": "eq"},
 					"hits": [
 					{
 						"_id": "1",

--- a/pkg/opensearch/snapshot_tests/testdata/lucene_logs.expected_result_generated_snapshot.golden.jsonc
+++ b/pkg/opensearch/snapshot_tests/testdata/lucene_logs.expected_result_generated_snapshot.golden.jsonc
@@ -5,6 +5,9 @@
 //          0,
 //          0
 //      ],
+//      "custom": {
+//          "total": 93
+//      },
 //      "preferredVisualisationType": "logs"
 //  }
 //  Name: 
@@ -38,6 +41,9 @@
             0,
             0
           ],
+          "custom": {
+            "total": 93
+          },
           "preferredVisualisationType": "logs"
         },
         "fields": [


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Port of https://github.com/grafana/grafana/pull/104117

**Which issue(s) this PR fixes**:

Together with https://github.com/grafana/grafana/pull/104117 this allows us to see the total logs number.

Fixes #

**Special notes for your reviewer**:

@idastambuk I was able to assert the total in the response in the browser network tab on the Grafana explorer page. Is there way to point the Grafana image to a recent version that would contain the other PR? I'm not sure how things work out version-wise.