### PR TITLE
Skipping connectivity checks for cross-cluster search

### DIFF
--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -540,6 +540,13 @@ export class OpenSearchDatasource
     // @ts-ignore-next-line
     // TODO: run through backend health check
 
+    if (this.index && this.index.includes(':')) {
+      return Promise.resolve({
+        status: 'success',
+        message: 'Datasource test skipped - cross-cluster search detected',
+      });
+    }
+
     if (!this.flavor || !valid(this.version)) {
       return Promise.reject({
         status: 'error',


### PR DESCRIPTION
Tests:

<img width="1394" alt="Zrzut ekranu 2025-06-2 o 21 22 12" src="https://github.com/user-attachments/assets/95944ffd-ae85-4aed-a570-194764fe3d86" />

<img width="1488" alt="Zrzut ekranu 2025-06-2 o 21 23 19" src="https://github.com/user-attachments/assets/164ef9d1-76d8-4cd2-a2ce-bba04832f095" />

**What this PR does / why we need it**:
Skips connectivity checks when cross-cluster search is detected. This will allow users to use cross-cluster search feature with a specific remote connection (not only wildcard as it is now). Currently if a user inputs "index,*:index" as Index name it will go through and logs from local and remote cluster will be fetched, but if a user specifies the name of the remote connection - index,remote_connection:index - a 404 will be thrown. This PR will fix it by skipping connectivity checks only when a cross-cluster search is detected.

**Which issue(s) this PR fixes**:

Fixes #610

**Special notes for your reviewer**: