### PR TITLE
Remove explicit timestamp conversions

### DIFF
--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -190,7 +190,7 @@ func TestClient(t *testing.T) {
 					assert.NoError(t, err)
 
 					t.Run("and replace index pattern with wildcard", func(t *testing.T) {
-						assert.Equal(t, "source = metrics-* | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')", jBody.Get("query").MustString())
+						assert.Equal(t, "source = metrics-* | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo'", jBody.Get("query").MustString())
 					})
 				})
 				t.Run("Should parse response", func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestClient(t *testing.T) {
 					assert.NoError(t, err)
 
 					t.Run("and replace index pattern with wildcard", func(t *testing.T) {
-						assert.Equal(t, "source = metrics-* | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')", jBody.Get("query").MustString())
+						assert.Equal(t, "source = metrics-* | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo'", jBody.Get("query").MustString())
 					})
 				})
 				t.Run("Should parse response", func(t *testing.T) {

--- a/pkg/opensearch/client/ppl_request.go
+++ b/pkg/opensearch/client/ppl_request.go
@@ -29,7 +29,7 @@ func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
 // AddPPLQueryString adds a new PPL query string with time range filter
 func (b *PPLRequestBuilder) AddPPLQueryString(timeField, to, from, querystring string) *PPLRequestBuilder {
 	var res []string
-	timeFilter := fmt.Sprintf(" where `%s` >= timestamp('%s') and `%s` <= timestamp('%s')", timeField, from, timeField, to)
+	timeFilter := fmt.Sprintf(" where `%s` >= '%s' and `%s` <= '%s'", timeField, from, timeField, to)
 
 	trimmedQuerystring := strings.TrimSpace(querystring)
 	// Sets a default query if the query string is empty

--- a/pkg/opensearch/client/ppl_request_test.go
+++ b/pkg/opensearch/client/ppl_request_test.go
@@ -37,7 +37,7 @@ func TestPPLRequest(t *testing.T) {
 
 					t.Run("Should have query string filter", func(t *testing.T) {
 						f := pr.Query
-						assert.Equal(t, "source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')", f)
+						assert.Equal(t, "source = default_index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo'", f)
 					})
 
 					t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestPPLRequest(t *testing.T) {
 						assert.NoError(t, err)
 						json, err := simplejson.NewJson(body)
 						assert.NoError(t, err)
-						assert.Equal(t, "source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')", json.Get("query").Interface())
+						assert.Equal(t, "source = default_index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo'", json.Get("query").Interface())
 					})
 				})
 			})
@@ -58,7 +58,7 @@ func TestPPLRequest(t *testing.T) {
 
 					t.Run("Should have query string filter", func(t *testing.T) {
 						f := pr.Query
-						assert.Equal(t, "source = index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | fields test", f)
+						assert.Equal(t, "source = index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo' | fields test", f)
 					})
 
 					t.Run("When marshal to JSON should generate correct json", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestPPLRequest(t *testing.T) {
 						assert.NoError(t, err)
 						json, err := simplejson.NewJson(body)
 						assert.NoError(t, err)
-						assert.Equal(t, "source = index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | fields test", json.Get("query").Interface())
+						assert.Equal(t, "source = index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo' | fields test", json.Get("query").Interface())
 					})
 				})
 			})
@@ -79,7 +79,7 @@ func Test_AddPPLQueryString_prepends_a_source_index_for_ppl_request_with_ad_hoc_
 	b.AddPPLQueryString("@timestamp", "$timeTo", "$timeFrom", " | where `ad_hoc_filter` = 'ad_hoc_filter_value'")
 	pr, err := b.Build()
 	assert.NoError(t, err)
-	assert.Equal(t, "source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | where `ad_hoc_filter` = 'ad_hoc_filter_value'", pr.Query)
+	assert.Equal(t, "source = default_index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo' | where `ad_hoc_filter` = 'ad_hoc_filter_value'", pr.Query)
 }
 
 func Test_AddPPLQueryString_does_not_prepend_source_index_if_query_starts_with_search_source_command(t *testing.T) {
@@ -87,5 +87,5 @@ func Test_AddPPLQueryString_does_not_prepend_source_index_if_query_starts_with_s
 	b.AddPPLQueryString("@timestamp", "$timeTo", "$timeFrom", "search source = default_index | where `ad_hoc_filter` = 'ad_hoc_filter_value'")
 	pr, err := b.Build()
 	assert.NoError(t, err)
-	assert.Equal(t, "search source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | where `ad_hoc_filter` = 'ad_hoc_filter_value'", pr.Query)
+	assert.Equal(t, "search source = default_index | where `@timestamp` >= '$timeFrom' and `@timestamp` <= '$timeTo' | where `ad_hoc_filter` = 'ad_hoc_filter_value'", pr.Query)
 }

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -977,7 +977,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			c := newFakeClient(client.OpenSearch, "1.0.0")
 			queryRes, err := executeTsdbQuery(c, `{
 				"timeField": "@timestamp",
-				"query": "source = index | stats count(response) by timestamp",
+				"query": "source = index | stats count(response) by @timestamp",
 				"queryType": "PPL"
 			}`, from, to, 15*time.Second)
 			assert.NoError(t, err)
@@ -985,7 +985,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			assert.Equal(t, queryRes.Responses["A"].Error.Error(), "response should have 2 fields but found 0")
 
 			req := c.pplRequest[0]
-			assert.Equal(t, "source = index | where `@timestamp` >= timestamp('2018-05-15 17:50:00') and `@timestamp` <= timestamp('2018-05-15 17:55:00') | stats count(response) by timestamp", req.Query)
+			assert.Equal(t, "source = index | where `@timestamp` >= '2018-05-15 17:50:00' and `@timestamp` <= '2018-05-15 17:55:00' | stats count(response) by @timestamp", req.Query)
 		})
 	})
 }

--- a/pkg/opensearch/snapshot_tests/ppl_logs_test.go
+++ b/pkg/opensearch/snapshot_tests/ppl_logs_test.go
@@ -41,7 +41,7 @@ func Test_ppl_logs_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest :=
-		`{"query":"source = opensearch_dashboards_sample_data_logs | where` + " `timestamp` " + `>= timestamp('2022-11-14 10:40:37') and` + " `timestamp` " + `<= timestamp('2022-11-14 10:43:45') | where geo.src = \"US\""}
+		`{"query":"source = opensearch_dashboards_sample_data_logs | where` + " `timestamp` " + `>= '2022-11-14 10:40:37' and` + " `timestamp` " + `<= '2022-11-14 10:43:45' | where geo.src = \"US\""}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }

--- a/pkg/opensearch/snapshot_tests/ppl_table_test.go
+++ b/pkg/opensearch/snapshot_tests/ppl_table_test.go
@@ -41,7 +41,7 @@ func Test_ppl_table_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest :=
-		`{"query":"search source=opensearch_dashboards_sample_data_flights | where` + " `timestamp` " + `>= timestamp('2022-11-14 10:40:37') and` + " `timestamp` " + `<= timestamp('2022-11-14 10:43:45') | where AvgTicketPrice > 1150 | where FlightDelay = true "}
+		`{"query":"search source=opensearch_dashboards_sample_data_flights | where` + " `timestamp` " + `>= '2022-11-14 10:40:37' and` + " `timestamp` " + `<= '2022-11-14 10:43:45' | where AvgTicketPrice > 1150 | where FlightDelay = true "}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -463,7 +463,7 @@ export class QueryBuilder {
     for (i = 0; i < adhocFilters.length; i++) {
       if (dateMath.isValid(adhocFilters[i].value)) {
         const validTime = dateTime(adhocFilters[i].value).utc().format('YYYY-MM-DD HH:mm:ss.SSSSSS');
-        value = `timestamp('${validTime}')`;
+        value = `'${validTime}'`;
       } else if (typeof adhocFilters[i].value === 'string') {
         value = `'${adhocFilters[i].value}'`;
       } else {
@@ -492,7 +492,7 @@ export class QueryBuilder {
       queryString = this.addPPLAdhocFilters(queryString, adhocFilters);
     }
 
-    const timeRangeFilter = " where $timestamp >= timestamp('$timeFrom') and $timestamp <= timestamp('$timeTo')";
+    const timeRangeFilter = " where $timestamp >= '$timeFrom' and $timestamp <= '$timeTo'";
     //time range filter must be placed before other query filters
     if (queryString) {
       const separatorIndex = queryString.indexOf('|');

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -267,7 +267,7 @@ function getAdHocPPLQuery(filter: AdHocVariableFilter): string {
   }
   if (dateMath.isValid(filter.value)) {
     const validTime = dateTime(filter.value).utc().format('YYYY-MM-DD HH:mm:ss.SSSSSS');
-    value = `timestamp('${validTime}')`;
+    value = `'${validTime}'`;
   } else if (typeof filter.value === 'string' && isNotANumber(filter.value)) {
     value = `'${filter.value}'`;
   } else {

--- a/src/opensearchDatasource.test.ts
+++ b/src/opensearchDatasource.test.ts
@@ -807,7 +807,7 @@ describe('OpenSearchDatasource', function (this: any) {
             adHocFilters
           );
           expect(query).toBe(
-            "source = test-index | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = timestamp('2020-11-22 16:40:43.000000')"
+            "source = test-index | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = '2020-11-22 16:40:43.000000'"
           );
         });
       });
@@ -848,7 +848,7 @@ describe('OpenSearchDatasource', function (this: any) {
 
       const interpolatedQueries = ctx.ds.interpolateVariablesInQueries([query], {}, adHocFilters);
       expect(interpolatedQueries[0].query).toBe(
-        "resolvedVariable | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = timestamp('2020-11-22 16:40:43.000000')"
+        "resolvedVariable | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = '2020-11-22 16:40:43.000000'"
       );
     });
   });
@@ -945,7 +945,7 @@ describe('OpenSearchDatasource', function (this: any) {
 
       const interpolatedQuery = ctx.ds.applyTemplateVariables(query, {}, adHocFilters);
       expect(interpolatedQuery.query).toBe(
-        "resolvedVariable | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = timestamp('2020-11-22 16:40:43.000000')"
+        "resolvedVariable | where `bar` = 'baz' and `job` != 'grafana' and `bytes` > 50 and `count` < 100 and `timestamp` = '2020-11-22 16:40:43.000000'"
       );
     });
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

OpenSearch natively infers the date format used by the plugin (`YYYY-MM-DD HH:MM:SS`) as a timestamp literal, so it seems unnecessary to have an explicit conversion using `timestamp()`. Removing it allows OpenSearch to use a range filter instead of a script in the query plan, which makes a significant difference to performance (see detail in #632)

**Which issue(s) this PR fixes**:

Fixes #632 

**Special notes for your reviewer**:

I've replaced the `timestamp()` calls everywhere but I'm not 100% sure whether the frontend code is used or not (the timestamp values applied via filters appear to be longs?) - would appreciate your insights :) 