### PR TITLE
Classify query request errors as downstream errors

### DIFF
--- a/pkg/opensearch/query_request.go
+++ b/pkg/opensearch/query_request.go
@@ -34,7 +34,7 @@ func (e *queryRequest) execute(ctx context.Context) (*backend.QueryDataResponse,
 	if err != nil {
 		return &backend.QueryDataResponse{
 			Responses: backend.Responses{
-				e.queries[0].RefID: backend.ErrorResponseWithErrorSource(backend.PluginError(err)),
+				e.queries[0].RefID: backend.ErrorResponseWithErrorSource(backend.DownstreamError(err)),
 			},
 		}, nil
 	}
@@ -43,7 +43,7 @@ func (e *queryRequest) execute(ctx context.Context) (*backend.QueryDataResponse,
 		if err := handlers[q.QueryType].processQuery(q); err != nil {
 			return &backend.QueryDataResponse{
 				Responses: backend.Responses{
-					q.RefID: backend.ErrorResponseWithErrorSource(backend.PluginError(err)),
+					q.RefID: backend.ErrorResponseWithErrorSource(backend.DownstreamError(err)),
 				},
 			}, nil
 		}

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -1319,7 +1319,7 @@ func Test_parse_queryType(t *testing.T) {
 		assert.Empty(t, c.multisearchRequests, 0) // multisearchRequests is a Lucene query
 		assert.Empty(t, c.pplRequest, 0)
 
-		assert.Equal(t, backend.ErrorSourcePlugin, queryRes.Responses["A"].ErrorSource)
+		assert.Equal(t, backend.ErrorSourceDownstream, queryRes.Responses["A"].ErrorSource)
 		assert.Equal(t, `invalid queryType: "randomWalk", expected Lucene or PPL`, queryRes.Responses["A"].Error.Error())
 		var unwrappedError invalidQueryTypeError
 		assert.True(t, errors.As(queryRes.Responses["A"].Error, &unwrappedError))
@@ -1340,7 +1340,7 @@ func Test_parse_queryType(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, c.multisearchRequests, 0) // multisearchRequests is a Lucene query
 		assert.Empty(t, c.pplRequest, 0)
-		assert.Equal(t, backend.ErrorSourcePlugin, queryRes.Responses["A"].ErrorSource)
+		assert.Equal(t, backend.ErrorSourceDownstream, queryRes.Responses["A"].ErrorSource)
 		assert.Equal(t, `invalid queryType: "", expected Lucene or PPL`, queryRes.Responses["A"].Error.Error())
 		var unwrappedError invalidQueryTypeError
 		assert.True(t, errors.As(queryRes.Responses["A"].Error, &unwrappedError))


### PR DESCRIPTION
## What this PR does

Changes the error source from `PluginError` to `DownstreamError` for query execution and processing failures in the query request path.

These errors stem from the incoming query/request (e.g. an invalid `queryType`) rather than a fault in the plugin itself, so classifying them as downstream is more accurate and avoids inflating plugin error metrics.

## Changes

- `pkg/opensearch/query_request.go`: use `backend.DownstreamError` instead of `backend.PluginError` when wrapping execute/processQuery errors.
- `pkg/opensearch/query_request_test.go`: update assertions to expect `backend.ErrorSourceDownstream`.

Fixes https://github.com/grafana/data-sources/issues/1278