### PR TITLE
Fix Wildcard in index breaks REST API Health Check

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -150,9 +150,16 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 	}
 	mapping, ok := jsonData.CheckGet(index)
 	if !ok {
-		res.Status = backend.HealthStatusError
-		res.Message = fmt.Sprintf("Index not found: %s", index)
-		return res, nil
+		indexMap, err := jsonData.Map()
+		if err != nil || len(indexMap) == 0 {
+			res.Status = backend.HealthStatusError
+			res.Message = fmt.Sprintf("Index not found: %s", index)
+			return res, nil
+		}
+		for firstIndex := range indexMap {
+			mapping = jsonData.Get(firstIndex)
+			break
+		}
 	}
 
 	timeFieldMapping, ok := mapping.Get("mappings").CheckGet(timeField)

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -130,6 +131,13 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 			res.Status = backend.HealthStatusUnknown
 			break
 		}
+
+		if string(body) == `{}` {
+			res.Status = backend.HealthStatusError
+			res.Message = "No indexes match pattern: " + index
+			break
+		}
+
 		res.Status = backend.HealthStatusError
 		res.Message = string(body)
 	}
@@ -156,10 +164,61 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 			res.Message = fmt.Sprintf("Index not found: %s", index)
 			return res, nil
 		}
-		for firstIndex := range indexMap {
-			mapping = jsonData.Get(firstIndex)
-			break
+
+		indexNames := make([]string, 0, len(indexMap))
+		for indexName := range indexMap {
+			indexNames = append(indexNames, indexName)
 		}
+		sort.Strings(indexNames)
+
+		invalidIndexes := make([]string, 0)
+		availableFields := make(map[string]bool)
+		for _, indexName := range indexNames {
+			indexMapping := jsonData.Get(indexName)
+			mappings := indexMapping.Get("mappings")
+
+			timeFieldMapping, ok := mappings.CheckGet(timeField)
+			if !ok {
+				invalidIndexes = append(invalidIndexes, fmt.Sprintf("%s (no field %s)", indexName, timeField))
+				continue
+			}
+
+			fieldType := timeFieldMapping.Get("mapping").Get(timeField).Get("type").MustString()
+
+			if len(availableFields) == 0 {
+				if mappingsMap, err := mappings.Map(); err == nil {
+					for fieldName := range mappingsMap {
+						availableFields[fieldName] = true
+					}
+				}
+			}
+
+			if fieldType != "date" {
+				invalidIndexes = append(invalidIndexes, fmt.Sprintf("%s (%s is not date type)", indexName, timeField))
+				continue
+			}
+		}
+
+		if len(invalidIndexes) > 0 {
+			res.Status = backend.HealthStatusError
+			errorMsg := fmt.Sprintf("Time field '%s' not found. Invalid indices: %s",
+				timeField, strings.Join(invalidIndexes, "; "))
+
+			if len(availableFields) > 0 {
+				fieldList := make([]string, 0, len(availableFields))
+				for field := range availableFields {
+					fieldList = append(fieldList, field)
+				}
+				sort.Strings(fieldList)
+				errorMsg += fmt.Sprintf(". Available fields in first index: %s", strings.Join(fieldList, ", "))
+			}
+			res.Message = errorMsg
+			return res, nil
+		}
+
+		res.Status = backend.HealthStatusOk
+		res.Message = "Index OK. Time field name OK."
+		return res, nil
 	}
 
 	timeFieldMapping, ok := mapping.Get("mappings").CheckGet(timeField)
@@ -169,8 +228,8 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 		return res, nil
 	}
 
-	timeType := timeFieldMapping.Get("mapping").Get(timeField).Get("type")
-	if timeType.MustString() != "date" {
+	fieldType := timeFieldMapping.Get("mapping").Get(timeField).Get("type").MustString()
+	if fieldType != "date" {
 		res.Status = backend.HealthStatusOk
 		res.Message = "Index OK. Note: " + timeField + " is not a date field"
 		return res, nil

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -252,3 +252,236 @@ func TestCallResource_Validation(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckHealth_WildcardIndexValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseBody   string
+		expectedStatus backend.HealthStatus
+		expectedMsg    string
+	}{
+		{
+			name: "All indexes valid with date field",
+			responseBody: `{
+				"logs-2026.04.01": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "date"
+								}
+							}
+						}
+					}
+				},
+				"logs-2026.04.02": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "date"
+								}
+							}
+						}
+					}
+				}
+			}`,
+			expectedStatus: backend.HealthStatusOk,
+			expectedMsg:    "Index OK. Time field name OK.",
+		},
+		{
+			name: "Some indexes missing time field",
+			responseBody: `{
+				"logs-2026.04.01": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "date"
+								}
+							}
+						}
+					}
+				},
+				"logs-2026.04.02": {
+					"mappings": {}
+				}
+			}`,
+			expectedStatus: backend.HealthStatusError,
+			expectedMsg:    "Time field '@timestamp' not found",
+		},
+		{
+			name: "Some indexes have wrong field type",
+			responseBody: `{
+				"logs-2026.04.01": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "date"
+								}
+							}
+						}
+					}
+				},
+				"logs-2026.04.02": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "keyword"
+								}
+							}
+						}
+					}
+				}
+			}`,
+			expectedStatus: backend.HealthStatusError,
+			expectedMsg:    "not date type",
+		},
+		{
+			name: "No valid indexes found",
+			responseBody: `{
+				"logs-2026.04.01": {
+					"mappings": {}
+				},
+				"logs-2026.04.02": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "text"
+								}
+							}
+						}
+					}
+				}
+			}`,
+			expectedStatus: backend.HealthStatusError,
+			expectedMsg:    "Time field",
+		},
+		{
+			name: "Multiple invalid indexes",
+			responseBody: `{
+				"logs-2026.04.01": {
+					"mappings": {}
+				},
+				"logs-2026.04.02": {
+					"mappings": {
+						"@timestamp": {
+							"full_name": "@timestamp",
+							"mapping": {
+								"@timestamp": {
+									"type": "text"
+								}
+							}
+						}
+					}
+				},
+				"logs-2026.04.03": {
+					"mappings": {
+						"other_field": {
+							"full_name": "other_field",
+							"mapping": {
+								"other_field": {
+									"type": "keyword"
+								}
+							}
+						}
+					}
+				}
+			}`,
+			expectedStatus: backend.HealthStatusError,
+			expectedMsg:    "Time field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			ds := &OpenSearchDatasource{
+				HttpClient: &http.Client{
+					Transport: &mockTransport{
+						RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+							requestCount++
+							return &http.Response{
+								StatusCode: 200,
+								Body:       io.NopCloser(bytes.NewBufferString(tt.responseBody)),
+								Header:     make(http.Header),
+							}, nil
+						},
+					},
+				},
+			}
+
+			jsonData := `{
+				"flavor": "opensearch",
+				"version": "2.3.0",
+				"timeField": "@timestamp",
+				"database": "logs-*",
+				"interval": "Daily"
+			}`
+
+			req := &backend.CheckHealthRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+						URL:      "http://localhost:9200",
+						JSONData: []byte(jsonData),
+					},
+				},
+			}
+
+			res, err := ds.CheckHealth(context.Background(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, requestCount)
+			assert.Equal(t, tt.expectedStatus, res.Status)
+			assert.Contains(t, res.Message, tt.expectedMsg)
+		})
+	}
+}
+
+func TestCheckHealth_WildcardIndex_EmptyIndexMap(t *testing.T) {
+	ds := &OpenSearchDatasource{
+		HttpClient: &http.Client{
+			Transport: &mockTransport{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString("{}")),
+						Header:     make(http.Header),
+					}, nil
+				},
+			},
+		},
+	}
+
+	jsonData := `{
+		"flavor": "opensearch",
+		"version": "2.3.0",
+		"timeField": "@timestamp",
+		"database": "logs-*",
+		"interval": "Daily"
+	}`
+
+	req := &backend.CheckHealthRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				URL:      "http://localhost:9200",
+				JSONData: []byte(jsonData),
+			},
+		},
+	}
+
+	res, err := ds.CheckHealth(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, backend.HealthStatusError, res.Status)
+	assert.Contains(t, res.Message, "Index not found")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the health checks, when executed from the API and you are using wildcards in your index definition. 

**Which issue(s) this PR fixes**:

Fixes #888

**Special notes for your reviewer**:

I tested it locally using a local grafana + new fixed plugin and our AWS OpenSearch. With the patched plugin version it worked as expected.