### PR TITLE
ci: pin plugin-ci-workflows reusable workflows to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@2b6533cf7a036b781cd1e4817823743b1fdad089 # ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@2b6533cf7a036b781cd1e4817823743b1fdad089 # ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## What

Pin the `ci.yml` and `cd.yml` reusable workflows from `grafana/plugin-ci-workflows` to the commit SHA that `ci-cd-workflows/v8.0.1` resolves to (`2b6533cf7a036b781cd1e4817823743b1fdad089`), keeping the version as a trailing comment.

## Why

Every other action in `.github/workflows/` is already pinned to a full commit SHA — these two reusable workflows were the only references still using a mutable tag. Pinning to an immutable SHA closes that supply-chain gap and matches the repo convention (SHA + version comment, so Renovate can still track upgrades).

🤖 Generated with [Claude Code](https://claude.com/claude-code)