### PR TITLE
Add title to data links

### DIFF
--- a/provisioning/datasources/aws-opensearch.yaml
+++ b/provisioning/datasources/aws-opensearch.yaml
@@ -26,6 +26,10 @@ datasources:
       tlsSkipVerify: true
       version: '2.18.0'
       versionLabel: 'OpenSearch 2.18.0'
+      dataLinks:
+        - field: ip
+          url: https://example.com
+          title: 'My Title'
     secureJsonData:
       basicAuthPassword: 'my_%New%_passW0rd!@#' # password is set in docker-compose.yaml with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` env var
   - name: AWS OpenSearch eCommerce Sample

--- a/src/configuration/DataLink.tsx
+++ b/src/configuration/DataLink.tsx
@@ -69,6 +69,22 @@ export const DataLink = (props: Props) => {
       </div>
       <div className="gf-form">
         <FormField
+          label="Title"
+          labelWidth={6}
+          inputWidth={null}
+          value={value.title || ''}
+          onChange={handleChange('title')}
+          className={css`
+            width: 100%;
+
+            > input {
+              margin-right: 0;
+            }
+          `}
+        />
+      </div>
+      <div className="gf-form">
+        <FormField
           label={showInternalLink ? 'Query' : 'URL'}
           labelWidth={6}
           inputEl={

--- a/src/opensearchDatasource.ts
+++ b/src/opensearchDatasource.ts
@@ -964,7 +964,7 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
       const dsSettings = dataSourceSrv.getInstanceSettings(dataLinkConfig.datasourceUid);
 
       link = {
-        title: '',
+        title: dataLinkConfig.title ?? '',
         url: '',
         internal: {
           query: { query: dataLinkConfig.url },
@@ -975,7 +975,7 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
       };
     } else {
       link = {
-        title: '',
+        title: dataLinkConfig.title ?? '',
         url: dataLinkConfig.url,
       };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export type DataLinkConfig = {
   field: string;
   url: string;
   datasourceUid?: string;
+  title?: string;
 };
 
 export enum QueryType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ function generateDataLink(linkConfig: DataLinkConfig): DataLink {
     const dsSettings = dataSourceSrv.getInstanceSettings(linkConfig.datasourceUid);
 
     return {
-      title: '',
+      title: linkConfig.title ?? '',
       url: '',
       internal: {
         query: { query: linkConfig.url },
@@ -249,7 +249,7 @@ function generateDataLink(linkConfig: DataLinkConfig): DataLink {
     };
   } else {
     return {
-      title: '',
+      title: linkConfig.title ?? '',
       url: linkConfig.url,
     };
   }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

Issue: If you add several data links that point to different URLs with the same hostname, it is hard to differentiate them:

<img width="725" height="115" alt="image" src="https://github.com/user-attachments/assets/ac61adef-109e-4479-a62e-af8ff8548d3b" />

Solution: Add title field to data links


<img width="628" height="101" alt="image" src="https://github.com/user-attachments/assets/ce334f7f-acb9-4e1e-9fc9-3e619af949c4" />

This can be configured in the UI for non-provisioned datasources:

<img width="1394" height="415" alt="image" src="https://github.com/user-attachments/assets/6718c5c5-d806-47a6-aa17-1629bb758c8b" />

And using YAML in provisioned datasources:

```yaml
datasources:
  - name: AWS OpenSearch
    type: grafana-opensearch-datasource
    // ...
    jsonData:
      // ...
      dataLinks:
        - field: ip
          url: https://example.com
          title: 'My Title'
```