### PR TITLE
Add execution hint support to terms aggregation

### DIFF
--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -341,11 +341,12 @@ type BucketScriptAggregation struct {
 
 // TermsAggregation represents a terms aggregation
 type TermsAggregation struct {
-	Field       string                 `json:"field"`
-	Size        int                    `json:"size"`
-	Order       map[string]interface{} `json:"order,omitempty"`
-	MinDocCount *int                   `json:"min_doc_count,omitempty"`
-	Missing     *string                `json:"missing,omitempty"`
+	Field         string                 `json:"field"`
+	Size          int                    `json:"size"`
+	Order         map[string]interface{} `json:"order,omitempty"`
+	MinDocCount   *int                   `json:"min_doc_count,omitempty"`
+	Missing       *string                `json:"missing,omitempty"`
+	ExecutionHint *string                `json:"execution_hint,omitempty"`
 }
 
 // ExtendedBounds represents extended bounds

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -545,6 +545,11 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 		}
 	}
 
+	// Handle ExecutionHint if it's not nil
+	if innerAgg.ExecutionHint != nil {
+		aggDef.aggregation.Aggregation.(*TermsAggregation).ExecutionHint = innerAgg.ExecutionHint
+	}
+
 	b.aggDefs = append(b.aggDefs, aggDef)
 
 	return b

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -435,6 +435,10 @@ func addTermsAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg, metrics []*
 			}
 		}
 
+		if executionHint, err := bucketAgg.Settings.Get("execution_hint").String(); err == nil {
+			a.ExecutionHint = &executionHint
+		}
+
 		aggBuilder = b
 	})
 

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -1152,7 +1152,8 @@ func TestTimeSeriesQueryParser(t *testing.T) {
 							"min_doc_count": 1,
 							"order": "desc",
 							"orderBy": "_term",
-							"size": "10"
+							"size": "10",
+							"execution_hint": "global_ordinals"
 						},
 						"type": "terms"
 					},
@@ -1203,6 +1204,7 @@ func TestTimeSeriesQueryParser(t *testing.T) {
 			assert.Equal(t, "desc", q.BucketAggs[0].Settings.Get("order").MustString())
 			assert.Equal(t, "_term", q.BucketAggs[0].Settings.Get("orderBy").MustString())
 			assert.Equal(t, "10", q.BucketAggs[0].Settings.Get("size").MustString())
+			assert.Equal(t, "global_ordinals", q.BucketAggs[0].Settings.Get("execution_hint").MustString())
 
 			assert.Equal(t, "@timestamp", q.BucketAggs[1].Field)
 			assert.Equal(t, "2", q.BucketAggs[1].ID)

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -59,7 +59,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
             />
           </InlineField>
 
-          <InlineField label="Execution Hint" {...inlineFieldProps} tooltip="Determines how the aggregation should be executed. Global ordinals is typically faster for high cardinality fields. Default: global_ordinals">
+          <InlineField label="Execution Hint" {...inlineFieldProps} tooltip="Determines how the aggregation should be executed. OpenSearch automatically chooses the optimal hint based on field type (global_ordinals for keyword fields, map for scripts) if not specified.">
             <Select
               data-testid="execution-hint-select"
               onChange={(e) =>
@@ -68,7 +68,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
                 )
               }
               options={executionHintOptions}
-              value={bucketAgg.settings?.execution_hint || bucketAggregationConfig[bucketAgg.type].defaultSettings?.execution_hint}
+              value={bucketAgg.settings?.execution_hint}
               placeholder="Select execution hint"
             />
           </InlineField>

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -68,7 +68,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
                 )
               }
               options={executionHintOptions}
-              value={bucketAgg.settings?.execution_hint}
+              value={bucketAgg.settings?.execution_hint || bucketAggregationConfig[bucketAgg.type].defaultSettings?.execution_hint}
               placeholder="Select execution hint"
             />
           </InlineField>

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -19,6 +19,11 @@ const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
   labelWidth: 16,
 };
 
+const executionHintOptions = [
+  { label: 'Map', value: 'map' },
+  { label: 'Global Ordinals', value: 'global_ordinals' },
+];
+
 interface Props {
   bucketAgg: BucketAggregation;
 }
@@ -51,6 +56,20 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
               options={sizeOptions}
               value={bucketAgg.settings?.size || bucketAggregationConfig[bucketAgg.type].defaultSettings?.size}
               allowCustomValue
+            />
+          </InlineField>
+
+          <InlineField label="Execution Hint" {...inlineFieldProps}>
+            <Select
+              data-testid="execution-hint-select"
+              onChange={(e) =>
+                dispatch(
+                  changeBucketAggregationSetting({ bucketAgg, settingName: 'execution_hint', newValue: e.value! })
+                )
+              }
+              options={executionHintOptions}
+              value={bucketAgg.settings?.execution_hint}
+              placeholder="Select execution hint"
             />
           </InlineField>
 

--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -59,7 +59,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
             />
           </InlineField>
 
-          <InlineField label="Execution Hint" {...inlineFieldProps}>
+          <InlineField label="Execution Hint" {...inlineFieldProps} tooltip="Determines how the aggregation should be executed. Global ordinals is typically faster for high cardinality fields. Default: global_ordinals">
             <Select
               data-testid="execution-hint-select"
               onChange={(e) =>

--- a/src/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
@@ -40,6 +40,7 @@ export interface Terms extends BucketAggregationWithField {
     min_doc_count?: string;
     orderBy?: string;
     missing?: string;
+    execution_hint?: string;
   };
 }
 

--- a/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -18,7 +18,6 @@ export const bucketAggregationConfig: BucketsConfiguration = {
       size: '10',
       order: 'desc',
       orderBy: '_term',
-      execution_hint: 'global_ordinals',
     },
   },
   filters: {

--- a/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -18,6 +18,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
       size: '10',
       order: 'desc',
       orderBy: '_term',
+      execution_hint: 'global_ordinals',
     },
   },
   filters: {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
- Updated TermsAggregation model to include an optional execution_hint field.
- Enhanced lucene_handler to handle execution_hint from bucket aggregation settings.
- Modified query_request_test to validate execution_hint functionality.
- Updated BucketAggregationsEditor to include execution hint selection in the UI.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
