### PR TITLE
chore(deps): bump @grafana/aws-sdk to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Bump `@grafana/aws-sdk` to 0.12.1 for SigV4 per-datasource Grafana Assume Role external IDs
+
 ## 2.34.3
 
 * docs: add redirect from old core docs path to plugin docs in https://github.com/grafana/opensearch-datasource/pull/1164

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@emotion/css": "11.13.5",
-    "@grafana/aws-sdk": "0.12.0",
+    "@grafana/aws-sdk": "0.12.1",
     "@grafana/data": "13.1.1",
     "@grafana/plugin-ui": "0.17.3",
     "@grafana/runtime": "13.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,12 +1596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@grafana/aws-sdk@npm:0.12.0"
+"@grafana/aws-sdk@npm:0.12.1":
+  version: 0.12.1
+  resolution: "@grafana/aws-sdk@npm:0.12.1"
   peerDependencies:
     "@grafana/plugin-ui": ">=0.14.0"
-  checksum: 10c0/ddaebf62d9f49d89bc5e1d4eba85c7131c92583ad1e382a0e836fcb93e363de2c76929ecb2ccd7ee37518b5b5a3263415988b840affea6b0af510f0294a7a306
+  checksum: 10c0/bda7becad21c72ac27d3308b3d4cd069b84cb3bcede8ce7d13746d7e9e06f8eb92a171c21d6cbeb372caac13e89144a2b2658b2f34bc1df13436d568249e1894
   languageName: node
   linkType: hard
 
@@ -7292,7 +7292,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@eslint/eslintrc": "npm:3.3.6"
     "@eslint/js": "npm:9.39.5"
-    "@grafana/aws-sdk": "npm:0.12.0"
+    "@grafana/aws-sdk": "npm:0.12.1"
     "@grafana/data": "npm:13.1.1"
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/plugin-e2e": "npm:3.10.0"


### PR DESCRIPTION
## Summary
- Bump `@grafana/aws-sdk` from 0.12.0 → 0.12.1
- Picks up SigV4 per-datasource Grafana Assume Role external ID mapping in `SIGV4ConnectionConfig` ([grafana-aws-sdk-react#501](https://github.com/grafana/grafana-aws-sdk-react/pull/501))

Depends on merged backend work:
- [grafana#129144](https://github.com/grafana/grafana/pull/129144) — mint/scrub prefixed keys
- [grafana-enterprise#12799](https://github.com/grafana/grafana-enterprise/pull/12799) — dsauth reads prefixed keys

## Test plan
- [ ] Yarn install / CI green
- [ ] SigV4 + Grafana Assume Role config shows per-DS external ID toggle (with FT on)
- [ ] Saving persists `sigV4GrafanaExternalId` / `sigV4UsePerDatasourceExternalId`