### PR TITLE
Update CHANGELOG.md to include breaking changes for Elasticsearch v6.8 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - Dependencies: Bump golang.org/x/net from 0.36.0 to 0.38.0 in the go_modules group in [#608](https://github.com/grafana/opensearch-datasource/pull/608)
 - Dependencies: Bump the all-node-dependencies group across 1 directory with 32 updates in [#624](https://github.com/grafana/opensearch-datasource/pull/624)
 
+- BRAKING-CHANGES: This version will not work with elasticserach ver-6.8, you will get the following error: "error while Decoding to MultiSearchResponse: json: cannot unmarshal number into Go struct field SearchResponseHits.responses.hits.total of type client.SearchResponseHitsTotal". In order to fix that, you can fix the plugin version in the configmap of the grafana deployment and you can do that by simply adding " 2.25.0" < - grafana-opensearch-datasource 2.25.0>
+
 ## 2.25.0
 
 - Chore: Cleanup Github actions files and add zizmor config in [#622](https://github.com/grafana/opensearch-datasource/pull/622)


### PR DESCRIPTION
Update CHANGELOG.md to include breaking changes for Elasticsearch v6.8 and how to fix it