### PR TITLE
Try adding draft false

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       golangci-lint-version: 2.1.6
-
+      github-draft-release: false
       # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
       # (and hide it for on-prem). This is required for some provisioned plugins.
       # scopes: grafana_cloud


### PR DESCRIPTION
[we pass draft:true by default](https://github.com/grafana/plugin-ci-workflows/blob/124ff1cc9e488f2b2b630453a372f8fb0e2e6d79/.github/workflows/cd.yml#L217) to the [underlying action](https://github.com/softprops/action-gh-release) we use for CD github release. I would like to try to pass false to it and see if that just publishes GH releases as..not draft