### PR TITLE
Use csv format instead of pipe to interpolate variables in ppl queries

### DIFF
--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -477,7 +477,7 @@ export class OpenSearchDatasource
   }
 
   private interpolatePPLQuery(queryString: string, scopedVars: ScopedVars) {
-    return this.templateSrv.replace(queryString, scopedVars, 'pipe');
+    return this.templateSrv.replace(queryString, scopedVars, 'csv');
   }
 
   // called from Explore


### PR DESCRIPTION
During a bug bash, we found some unexpected behaviour where multi-value variables are interpolated as `value1|value2` in PPL. This is because we're passing format `ppl` when calling templateSrv.replace in the datasource for PPL. 
Considering a pipe is a reserved symbol in PPL and it signifies the start of a new command, I'm finding it hard to imagine a scenario where this would be the intended result. 
- users might want to use the string to query like(message, $someString), in which case the `csv` format is enough (`pipe` format would do the same thing for single-value variables). 
- for multi-value variables: in the `fields` command, they might want to select multiple columns to query, in which case we need them to be separated by a comma, therefore 'csv' format should work
Maybe there's a third case I'm not thinking about, but beyond "add ppl subqueries as variables" I can't think of anything that would justify a pipe separator. 
<img width="1475" height="698" alt="Screenshot 2025-07-24 at 17 32 39" src="https://github.com/user-attachments/assets/7ade6eaf-682a-4a2c-ba81-25a114f97a54" />
