### PR TITLE
fix missing permission on cd.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.1.0
     permissions:
       contents: write
+      pull-requests: read
       id-token: write
       attestations: write
     with:


### PR DESCRIPTION
missed adding a new required permission from this update https://github.com/grafana/opensearch-datasource/pull/960.

> **cd:** allow releasing to prod from non-main branches ([#&#8203;378](https://redirect.github.com/grafana/plugin-ci-workflows/issues/378))
> 
> Calls to `cd.yml` must be adjusted to include an additional permission: `pull-requests: read`, otherwise the workflow will fail with the following error:
> 
> ```
> Invalid workflow file: ...
> The workflow is not valid. .github/workflows/publish.yaml (...): Error calling workflow 'grafana/plugin-ci-workflows/.github/workflows/cd.yml@.... The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
> ```