### PR TITLE
fix:  datasorces deprecated api

### DIFF
--- a/src/configuration/ConfigEditor.tsx
+++ b/src/configuration/ConfigEditor.tsx
@@ -44,7 +44,7 @@ export const ConfigEditor = (props: Props) => {
     if (saved) {
       return;
     }
-    const { datasource } = await getBackendSrv().put(`/api/datasources/${options.id}`, value);
+    const { datasource } = await getBackendSrv().put(`/api/datasources/uid/${options.uid}`, value);
     value.version = datasource.version;
     onOptionsChange(value);
     setSaved(true);


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**: This PR fixes a bug where plugin uses deprecated datasource api then trying to fetch OS version.

**Which issue(s) this PR fixes**: Fixes #1083.

Fixes #

**Special notes for your reviewer**:
