### PR TITLE
fix: use field configured in query editor as field for date_histogram aggregations (#425)

### DIFF
--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -101,7 +101,7 @@ export class QueryBuilder {
     const esAgg: any = {};
     const settings = aggDef.settings || {};
     esAgg.interval = settings.interval;
-    esAgg.field = this.timeField;
+    esAgg.field = aggDef.field || this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';


### PR DESCRIPTION
fix: use field configured in query editor as field for date_histogram aggregations (#425)

<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:

This PR fixes (#425), which has been fixed 4 years ago for the elasticsearch plugin ([PR](https://github.com/grafana/grafana/pull/41258), [issue](https://github.com/grafana/grafana/issues/8260)).

**Which issue(s) this PR fixes**:

Fixes #425

**Special notes for your reviewer**:

N/A