### PR TITLE
build: upgrade Go to 1.26.6

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -7,7 +7,7 @@ ARG anonymous_auth_enabled=true
 ARG development=false
 ARG TARGETARCH
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG GO_ARCH=${TARGETARCH:-amd64}
 
 ENV DEV "${development}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/opensearch-datasource
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

- Updates the Go version in go.mod and the backend development/build image from 1.26.5 to 1.26.6.
- Ensures newly built backend binaries use the current Go 1.26 patch release and its standard-library security fixes.
- A new signed plugin release is needed after merge because existing release artifacts are immutable.

**Which issue(s) this PR fixes**:

No linked issue.

**Validation**:

- go test ./...
- go vet ./...
- Mage cross-platform backend build
- Verified all six generated backend binaries report go1.26.6

**Special notes for your reviewer**:

@mattvella07 @aangelisc, please review this build-only security update. Once it is merged, could a maintainer publish a new signed plugin release so the catalog artifacts are rebuilt with Go 1.26.6?