### PR TITLE
Prepare 2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.27.0
+
+- Add execution hint support to terms aggregation by @enawar-knowunity in [#639](https://github.com/grafana/opensearch-datasource/pull/639)
+- Chore: migrate to github actions for publishing in [#652](https://github.com/grafana/opensearch-datasource/pull/652)
+
 ## 2.26.1
 
 - Bugfix: Add support for Elasticsearch 6.8 by handling hits.total as number by @ranyhb in [#643](https://github.com/grafana/opensearch-datasource/pull/643)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -143,6 +143,8 @@
     "compatibilitycheck",
     "zizmor",
     "ranyhb",
-    "golangci"
+    "golangci",
+    "enawar",
+    "knowunity"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opensearch-datasource",
-  "version": "2.26.1",
+  "version": "2.27.0",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 2.27.0

- Add execution hint support to terms aggregation by @enawar-knowunity in [#639](https://github.com/grafana/opensearch-datasource/pull/639)
- Chore: migrate to github actions for publishing in [#652](https://github.com/grafana/opensearch-datasource/pull/652)