### PR TITLE
Update go version in the build tooling

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,5 +17,4 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      go-version: '1.24.11'
       golangci-lint-version: 2.1.6


### PR DESCRIPTION
**What this PR does / why we need it**:
I had bumped the go toolchain in https://github.com/grafana/opensearch-datasource/pull/938 , but I believe due to the version pin in this build file, the plugin still was only able to build with go 1.24.6 which still contained [CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729).

This PR bumps the CI tooling version to match the go toolchain version to build CVE-free.

Optionally, we can remove this go-version arg and let the version be determined by the go.mod if that would be preferred. https://github.com/grafana/plugin-ci-workflows/blob/main/.github/workflows/ci.yml#L382-L393