### PR TITLE
Suggest | after completed PPL fields/where/stats segments

### DIFF
--- a/src/__mocks__/monarch/Monaco.ts
+++ b/src/__mocks__/monarch/Monaco.ts
@@ -79,14 +79,20 @@ const MonacoMock: Monaco = {
             PPLSingleLineQueries.sourceHyphenIncompleteQuery.tokens,
           [PPLSingleLineQueries.sourceHyphenCompleteQuery.query]: PPLSingleLineQueries.sourceHyphenCompleteQuery.tokens,
           [PPLSingleLineQueries.fieldsCompleteQuery.query]: PPLSingleLineQueries.fieldsCompleteQuery.tokens,
+          [PPLSingleLineQueries.fieldsFunctionFieldQuery.query]: PPLSingleLineQueries.fieldsFunctionFieldQuery.tokens,
           [PPLSingleLineQueries.fieldsTrailingCommaQuery.query]: PPLSingleLineQueries.fieldsTrailingCommaQuery.tokens,
           [PPLSingleLineQueries.sortCompleteQuery.query]: PPLSingleLineQueries.sortCompleteQuery.tokens,
+          [PPLSingleLineQueries.sortFunctionFieldQuery.query]: PPLSingleLineQueries.sortFunctionFieldQuery.tokens,
           [PPLSingleLineQueries.sortDanglingOperatorQuery.query]: PPLSingleLineQueries.sortDanglingOperatorQuery.tokens,
           [PPLSingleLineQueries.whereCompleteQuery.query]: PPLSingleLineQueries.whereCompleteQuery.tokens,
           [PPLSingleLineQueries.whereDanglingAndQuery.query]: PPLSingleLineQueries.whereDanglingAndQuery.tokens,
           [PPLSingleLineQueries.whereConditionCompleteQuery.query]:
             PPLSingleLineQueries.whereConditionCompleteQuery.tokens,
           [PPLSingleLineQueries.statsCountCompleteQuery.query]: PPLSingleLineQueries.statsCountCompleteQuery.tokens,
+          [PPLSingleLineQueries.statsCountTrailingCommaQuery.query]:
+            PPLSingleLineQueries.statsCountTrailingCommaQuery.tokens,
+          [PPLSingleLineQueries.eventstatsCountCompleteQuery.query]:
+            PPLSingleLineQueries.eventstatsCountCompleteQuery.tokens,
           [PPLSingleLineQueries.statsByCompleteQuery.query]: PPLSingleLineQueries.statsByCompleteQuery.tokens,
           [PPLSingleLineQueries.statsByIncompleteQuery.query]: PPLSingleLineQueries.statsByIncompleteQuery.tokens,
           [PPLSingleLineQueries.headCompleteQuery.query]: PPLSingleLineQueries.headCompleteQuery.tokens,

--- a/src/__mocks__/monarch/Monaco.ts
+++ b/src/__mocks__/monarch/Monaco.ts
@@ -52,6 +52,8 @@ const MonacoMock: Monaco = {
           [PPLSingleLineQueries.fillNullWithQuery.query]: PPLSingleLineQueries.fillNullWithQuery.tokens,
           [PPLSingleLineQueries.trendlineQuery.query]: PPLSingleLineQueries.trendlineQuery.tokens,
           [PPLSingleLineQueries.appendColQuery.query]: PPLSingleLineQueries.appendColQuery.tokens,
+          [PPLSingleLineQueries.appendColBracketedStatsQuery.query]:
+            PPLSingleLineQueries.appendColBracketedStatsQuery.tokens,
           [PPLSingleLineQueries.expandQuery.query]: PPLSingleLineQueries.expandQuery.tokens,
           [PPLSingleLineQueries.flattenQuery.query]: PPLSingleLineQueries.flattenQuery.tokens,
           [PPLSingleLineQueries.reverseQuery.query]: PPLSingleLineQueries.reverseQuery.tokens,

--- a/src/__mocks__/monarch/Monaco.ts
+++ b/src/__mocks__/monarch/Monaco.ts
@@ -78,6 +78,22 @@ const MonacoMock: Monaco = {
           [PPLSingleLineQueries.sourceHyphenIncompleteQuery.query]:
             PPLSingleLineQueries.sourceHyphenIncompleteQuery.tokens,
           [PPLSingleLineQueries.sourceHyphenCompleteQuery.query]: PPLSingleLineQueries.sourceHyphenCompleteQuery.tokens,
+          [PPLSingleLineQueries.fieldsCompleteQuery.query]: PPLSingleLineQueries.fieldsCompleteQuery.tokens,
+          [PPLSingleLineQueries.fieldsTrailingCommaQuery.query]: PPLSingleLineQueries.fieldsTrailingCommaQuery.tokens,
+          [PPLSingleLineQueries.sortCompleteQuery.query]: PPLSingleLineQueries.sortCompleteQuery.tokens,
+          [PPLSingleLineQueries.sortDanglingOperatorQuery.query]: PPLSingleLineQueries.sortDanglingOperatorQuery.tokens,
+          [PPLSingleLineQueries.whereCompleteQuery.query]: PPLSingleLineQueries.whereCompleteQuery.tokens,
+          [PPLSingleLineQueries.whereDanglingAndQuery.query]: PPLSingleLineQueries.whereDanglingAndQuery.tokens,
+          [PPLSingleLineQueries.whereConditionCompleteQuery.query]:
+            PPLSingleLineQueries.whereConditionCompleteQuery.tokens,
+          [PPLSingleLineQueries.statsCountCompleteQuery.query]: PPLSingleLineQueries.statsCountCompleteQuery.tokens,
+          [PPLSingleLineQueries.statsByCompleteQuery.query]: PPLSingleLineQueries.statsByCompleteQuery.tokens,
+          [PPLSingleLineQueries.statsByIncompleteQuery.query]: PPLSingleLineQueries.statsByIncompleteQuery.tokens,
+          [PPLSingleLineQueries.headCompleteQuery.query]: PPLSingleLineQueries.headCompleteQuery.tokens,
+          [PPLSingleLineQueries.sourceThenFieldsCompleteQuery.query]:
+            PPLSingleLineQueries.sourceThenFieldsCompleteQuery.tokens,
+          [PPLSingleLineQueries.sourceThenFieldsTrailingCommaQuery.query]:
+            PPLSingleLineQueries.sourceThenFieldsTrailingCommaQuery.tokens,
         };
         return TestData[value];
       }

--- a/src/__mocks__/ppl-test-data/singleLineQueries.ts
+++ b/src/__mocks__/ppl-test-data/singleLineQueries.ts
@@ -1126,3 +1126,217 @@ export const sourceThenWhereSourceEqualsQuery = {
     ],
   ] as monacoTypes.Token[][],
 };
+
+/** `fields status ` — complete field list ending on a field */
+export const fieldsCompleteQuery = {
+  query: 'fields status ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "fields"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 13, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `fields status, ` — trailing comma, incomplete */
+export const fieldsTrailingCommaQuery = {
+  query: 'fields status, ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "fields"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 13, type: PPLTokenTypes.Delimiter, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ","
+      { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `sort - timestamp ` — complete sort field after +/- */
+export const sortCompleteQuery = {
+  query: 'sort - timestamp ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "sort"
+      { offset: 4, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 5, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "-"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "timestamp"
+      { offset: 16, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `sort - ` — dangling field operator */
+export const sortDanglingOperatorQuery = {
+  query: 'sort - ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "sort"
+      { offset: 4, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 5, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "-"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `where status = 200 ` — complete comparison */
+export const whereCompleteQuery = {
+  query: 'where status = 200 ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "where"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 12, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 13, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "="
+      { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 15, type: PPLTokenTypes.Number, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "200"
+      { offset: 18, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `where status = 200 and ` — dangling AND */
+export const whereDanglingAndQuery = {
+  query: 'where status = 200 and ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "where"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 12, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 13, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "="
+      { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 15, type: PPLTokenTypes.Number, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "200"
+      { offset: 18, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 19, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "and"
+      { offset: 22, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `where isnull(status) ` — complete condition function */
+export const whereConditionCompleteQuery = {
+  query: 'where isnull(status) ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "where"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "isnull"
+      { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 13, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 19, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 20, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `stats count() ` — closed stats function */
+export const statsCountCompleteQuery = {
+  query: 'stats count() ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "stats"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 11, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 13, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `stats count() by host ` — by field complete */
+export const statsByCompleteQuery = {
+  query: 'stats count() by host ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "stats"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 11, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 13, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 14, type: PPLTokenTypes.Keyword, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "by"
+      { offset: 16, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 17, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "host"
+      { offset: 21, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `stats count() by ` — by with no field yet */
+export const statsByIncompleteQuery = {
+  query: 'stats count() by ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "stats"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 11, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 13, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 14, type: PPLTokenTypes.Keyword, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "by"
+      { offset: 16, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `head 10 ` — terminal command, never suggest pipe */
+export const headCompleteQuery = {
+  query: 'head 10 ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "head"
+      { offset: 4, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 5, type: PPLTokenTypes.Number, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "10"
+      { offset: 7, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `source = inventory | fields status ` — provider integration happy path */
+export const sourceThenFieldsCompleteQuery = {
+  query: 'source = inventory | fields status ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Keyword, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "source"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "="
+      { offset: 8, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 9, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "inventory"
+      { offset: 18, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 19, type: PPLTokenTypes.Pipe, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "|"
+      { offset: 20, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 21, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "fields"
+      { offset: 27, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 28, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 34, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `source = inventory | fields status, ` — trailing comma, no pipe */
+export const sourceThenFieldsTrailingCommaQuery = {
+  query: 'source = inventory | fields status, ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Keyword, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "source"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "="
+      { offset: 8, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 9, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "inventory"
+      { offset: 18, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 19, type: PPLTokenTypes.Pipe, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "|"
+      { offset: 20, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 21, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "fields"
+      { offset: 27, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 28, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "status"
+      { offset: 34, type: PPLTokenTypes.Delimiter, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ","
+      { offset: 35, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};

--- a/src/__mocks__/ppl-test-data/singleLineQueries.ts
+++ b/src/__mocks__/ppl-test-data/singleLineQueries.ts
@@ -762,7 +762,7 @@ export const trendlineQuery = {
       { offset: 10, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "sort"
       { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
       { offset: 15, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "-"
-      { offset: 16, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "byte_sent"
+      { offset: 16, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "byte_sent"
       { offset: 25, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
       { offset: 26, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "SMA"
       { offset: 29, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
@@ -1140,6 +1140,22 @@ export const fieldsCompleteQuery = {
   ] as monacoTypes.Token[][],
 };
 
+/**
+ * `fields count ` — field name collides with a builtin function (`count`), so the
+ * real Monarch tokenizer emits `Function` (predefined), not `Identifier`, for it.
+ */
+export const fieldsFunctionFieldQuery = {
+  query: 'fields count ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "fields"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 12, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
 /** `fields status, ` — trailing comma, incomplete */
 export const fieldsTrailingCommaQuery = {
   query: 'fields status, ',
@@ -1154,17 +1170,35 @@ export const fieldsTrailingCommaQuery = {
   ] as monacoTypes.Token[][],
 };
 
-/** `sort - timestamp ` — complete sort field after +/- */
+/** `sort - latency ` — complete sort field after +/- (plain identifier) */
 export const sortCompleteQuery = {
-  query: 'sort - timestamp ',
+  query: 'sort - latency ',
   tokens: [
     [
       { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "sort"
       { offset: 4, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
       { offset: 5, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "-"
       { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
-      { offset: 7, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "timestamp"
-      { offset: 16, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "latency"
+      { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/**
+ * `sort - count ` — field name collides with a builtin function (`count`), so the
+ * real Monarch tokenizer emits `Function` (predefined), not `Identifier`, for it.
+ */
+export const sortFunctionFieldQuery = {
+  query: 'sort - count ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "sort"
+      { offset: 4, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 5, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "-"
+      { offset: 6, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 7, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 12, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
     ],
   ] as monacoTypes.Token[][],
 };
@@ -1245,6 +1279,37 @@ export const statsCountCompleteQuery = {
       { offset: 11, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
       { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
       { offset: 13, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `stats count(), ` — dangling comma after closed function, incomplete */
+export const statsCountTrailingCommaQuery = {
+  query: 'stats count(), ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "stats"
+      { offset: 5, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 6, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 11, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 12, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 13, type: PPLTokenTypes.Delimiter, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ","
+      { offset: 14, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
+
+/** `eventstats count() ` — closed stats function, eventstats variant */
+export const eventstatsCountCompleteQuery = {
+  query: 'eventstats count() ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "eventstats"
+      { offset: 10, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 11, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 16, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 17, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 18, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
     ],
   ] as monacoTypes.Token[][],
 };

--- a/src/__mocks__/ppl-test-data/singleLineQueries.ts
+++ b/src/__mocks__/ppl-test-data/singleLineQueries.ts
@@ -807,6 +807,27 @@ export const appendColQuery = {
     ],
   ] as monacoTypes.Token[][],
 };
+/** `appendcol override=true [stats count() ` — completed stats as first command of a bracketed subquery */
+export const appendColBracketedStatsQuery = {
+  query: 'appendcol override=true [stats count() ',
+  tokens: [
+    [
+      { offset: 0, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "appendcol"
+      { offset: 9, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 10, type: PPLTokenTypes.Identifier, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "override"
+      { offset: 18, type: PPLTokenTypes.Operator, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "="
+      { offset: 19, type: PPLTokenTypes.Keyword, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "true"
+      { offset: 23, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 24, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "["
+      { offset: 25, type: PPLTokenTypes.Command, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "stats"
+      { offset: 30, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+      { offset: 31, type: PPLTokenTypes.Function, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "count"
+      { offset: 36, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // "("
+      { offset: 37, type: PPLTokenTypes.Parenthesis, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // ")"
+      { offset: 38, type: PPLTokenTypes.Whitespace, language: OPENSEARCH_PPL_LANGUAGE_DEFINITION_ID }, // " "
+    ],
+  ] as monacoTypes.Token[][],
+};
 export const expandQuery = {
   query: 'expand field1 as renamedField1',
   tokens: [

--- a/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
+++ b/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
@@ -188,6 +188,15 @@ describe('PPLCompletionItemProvider', () => {
       expect(suggestionLabels).toContain('|');
     });
 
+    it('should suggest pipe when the cursor is still on the last fields argument', async () => {
+      const suggestions = await getSuggestions(sourceThenFieldsCompleteQuery.query, {
+        lineNumber: 1,
+        column: 34,
+      });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toContain('|');
+    });
+
     it('should not suggest pipe after a trailing comma in fields', async () => {
       const suggestions = await getSuggestions(sourceThenFieldsTrailingCommaQuery.query, {
         lineNumber: 1,

--- a/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
+++ b/src/language/ppl/completion/PPLCompletionItemProvider.test.ts
@@ -37,6 +37,8 @@ import {
   sourceEqualsCompleteQuery,
   sourceHyphenCompleteQuery,
   sourceThenFieldsQuery,
+  sourceThenFieldsCompleteQuery,
+  sourceThenFieldsTrailingCommaQuery,
   sourceThenWhereEqualsQuery,
   sourceThenWhereIndexEqualsQuery,
   sourceThenWhereSourceEqualsQuery,
@@ -175,6 +177,24 @@ describe('PPLCompletionItemProvider', () => {
       const suggestions = await getSuggestions(sourceHyphenCompleteQuery.query, { lineNumber: 1, column: 19 });
       const suggestionLabels = suggestions.map((s) => s.label);
       expect(suggestionLabels).toContain('|');
+    });
+
+    it('should suggest pipe after a completed fields list', async () => {
+      const suggestions = await getSuggestions(sourceThenFieldsCompleteQuery.query, {
+        lineNumber: 1,
+        column: 35,
+      });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toContain('|');
+    });
+
+    it('should not suggest pipe after a trailing comma in fields', async () => {
+      const suggestions = await getSuggestions(sourceThenFieldsTrailingCommaQuery.query, {
+        lineNumber: 1,
+        column: 36,
+      });
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).not.toContain('|');
     });
 
     it('should suggest field values after a comparison in where', async () => {

--- a/src/language/ppl/completion/PPLCompletionItemProvider.ts
+++ b/src/language/ppl/completion/PPLCompletionItemProvider.ts
@@ -52,6 +52,7 @@ import { getStatementPosition } from './statementPosition';
 import { getSuggestionKinds } from './suggestionKinds';
 import { getFieldNameBeforeComparison, getSourceIndexFromTokens } from './sourceIndex';
 import { resolveAggregatableTermsField, isSuggestablePplField } from './aggregatableField';
+import { canSuggestPipe } from './pipeSuggestion';
 import { PPLTokenTypes } from '../tokenTypes';
 import { MetricFindValue } from '@grafana/data';
 import { OpenSearchIndex } from 'types';
@@ -83,6 +84,10 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
     position: monacoTypes.IPosition
   ): Promise<CompletionItem[]> {
     const suggestions: CompletionItem[] = [];
+    const kinds = [...suggestionKinds];
+    if (canSuggestPipe(currentToken) && !kinds.includes(SuggestionKind.Pipe)) {
+      kinds.push(SuggestionKind.Pipe);
+    }
     const invalidRangeToken =
       currentToken?.isWhiteSpace() || currentToken?.isParenthesis() || currentToken?.is(PPLTokenTypes.Backtick); // PPLTokenTypes.Backtick for field wrapping
     const range =
@@ -103,7 +108,7 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
       suggestions.push(toCompletionItem(value, rest));
     }
 
-    for (const kind of suggestionKinds) {
+    for (const kind of kinds) {
       switch (kind) {
         case SuggestionKind.Command:
           PPL_COMMANDS.forEach((command) => {

--- a/src/language/ppl/completion/pipeSuggestion.test.ts
+++ b/src/language/ppl/completion/pipeSuggestion.test.ts
@@ -44,6 +44,10 @@ describe('canSuggestPipe', () => {
     expect(canSuggestPipe(generateToken(fieldsCompleteQuery.query, { lineNumber: 1, column: 14 }))).toBe(true);
   });
 
+  it('returns true when the cursor is still on the last fields argument (no trailing space)', () => {
+    expect(canSuggestPipe(generateToken(fieldsCompleteQuery.query, { lineNumber: 1, column: 13 }))).toBe(true);
+  });
+
   it('returns false after a trailing comma in fields', () => {
     expect(canSuggestPipe(generateToken(fieldsTrailingCommaQuery.query, { lineNumber: 1, column: 15 }))).toBe(false);
   });
@@ -66,6 +70,10 @@ describe('canSuggestPipe', () => {
 
   it('returns true after a complete where comparison', () => {
     expect(canSuggestPipe(generateToken(whereCompleteQuery.query, { lineNumber: 1, column: 19 }))).toBe(true);
+  });
+
+  it('returns true when the cursor is still on the where comparison value (no trailing space)', () => {
+    expect(canSuggestPipe(generateToken(whereCompleteQuery.query, { lineNumber: 1, column: 18 }))).toBe(true);
   });
 
   it('returns false after a dangling AND in where', () => {

--- a/src/language/ppl/completion/pipeSuggestion.test.ts
+++ b/src/language/ppl/completion/pipeSuggestion.test.ts
@@ -1,0 +1,88 @@
+import { monacoTypes } from '@grafana/ui';
+
+import {
+  fieldsCompleteQuery,
+  fieldsTrailingCommaQuery,
+  headCompleteQuery,
+  sortCompleteQuery,
+  sortDanglingOperatorQuery,
+  statsByCompleteQuery,
+  statsByIncompleteQuery,
+  statsCountCompleteQuery,
+  whereCompleteQuery,
+  whereConditionCompleteQuery,
+  whereDanglingAndQuery,
+  whereFieldEqualsQuery,
+} from '../../../__mocks__/ppl-test-data/singleLineQueries';
+import MonacoMock from '../../../__mocks__/monarch/Monaco';
+import TextModel from '../../../__mocks__/monarch/TextModel';
+import { linkedTokenBuilder } from '../../monarch/linkedTokenBuilder';
+import { PPLTokenTypes } from '../tokenTypes';
+import openSearchPPLLanguageDefinition from '../definition';
+
+import { canSuggestPipe } from './pipeSuggestion';
+
+function generateToken(query: string, position: monacoTypes.IPosition) {
+  const testModel = TextModel(query);
+  return linkedTokenBuilder(
+    MonacoMock,
+    openSearchPPLLanguageDefinition,
+    testModel as monacoTypes.editor.ITextModel,
+    position,
+    PPLTokenTypes
+  );
+}
+
+describe('canSuggestPipe', () => {
+  it('returns true after a completed fields argument list', () => {
+    expect(canSuggestPipe(generateToken(fieldsCompleteQuery.query, { lineNumber: 1, column: 14 }))).toBe(true);
+  });
+
+  it('returns false after a trailing comma in fields', () => {
+    expect(canSuggestPipe(generateToken(fieldsTrailingCommaQuery.query, { lineNumber: 1, column: 15 }))).toBe(false);
+  });
+
+  it('returns true after a completed sort field', () => {
+    expect(canSuggestPipe(generateToken(sortCompleteQuery.query, { lineNumber: 1, column: 17 }))).toBe(true);
+  });
+
+  it('returns false after a dangling sort +/- operator', () => {
+    expect(canSuggestPipe(generateToken(sortDanglingOperatorQuery.query, { lineNumber: 1, column: 7 }))).toBe(false);
+  });
+
+  it('returns true after a complete where comparison', () => {
+    expect(canSuggestPipe(generateToken(whereCompleteQuery.query, { lineNumber: 1, column: 19 }))).toBe(true);
+  });
+
+  it('returns false after a dangling AND in where', () => {
+    expect(canSuggestPipe(generateToken(whereDanglingAndQuery.query, { lineNumber: 1, column: 23 }))).toBe(false);
+  });
+
+  it('returns false after an incomplete where comparison', () => {
+    expect(canSuggestPipe(generateToken(whereFieldEqualsQuery.query, { lineNumber: 1, column: 15 }))).toBe(false);
+  });
+
+  it('returns true after a closed where condition function', () => {
+    expect(canSuggestPipe(generateToken(whereConditionCompleteQuery.query, { lineNumber: 1, column: 21 }))).toBe(true);
+  });
+
+  it('returns true after a closed stats function', () => {
+    expect(canSuggestPipe(generateToken(statsCountCompleteQuery.query, { lineNumber: 1, column: 14 }))).toBe(true);
+  });
+
+  it('returns true after a stats by field', () => {
+    expect(canSuggestPipe(generateToken(statsByCompleteQuery.query, { lineNumber: 1, column: 22 }))).toBe(true);
+  });
+
+  it('returns false after stats by with no field', () => {
+    expect(canSuggestPipe(generateToken(statsByIncompleteQuery.query, { lineNumber: 1, column: 17 }))).toBe(false);
+  });
+
+  it('returns false after head', () => {
+    expect(canSuggestPipe(generateToken(headCompleteQuery.query, { lineNumber: 1, column: 8 }))).toBe(false);
+  });
+
+  it('returns false for null token', () => {
+    expect(canSuggestPipe(null)).toBe(false);
+  });
+});

--- a/src/language/ppl/completion/pipeSuggestion.test.ts
+++ b/src/language/ppl/completion/pipeSuggestion.test.ts
@@ -1,6 +1,7 @@
 import { monacoTypes } from '@grafana/ui';
 
 import {
+  appendColBracketedStatsQuery,
   eventstatsCountCompleteQuery,
   fieldsCompleteQuery,
   fieldsFunctionFieldQuery,
@@ -13,6 +14,7 @@ import {
   statsByIncompleteQuery,
   statsCountCompleteQuery,
   statsCountTrailingCommaQuery,
+  trendlineQuery,
   whereCompleteQuery,
   whereConditionCompleteQuery,
   whereDanglingAndQuery,
@@ -106,5 +108,13 @@ describe('canSuggestPipe', () => {
 
   it('returns false for null token', () => {
     expect(canSuggestPipe(null)).toBe(false);
+  });
+
+  it('returns false after a completed sort field nested inside TRENDLINE (not a real pipe boundary)', () => {
+    expect(canSuggestPipe(generateToken(trendlineQuery.query, { lineNumber: 1, column: 26 }))).toBe(false);
+  });
+
+  it('returns true after a completed stats function as the first command of a bracketed subquery', () => {
+    expect(canSuggestPipe(generateToken(appendColBracketedStatsQuery.query, { lineNumber: 1, column: 39 }))).toBe(true);
   });
 });

--- a/src/language/ppl/completion/pipeSuggestion.test.ts
+++ b/src/language/ppl/completion/pipeSuggestion.test.ts
@@ -1,14 +1,18 @@
 import { monacoTypes } from '@grafana/ui';
 
 import {
+  eventstatsCountCompleteQuery,
   fieldsCompleteQuery,
+  fieldsFunctionFieldQuery,
   fieldsTrailingCommaQuery,
   headCompleteQuery,
   sortCompleteQuery,
   sortDanglingOperatorQuery,
+  sortFunctionFieldQuery,
   statsByCompleteQuery,
   statsByIncompleteQuery,
   statsCountCompleteQuery,
+  statsCountTrailingCommaQuery,
   whereCompleteQuery,
   whereConditionCompleteQuery,
   whereDanglingAndQuery,
@@ -43,11 +47,19 @@ describe('canSuggestPipe', () => {
   });
 
   it('returns true after a completed sort field', () => {
-    expect(canSuggestPipe(generateToken(sortCompleteQuery.query, { lineNumber: 1, column: 17 }))).toBe(true);
+    expect(canSuggestPipe(generateToken(sortCompleteQuery.query, { lineNumber: 1, column: 15 }))).toBe(true);
   });
 
   it('returns false after a dangling sort +/- operator', () => {
     expect(canSuggestPipe(generateToken(sortDanglingOperatorQuery.query, { lineNumber: 1, column: 7 }))).toBe(false);
+  });
+
+  it('returns true after a fields argument whose name collides with a builtin function', () => {
+    expect(canSuggestPipe(generateToken(fieldsFunctionFieldQuery.query, { lineNumber: 1, column: 13 }))).toBe(true);
+  });
+
+  it('returns true after a sort field whose name collides with a builtin function', () => {
+    expect(canSuggestPipe(generateToken(sortFunctionFieldQuery.query, { lineNumber: 1, column: 13 }))).toBe(true);
   });
 
   it('returns true after a complete where comparison', () => {
@@ -68,6 +80,16 @@ describe('canSuggestPipe', () => {
 
   it('returns true after a closed stats function', () => {
     expect(canSuggestPipe(generateToken(statsCountCompleteQuery.query, { lineNumber: 1, column: 14 }))).toBe(true);
+  });
+
+  it('returns false after a dangling comma following a closed stats function', () => {
+    expect(canSuggestPipe(generateToken(statsCountTrailingCommaQuery.query, { lineNumber: 1, column: 16 }))).toBe(
+      false
+    );
+  });
+
+  it('returns true after a closed eventstats function', () => {
+    expect(canSuggestPipe(generateToken(eventstatsCountCompleteQuery.query, { lineNumber: 1, column: 20 }))).toBe(true);
   });
 
   it('returns true after a stats by field', () => {

--- a/src/language/ppl/completion/pipeSuggestion.ts
+++ b/src/language/ppl/completion/pipeSuggestion.ts
@@ -11,8 +11,18 @@ export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
     return false;
   }
 
-  const command = currentToken.getPreviousOfType(PPLTokenTypes.Command)?.value?.toLowerCase();
-  if (!command) {
+  const commandToken = currentToken.getPreviousOfType(PPLTokenTypes.Command);
+  const command = commandToken?.value?.toLowerCase();
+  if (!commandToken || !command) {
+    return false;
+  }
+
+  // Only treat this as a top-level pipe-stage command when nothing but a pipe (or the
+  // start of the query) precedes it. Some commands (e.g. TRENDLINE) have their own
+  // sub-syntax that reuses command keywords like SORT internally; those aren't real
+  // pipe-stage boundaries and shouldn't be treated as suggestable-pipe positions.
+  const beforeCommand = commandToken.getPreviousNonWhiteSpaceToken();
+  if (beforeCommand && !beforeCommand.is(PPLTokenTypes.Pipe)) {
     return false;
   }
 
@@ -36,7 +46,18 @@ export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
 }
 
 function isFieldNameToken(token: LinkedToken, allowNumber: boolean): boolean {
-  return token.isIdentifier() || token.is(PPLTokenTypes.Backtick) || (allowNumber && token.isNumber());
+  if (token.isIdentifier() || token.is(PPLTokenTypes.Backtick) || (allowNumber && token.isNumber())) {
+    return true;
+  }
+
+  // A field whose name collides with a builtin PPL function (e.g. `count`, `timestamp`)
+  // is tokenized as Function/`predefined` rather than Identifier. Treat it as a field
+  // name as long as it isn't actually being called, i.e. not immediately followed by `(`.
+  if (token.isFunction()) {
+    return !token.getNextNonWhiteSpaceToken()?.is(PPLTokenTypes.Parenthesis, '(');
+  }
+
+  return false;
 }
 
 function isValueLikeToken(token: LinkedToken): boolean {

--- a/src/language/ppl/completion/pipeSuggestion.ts
+++ b/src/language/ppl/completion/pipeSuggestion.ts
@@ -17,12 +17,16 @@ export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
     return false;
   }
 
-  // Only treat this as a top-level pipe-stage command when nothing but a pipe (or the
-  // start of the query) precedes it. Some commands (e.g. TRENDLINE) have their own
-  // sub-syntax that reuses command keywords like SORT internally; those aren't real
-  // pipe-stage boundaries and shouldn't be treated as suggestable-pipe positions.
+  // Only treat this as a top-level pipe-stage command when nothing but a pipe, the
+  // start of a bracketed subquery (e.g. `appendcol ... [stats ...`), or the start of
+  // the query precedes it. Some commands (e.g. TRENDLINE) have their own sub-syntax
+  // that reuses command keywords like SORT internally; those aren't real pipe-stage
+  // boundaries and shouldn't be treated as suggestable-pipe positions.
   const beforeCommand = commandToken.getPreviousNonWhiteSpaceToken();
-  if (beforeCommand && !beforeCommand.is(PPLTokenTypes.Pipe)) {
+  const isSubqueryOpener =
+    !!beforeCommand &&
+    (beforeCommand.is(PPLTokenTypes.Parenthesis, '[') || beforeCommand.is(PPLTokenTypes.Parenthesis, '[]'));
+  if (beforeCommand && !beforeCommand.is(PPLTokenTypes.Pipe) && !isSubqueryOpener) {
     return false;
   }
 

--- a/src/language/ppl/completion/pipeSuggestion.ts
+++ b/src/language/ppl/completion/pipeSuggestion.ts
@@ -1,0 +1,71 @@
+import { LinkedToken } from '../../monarch/LinkedToken';
+import { BY, COMPARISON_OPERATORS, CONDITION_FUNCTIONS, EVENTSTATS, FIELDS, SORT, STATS, WHERE } from '../language';
+import { PPLTokenTypes } from '../tokenTypes';
+
+/**
+ * True when the cursor is in whitespace after a completed fields/sort/where/stats
+ * clause and `|` is a reasonable next suggestion. Conservative: ambiguous → false.
+ */
+export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
+  if (!currentToken?.isWhiteSpace()) {
+    return false;
+  }
+
+  const command = currentToken.getPreviousOfType(PPLTokenTypes.Command)?.value?.toLowerCase();
+  if (!command) {
+    return false;
+  }
+
+  const prev = currentToken.getPreviousNonWhiteSpaceToken();
+  if (!prev) {
+    return false;
+  }
+
+  switch (command) {
+    case FIELDS:
+    case SORT:
+      return isFieldNameToken(prev, command === SORT);
+    case WHERE:
+      return isCompleteWhereClause(prev);
+    case STATS:
+    case EVENTSTATS:
+      return isCompleteStatsClause(prev, currentToken);
+    default:
+      return false;
+  }
+}
+
+function isFieldNameToken(token: LinkedToken, allowNumber: boolean): boolean {
+  return token.isIdentifier() || token.is(PPLTokenTypes.Backtick) || (allowNumber && token.isNumber());
+}
+
+function isValueLikeToken(token: LinkedToken): boolean {
+  return token.isIdentifier() || token.isNumber() || token.isString() || token.is(PPLTokenTypes.Backtick);
+}
+
+function isCompleteWhereClause(prev: LinkedToken): boolean {
+  if (prev.is(PPLTokenTypes.Parenthesis, ')')) {
+    const fn = prev.getPreviousOfType(PPLTokenTypes.Function)?.value?.toLowerCase();
+    return !!fn && CONDITION_FUNCTIONS.includes(fn);
+  }
+
+  if (!isValueLikeToken(prev)) {
+    return false;
+  }
+
+  const beforeValue = prev.getPreviousNonWhiteSpaceToken();
+  return !!beforeValue && COMPARISON_OPERATORS.includes(beforeValue.value);
+}
+
+function isCompleteStatsClause(prev: LinkedToken, currentToken: LinkedToken): boolean {
+  if (prev.is(PPLTokenTypes.Parenthesis, ')')) {
+    return true;
+  }
+
+  if (!isFieldNameToken(prev, false)) {
+    return false;
+  }
+
+  const byKeyword = currentToken.getPreviousOfType(PPLTokenTypes.Keyword, BY);
+  return byKeyword != null;
+}

--- a/src/language/ppl/completion/pipeSuggestion.ts
+++ b/src/language/ppl/completion/pipeSuggestion.ts
@@ -3,15 +3,25 @@ import { BY, COMPARISON_OPERATORS, CONDITION_FUNCTIONS, EVENTSTATS, FIELDS, SORT
 import { PPLTokenTypes } from '../tokenTypes';
 
 /**
- * True when the cursor is in whitespace after a completed fields/sort/where/stats
- * clause and `|` is a reasonable next suggestion. Conservative: ambiguous → false.
+ * True when `|` is a reasonable next suggestion after a completed
+ * fields/sort/where/stats clause. Conservative: ambiguous → false.
+ *
+ * The cursor may sit in trailing whitespace or still on the last token of the
+ * clause (no trailing space yet).
  */
 export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
-  if (!currentToken?.isWhiteSpace()) {
+  if (!currentToken) {
     return false;
   }
 
-  const commandToken = currentToken.getPreviousOfType(PPLTokenTypes.Command);
+  const clauseEnd = currentToken.isWhiteSpace() ? currentToken.getPreviousNonWhiteSpaceToken() : currentToken;
+  if (!clauseEnd) {
+    return false;
+  }
+
+  const commandToken = clauseEnd.is(PPLTokenTypes.Command)
+    ? clauseEnd
+    : clauseEnd.getPreviousOfType(PPLTokenTypes.Command);
   const command = commandToken?.value?.toLowerCase();
   if (!commandToken || !command) {
     return false;
@@ -30,20 +40,15 @@ export function canSuggestPipe(currentToken: LinkedToken | null): boolean {
     return false;
   }
 
-  const prev = currentToken.getPreviousNonWhiteSpaceToken();
-  if (!prev) {
-    return false;
-  }
-
   switch (command) {
     case FIELDS:
     case SORT:
-      return isFieldNameToken(prev, command === SORT);
+      return isFieldNameToken(clauseEnd, command === SORT);
     case WHERE:
-      return isCompleteWhereClause(prev);
+      return isCompleteWhereClause(clauseEnd);
     case STATS:
     case EVENTSTATS:
-      return isCompleteStatsClause(prev, currentToken);
+      return isCompleteStatsClause(clauseEnd);
     default:
       return false;
   }
@@ -82,15 +87,14 @@ function isCompleteWhereClause(prev: LinkedToken): boolean {
   return !!beforeValue && COMPARISON_OPERATORS.includes(beforeValue.value);
 }
 
-function isCompleteStatsClause(prev: LinkedToken, currentToken: LinkedToken): boolean {
-  if (prev.is(PPLTokenTypes.Parenthesis, ')')) {
+function isCompleteStatsClause(clauseEnd: LinkedToken): boolean {
+  if (clauseEnd.is(PPLTokenTypes.Parenthesis, ')')) {
     return true;
   }
 
-  if (!isFieldNameToken(prev, false)) {
+  if (!isFieldNameToken(clauseEnd, false)) {
     return false;
   }
 
-  const byKeyword = currentToken.getPreviousOfType(PPLTokenTypes.Keyword, BY);
-  return byKeyword != null;
+  return clauseEnd.getPreviousOfType(PPLTokenTypes.Keyword, BY) != null;
 }


### PR DESCRIPTION
## Summary

* Suggest `|` after a completed `fields` / `where` / `sort` / `stats` segment (Discover-like), not only after `source = <index>`.
* Skip pipe after trailing commas, dangling `AND`/`OR`, and typically terminal commands (`head`).
* Treat function-colliding field names as valid, and allow pipe as the first command of a bracketed subquery.

Stacked on #1157 (`feat/ppl-aggregatable-term-fields`). Completes the remaining #1138 item; do not use auto-close until this is retargeted to `main` after #1157 merges.

## Test plan

- [ ] Unit: `pipeSuggestion`, `PPLCompletionItemProvider`
- [ ] Explore → PPL: `|` after `source = idx | fields a`
- [ ] No `|` after `fields a,` (trailing comma)
- [ ] `|` after a finished `where a = 1` (not after `where a = 1 AND`)
- [ ] No `|` after `head 10`