### PR TITLE
docs: add redirect from old core docs path to plugin docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - /docs/plugins/grafana-opensearch-datasource/
+  - /docs/grafana/latest/datasources/opensearch/
 description: Use the OpenSearch data source to query and visualize logs, metrics, and traces from OpenSearch in Grafana.
 keywords:
   - grafana


### PR DESCRIPTION
## Summary

- Add an alias for the legacy `/docs/grafana/latest/datasources/opensearch/` path on the OpenSearch docs landing page so it redirects to the current plugin docs page instead of returning a 404.

## Context

A customer reported that the old URL still circulating on the web returns a 404:

- Old (404s): https://grafana.com/docs/grafana/latest/datasources/opensearch/
- Current content: https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/

This is a missing redirect rather than missing content.

## Note

Aliases in this repo generate redirects within the plugin docs site's build. If the `/docs/grafana/...` path is owned by the separate `grafana/grafana` core docs site, the redirect may also need to be added there. Flagging for the docs team in case this alias alone doesn't resolve the 404 after publishing.


Made with [Cursor](https://cursor.com)