### PR TITLE
Improve PPL value autocomplete and fix Loading on refocus

### DIFF
--- a/src/components/QueryEditor/PPLQueryEditor/PPLQueryField.tsx
+++ b/src/components/QueryEditor/PPLQueryEditor/PPLQueryField.tsx
@@ -5,10 +5,10 @@ import { CodeEditor, Monaco, monacoTypes } from '@grafana/ui';
 import { OpenSearchQuery } from 'types';
 import { MonacoCodeEditorProps } from './types';
 import { css } from '@emotion/css';
-import { registerLanguage, reRegisterCompletionProvider } from 'language/monarch/register';
+import { registerLanguage } from 'language/monarch/register';
 import language from 'language/ppl/definition';
 import { useDatasource } from '../OpenSearchQueryContext';
-import { TRIGGER_SUGGEST } from 'language/monarch/commands';
+import { HIDE_SUGGEST, TRIGGER_SUGGEST } from 'language/monarch/commands';
 import { useEffectOnce } from 'react-use';
 
 interface CodeEditorProps {
@@ -42,7 +42,6 @@ export const PPLQueryField = (props: CodeEditorProps) => {
   const { query, onChange } = props;
   const datasource = useDatasource();
 
-  const monacoRef = useRef<Monaco>();
   const disposalRef = useRef<monacoTypes.IDisposable>();
   const editorRef = useRef<monacoTypes.editor.IStandaloneCodeEditor>();
 
@@ -69,17 +68,13 @@ export const PPLQueryField = (props: CodeEditorProps) => {
     }
   });
 
-  const onFocus = useCallback(async () => {
-    disposalRef.current = await reRegisterCompletionProvider(
-      monacoRef.current!,
-      language,
-      datasource.pplCompletionItemProvider,
-      disposalRef.current
-    );
-    // Trigger suggest only after the provider is registered. Firing suggest while
-    // dispose/re-register is in flight leaves Monaco stuck on "Loading...".
+  // Unlike CloudWatch PPL, our completion provider is not query-scoped, so keep it
+  // registered across blur/focus. Disposing on blur and re-registering on focus races
+  // Monaco's suggest widget and leaves it stuck on "Loading...". registerLanguage
+  // ref-counts a single shared provider so multiple editors do not duplicate suggestions.
+  const onFocus = useCallback(() => {
     editorRef.current?.trigger(TRIGGER_SUGGEST.id, TRIGGER_SUGGEST.id, {});
-  }, [datasource]);
+  }, []);
 
   const onEditorMount = useCallback(
     (editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: Monaco) => {
@@ -101,7 +96,6 @@ export const PPLQueryField = (props: CodeEditorProps) => {
     [onChange, query]
   );
   const onBeforeEditorMount = async (monaco: Monaco) => {
-    monacoRef.current = monaco;
     disposalRef.current = await registerLanguage(monaco, language, datasource.pplCompletionItemProvider);
   };
 
@@ -127,7 +121,7 @@ export const PPLQueryField = (props: CodeEditorProps) => {
         if (value !== query.query) {
           onChangeQuery(value);
         }
-        disposalRef.current?.dispose();
+        editorRef.current?.trigger(HIDE_SUGGEST.id, HIDE_SUGGEST.id, {});
       }}
       onFocus={onFocus}
       onBeforeEditorMount={onBeforeEditorMount}

--- a/src/language/monarch/commands.ts
+++ b/src/language/monarch/commands.ts
@@ -2,3 +2,8 @@ export const TRIGGER_SUGGEST = {
   id: 'editor.action.triggerSuggest',
   title: '',
 };
+
+export const HIDE_SUGGEST = {
+  id: 'hideSuggestWidget',
+  title: '',
+};

--- a/src/language/monarch/register.test.ts
+++ b/src/language/monarch/register.test.ts
@@ -1,0 +1,66 @@
+import { registerLanguage, __resetCompletionProviderRefsForTests, type LanguageDefinition } from './register';
+import type { Completeable } from './types';
+
+describe('registerLanguage completion provider refs', () => {
+  const registeredProviders: Array<{ dispose: jest.Mock }> = [];
+
+  const monaco = {
+    languages: {
+      getLanguages: jest.fn(() => [] as Array<{ id: string }>),
+      register: jest.fn(),
+      setMonarchTokensProvider: jest.fn(),
+      setLanguageConfiguration: jest.fn(),
+      registerCompletionItemProvider: jest.fn(() => {
+        const disposable = { dispose: jest.fn() };
+        registeredProviders.push(disposable);
+        return disposable;
+      }),
+    },
+  };
+
+  const language: LanguageDefinition = {
+    id: 'test-ppl',
+    loader: async () =>
+      ({
+        language: {},
+        conf: {},
+      }) as any,
+  };
+
+  const completionItemProvider: Completeable = {
+    getCompletionProvider: jest.fn(() => ({ provideCompletionItems: jest.fn() })),
+  };
+
+  beforeEach(() => {
+    __resetCompletionProviderRefsForTests();
+    registeredProviders.length = 0;
+    jest.clearAllMocks();
+    monaco.languages.getLanguages.mockReturnValue([]);
+  });
+
+  it('registers a single completion provider when two editors mount the same language', async () => {
+    const first = await registerLanguage(monaco as any, language, completionItemProvider);
+    monaco.languages.getLanguages.mockReturnValue([{ id: 'test-ppl' }]);
+    const second = await registerLanguage(monaco as any, language, completionItemProvider);
+
+    expect(monaco.languages.registerCompletionItemProvider).toHaveBeenCalledTimes(1);
+    expect(registeredProviders).toHaveLength(1);
+
+    first?.dispose();
+    expect(registeredProviders[0].dispose).not.toHaveBeenCalled();
+
+    second?.dispose();
+    expect(registeredProviders[0].dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-attaches a provider after the last editor unmounts', async () => {
+    const first = await registerLanguage(monaco as any, language, completionItemProvider);
+    monaco.languages.getLanguages.mockReturnValue([{ id: 'test-ppl' }]);
+    first?.dispose();
+
+    expect(registeredProviders[0].dispose).toHaveBeenCalledTimes(1);
+
+    await registerLanguage(monaco as any, language, completionItemProvider);
+    expect(monaco.languages.registerCompletionItemProvider).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/language/monarch/register.ts
+++ b/src/language/monarch/register.ts
@@ -15,21 +15,50 @@ export type LanguageDefinition = {
   }>;
 };
 
-export const reRegisterCompletionProvider = async (
-  monaco: Monaco,
-  language: LanguageDefinition,
-  completionItemProvider: Completeable,
-  disposal?: monacoType.IDisposable
-) => {
-  const { id, loader } = language;
-  disposal?.dispose();
-  return loader().then((monarch) => {
-    return monaco.languages.registerCompletionItemProvider(
-      id,
-      completionItemProvider.getCompletionProvider(monaco, language)
-    );
-  });
+type ProviderRef = {
+  disposable: monacoType.IDisposable;
+  refs: number;
 };
+
+/** One shared completion provider per language id (Monaco providers are global). */
+const completionProviderRefs = new Map<string, ProviderRef>();
+
+/** @internal test-only */
+export function __resetCompletionProviderRefsForTests() {
+  completionProviderRefs.clear();
+}
+
+function retainCompletionProvider(
+  monaco: Monaco,
+  languageId: string,
+  provider: monacoType.languages.CompletionItemProvider
+): monacoType.IDisposable {
+  const existing = completionProviderRefs.get(languageId);
+  if (existing) {
+    existing.refs += 1;
+    return {
+      dispose: () => releaseCompletionProvider(languageId),
+    };
+  }
+
+  const disposable = monaco.languages.registerCompletionItemProvider(languageId, provider);
+  completionProviderRefs.set(languageId, { disposable, refs: 1 });
+  return {
+    dispose: () => releaseCompletionProvider(languageId),
+  };
+}
+
+function releaseCompletionProvider(languageId: string) {
+  const entry = completionProviderRefs.get(languageId);
+  if (!entry) {
+    return;
+  }
+  entry.refs -= 1;
+  if (entry.refs <= 0) {
+    entry.disposable.dispose();
+    completionProviderRefs.delete(languageId);
+  }
+}
 
 export const registerLanguage = async (
   monaco: Monaco,
@@ -37,19 +66,19 @@ export const registerLanguage = async (
   completionItemProvider: Completeable
 ) => {
   const { id, loader } = language;
+  const provider = completionItemProvider.getCompletionProvider(monaco, language);
 
   const languages = monaco.languages.getLanguages();
   if (languages.find((l) => l.id === id)) {
-    return;
+    // Language stays registered globally after unmount; retain/re-attach a single
+    // shared completion provider so multiple editors do not duplicate suggestions.
+    return retainCompletionProvider(monaco, id, provider);
   }
 
   monaco.languages.register({ id });
   return loader().then((monarch) => {
     monaco.languages.setMonarchTokensProvider(id, monarch.language);
     monaco.languages.setLanguageConfiguration(id, monarch.conf);
-    return monaco.languages.registerCompletionItemProvider(
-      id,
-      completionItemProvider.getCompletionProvider(monaco, language)
-    );
+    return retainCompletionProvider(monaco, id, provider);
   });
 };

--- a/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
+++ b/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
@@ -184,6 +184,14 @@ describe('PPLCompletionItemProvider', () => {
       expect(getTerms).toHaveBeenCalledWith('status', undefined);
     });
 
+    it('should fetch terms via field.keyword when present for text fields', async () => {
+      getFields.mockResolvedValueOnce([{ text: 'status' }, { text: 'status.keyword' }, { text: 'bytes' }]);
+      const suggestions = await getSuggestions(whereFieldEqualsQuery.query, { lineNumber: 1, column: 15 });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toEqual(expect.arrayContaining(mockTermLabels));
+      expect(getTerms).toHaveBeenCalledWith('status.keyword', undefined);
+    });
+
     it('should pass source index into getFields when suggesting fields after source =', async () => {
       await getSuggestions(sourceThenFieldsQuery.query, { lineNumber: 1, column: 28 });
       expect(getFields).toHaveBeenCalledWith('inventory');
@@ -194,9 +202,33 @@ describe('PPLCompletionItemProvider', () => {
       expect(getFields).toHaveBeenCalledWith(undefined);
     });
 
+    it('should omit .keyword and .raw multi-fields from field suggestions', async () => {
+      getFields.mockResolvedValueOnce([
+        { text: 'audit_node_name' },
+        { text: 'audit_node_name.keyword' },
+        { text: 'message' },
+        { text: 'message.raw' },
+        { text: 'distance' },
+      ]);
+      const suggestions = await getSuggestions(fieldsQuery.query, { lineNumber: 1, column: 9 });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toEqual(expect.arrayContaining(['audit_node_name', 'message', 'distance']));
+      expect(suggestionLabels).not.toContain('audit_node_name.keyword');
+      expect(suggestionLabels).not.toContain('message.raw');
+    });
+
     it('should pass source index into getTerms when suggesting values after source =', async () => {
       await getSuggestions(sourceThenWhereEqualsQuery.query, { lineNumber: 1, column: 36 });
       expect(getTerms).toHaveBeenCalledWith('status', 'inventory');
+    });
+
+    it('should fetch terms via field.keyword for the query source index when both apply', async () => {
+      getFields.mockResolvedValueOnce([{ text: 'status' }, { text: 'status.keyword' }, { text: 'bytes' }]);
+      const suggestions = await getSuggestions(sourceThenWhereEqualsQuery.query, { lineNumber: 1, column: 36 });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toEqual(expect.arrayContaining(mockTermLabels));
+      expect(getFields).toHaveBeenCalledWith('inventory');
+      expect(getTerms).toHaveBeenCalledWith('status.keyword', 'inventory');
     });
 
     it('should suggest field values for where index = / where source =, not index names', async () => {

--- a/src/language/ppl/completion/PPLCompletionItemProvider.ts
+++ b/src/language/ppl/completion/PPLCompletionItemProvider.ts
@@ -51,6 +51,7 @@ import {
 import { getStatementPosition } from './statementPosition';
 import { getSuggestionKinds } from './suggestionKinds';
 import { getFieldNameBeforeComparison, getSourceIndexFromTokens } from './sourceIndex';
+import { resolveAggregatableTermsField, isSuggestablePplField } from './aggregatableField';
 import { PPLTokenTypes } from '../tokenTypes';
 import { MetricFindValue } from '@grafana/data';
 import { OpenSearchIndex } from 'types';
@@ -498,7 +499,7 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
       const sourceIndex = getSourceIndexFromTokens(currentToken ?? null);
       let fields = await this.getFields(sourceIndex);
       fields.forEach((field) => {
-        if (field.text) {
+        if (field.text && isSuggestablePplField(field.text)) {
           addSuggestion(field.text, {
             range,
             label: field.text,
@@ -550,7 +551,10 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
 
     try {
       const sourceIndex = getSourceIndexFromTokens(currentToken ?? null);
-      const terms = await this.getTerms(fieldName, sourceIndex);
+      const fields = await this.getFields(sourceIndex);
+      const fieldNames = fields.map((f) => f.text).filter((name): name is string => Boolean(name));
+      const termsField = resolveAggregatableTermsField(fieldName, fieldNames);
+      const terms = await this.getTerms(termsField, sourceIndex);
       terms.forEach((term) => {
         if (term.text !== undefined && term.text !== null) {
           const quoted = `'${String(term.text).replace(/'/g, "\\'")}'`;

--- a/src/language/ppl/completion/aggregatableField.test.ts
+++ b/src/language/ppl/completion/aggregatableField.test.ts
@@ -1,0 +1,60 @@
+import { resolveAggregatableTermsField, isSuggestablePplField } from './aggregatableField';
+
+describe('resolveAggregatableTermsField', () => {
+  it('returns the field unchanged when it is already aggregatable (no multi-field needed)', () => {
+    expect(resolveAggregatableTermsField('status', ['status', 'bytes'])).toBe('status');
+  });
+
+  it('prefers field.keyword when present for a text field', () => {
+    expect(
+      resolveAggregatableTermsField('audit_node_name', ['audit_node_name', 'audit_node_name.keyword', 'status'])
+    ).toBe('audit_node_name.keyword');
+  });
+
+  it('falls back to field.raw when keyword is absent', () => {
+    expect(resolveAggregatableTermsField('message', ['message', 'message.raw'])).toBe('message.raw');
+  });
+
+  it('prefers .keyword over .raw when both exist', () => {
+    expect(resolveAggregatableTermsField('title', ['title', 'title.raw', 'title.keyword'])).toBe('title.keyword');
+  });
+
+  it('returns the field unchanged when already a multi-field path', () => {
+    expect(
+      resolveAggregatableTermsField('audit_node_name.keyword', ['audit_node_name', 'audit_node_name.keyword'])
+    ).toBe('audit_node_name.keyword');
+  });
+
+  it('resolves keyword for dotted field names', () => {
+    expect(
+      resolveAggregatableTermsField('integration-instance.name', [
+        'integration-instance.name',
+        'integration-instance.name.keyword',
+      ])
+    ).toBe('integration-instance.name.keyword');
+  });
+
+  it('returns the field unchanged when no aggregatable sibling exists', () => {
+    expect(resolveAggregatableTermsField('audit_node_name', ['audit_node_name', 'status'])).toBe('audit_node_name');
+  });
+
+  it('does not pick an unrelated field that only shares a prefix', () => {
+    expect(resolveAggregatableTermsField('host', ['host', 'hostName', 'hostName.keyword', 'hostname.keyword'])).toBe(
+      'host'
+    );
+  });
+});
+
+describe('isSuggestablePplField', () => {
+  it('keeps normal fields', () => {
+    expect(isSuggestablePplField('audit_node_name')).toBe(true);
+    expect(isSuggestablePplField('status')).toBe(true);
+    expect(isSuggestablePplField('integration-instance.name')).toBe(true);
+  });
+
+  it('hides aggregatable multi-field suffixes used only for terms/aggs', () => {
+    expect(isSuggestablePplField('audit_node_name.keyword')).toBe(false);
+    expect(isSuggestablePplField('message.raw')).toBe(false);
+    expect(isSuggestablePplField('integration-instance.name.keyword')).toBe(false);
+  });
+});

--- a/src/language/ppl/completion/aggregatableField.ts
+++ b/src/language/ppl/completion/aggregatableField.ts
@@ -1,0 +1,31 @@
+/**
+ * Prefer an aggregatable multi-field for terms aggregations while leaving the
+ * query field name unchanged (e.g. `where audit_node_name =` still uses the text field).
+ *
+ * OpenSearch/ES text fields are not aggregatable by default; values live on `.keyword`
+ * (or older `.raw`) multi-fields. See datasource docs for template-variable guidance.
+ */
+export function resolveAggregatableTermsField(field: string, availableFields: string[]): string {
+  const keyword = `${field}.keyword`;
+  if (availableFields.includes(keyword)) {
+    return keyword;
+  }
+
+  const raw = `${field}.raw`;
+  if (availableFields.includes(raw)) {
+    return raw;
+  }
+
+  return field;
+}
+
+/** Multi-field suffixes used for aggregations/sorting — hide from PPL field suggestions. */
+const AGGREGATABLE_MULTI_FIELD_SUFFIXES = ['.keyword', '.raw'];
+
+/**
+ * Whether a field name should appear in PPL field autocomplete.
+ * Hides `.keyword` / `.raw` multi-fields; value suggestions still resolve them under the hood.
+ */
+export function isSuggestablePplField(fieldName: string): boolean {
+  return !AGGREGATABLE_MULTI_FIELD_SUFFIXES.some((suffix) => fieldName.endsWith(suffix));
+}


### PR DESCRIPTION
## Summary

* When suggesting values after `where <field> =`, resolve an aggregatable sibling (`field.keyword`, then `field.raw`) from field caps before calling `getTerms`, while keeping the bare field in the query.
* Hide `.keyword` / `.raw` multi-fields from PPL field suggestions (value resolution still uses them under the hood).
* Fix stuck `Loading...` after leaving the editor with autocomplete open and returning: keep a ref-counted completion provider across blur/focus (no dispose/re-register race), and dismiss the suggest widget on blur.

Follow-up to #1137. Custom aggregatable siblings (e.g. `.exact`) are still unresolved without field-caps aggregatable metadata — deferred.

Related to #1138 (higher-priority remaining work: aggregatable term fields + Loading on refocus). Does not close #1138: suggesting `|` after completed `where` / `fields` / `sort` / `stats` segments is still open.

## Test plan

- [ ] Unit: `aggregatableField`, `PPLCompletionItemProvider`, `registerLanguage` suites
- [ ] Explore → PPL: `where <text-field> = ` suggests values (uses `.keyword` under the hood)
- [ ] Same query still runs with the bare field name (not `.keyword`)
- [ ] Keyword/numeric fields still suggest values unchanged
- [ ] With `source = <index>`, field caps / terms use that index
- [ ] Field suggestions omit `.keyword` / `.raw`
- [ ] Leave editor while autocomplete is open, click back: suggestions work (no stuck Loading; Esc not required)