### PR TITLE
fix: Support rollup queries

### DIFF
--- a/pkg/opensearch/client/client_test.go
+++ b/pkg/opensearch/client/client_test.go
@@ -115,7 +115,7 @@ func TestClient(t *testing.T) {
 					})
 
 					t.Run("and replace $__interval_ms variable", func(t *testing.T) {
-						assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "interval").MustString())
+						assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "fixed_interval").MustString())
 					})
 				})
 

--- a/pkg/opensearch/client/models.go
+++ b/pkg/opensearch/client/models.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	simplejson "github.com/bitly/go-simplejson"
 
@@ -198,6 +200,32 @@ type QueryStringFilter struct {
 	AnalyzeWildcard bool
 }
 
+// MatchAllFilter represents a match_all search filter.
+type MatchAllFilter struct{}
+
+// MarshalJSON returns the JSON encoding of the match_all filter.
+func (f *MatchAllFilter) MarshalJSON() ([]byte, error) {
+	return []byte(`{"match_all":{}}`), nil
+}
+
+// NewLuceneFilter returns the appropriate filter for a Lucene query. Empty
+// queries do not add a filter, while match-all wildcards use match_all so
+// OpenSearch does not expand them across mapped fields.
+func NewLuceneFilter(query string, analyzeWildcard bool) Filter {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil
+	}
+	if query == "*" || query == "*:*" {
+		return &MatchAllFilter{}
+	}
+
+	return &QueryStringFilter{
+		Query:           query,
+		AnalyzeWildcard: analyzeWildcard,
+	}
+}
+
 // MarshalJSON returns the JSON encoding of the query string filter.
 func (f *QueryStringFilter) MarshalJSON() ([]byte, error) {
 	root := map[string]interface{}{
@@ -337,13 +365,60 @@ type HistogramAgg struct {
 
 // DateHistogramAgg represents a date histogram aggregation
 type DateHistogramAgg struct {
-	Field          string          `json:"field"`
-	Interval       string          `json:"interval,omitempty"`
-	MinDocCount    int             `json:"min_doc_count"`
-	Missing        *string         `json:"missing,omitempty"`
-	ExtendedBounds *ExtendedBounds `json:"extended_bounds"`
-	Format         string          `json:"format"`
-	Offset         string          `json:"offset,omitempty"`
+	Field                 string          `json:"field"`
+	Interval              string          `json:"interval,omitempty"`
+	MinDocCount           int             `json:"min_doc_count"`
+	Missing               *string         `json:"missing,omitempty"`
+	ExtendedBounds        *ExtendedBounds `json:"extended_bounds"`
+	Format                string          `json:"format"`
+	Offset                string          `json:"offset,omitempty"`
+	UseFixedInterval      bool            `json:"-"`
+	ResolvedFixedInterval string          `json:"-"`
+}
+
+// MarshalJSON uses the fixed interval parameter required by current OpenSearch
+// versions while retaining the legacy interval parameter for Elasticsearch.
+func (a *DateHistogramAgg) MarshalJSON() ([]byte, error) {
+	type dateHistogramAgg DateHistogramAgg
+	if !a.UseFixedInterval {
+		return json.Marshal((*dateHistogramAgg)(a))
+	}
+
+	interval := a.Interval
+	if interval == "$__interval" && a.ResolvedFixedInterval != "" {
+		interval = a.ResolvedFixedInterval
+	}
+	interval = normalizeFixedInterval(interval)
+
+	explicit := struct {
+		Field          string          `json:"field"`
+		FixedInterval  string          `json:"fixed_interval,omitempty"`
+		MinDocCount    int             `json:"min_doc_count"`
+		Missing        *string         `json:"missing,omitempty"`
+		ExtendedBounds *ExtendedBounds `json:"extended_bounds"`
+		Format         string          `json:"format"`
+		Offset         string          `json:"offset,omitempty"`
+	}{
+		Field:          a.Field,
+		FixedInterval:  interval,
+		MinDocCount:    a.MinDocCount,
+		Missing:        a.Missing,
+		ExtendedBounds: a.ExtendedBounds,
+		Format:         a.Format,
+		Offset:         a.Offset,
+	}
+
+	return json.Marshal(explicit)
+}
+
+func normalizeFixedInterval(interval string) string {
+	if strings.HasSuffix(interval, "y") {
+		years, err := strconv.ParseInt(strings.TrimSuffix(interval, "y"), 10, 64)
+		if err == nil && years > 0 {
+			return fmt.Sprintf("%dd", years*365)
+		}
+	}
+	return interval
 }
 
 // FiltersAggregation represents a filters aggregation

--- a/pkg/opensearch/client/search_request.go
+++ b/pkg/opensearch/client/search_request.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"strings"
-
 	"github.com/Masterminds/semver"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 )
@@ -148,7 +146,7 @@ func (b *SearchRequestBuilder) Query() *QueryBuilder {
 
 // Agg initiate and returns a new aggregation builder
 func (b *SearchRequestBuilder) Agg() AggBuilder {
-	aggBuilder := newAggBuilder(b.version, b.flavor)
+	aggBuilder := newAggBuilder(b.version, b.flavor, b.interval)
 	b.aggBuilders = append(b.aggBuilders, aggBuilder)
 	return aggBuilder
 }
@@ -248,12 +246,8 @@ func (b *SearchRequestBuilder) SetTraceListFilters(to, from int64, query string)
 			Gte: from,
 		})
 
-	if strings.TrimSpace(query) != "" {
-		mustQueryBuilder.filters = append(mustQueryBuilder.filters,
-			&QueryStringFilter{
-				Query:           query,
-				AnalyzeWildcard: true,
-			})
+	if filter := NewLuceneFilter(query, true); filter != nil {
+		mustQueryBuilder.filters = append(mustQueryBuilder.filters, filter)
 	}
 
 	b.Size(10)
@@ -415,14 +409,9 @@ func (b *FilterQueryBuilder) AddFilterQuery(query Query) *FilterQueryBuilder {
 
 // AddQueryStringFilter adds a new query string filter
 func (b *FilterQueryBuilder) AddQueryStringFilter(querystring string, analyzeWildcard bool) *FilterQueryBuilder {
-	if len(strings.TrimSpace(querystring)) == 0 {
-		return b
+	if filter := NewLuceneFilter(querystring, analyzeWildcard); filter != nil {
+		b.filters = append(b.filters, filter)
 	}
-
-	b.filters = append(b.filters, &QueryStringFilter{
-		Query:           querystring,
-		AnalyzeWildcard: analyzeWildcard,
-	})
 	return b
 }
 
@@ -448,16 +437,18 @@ type AggBuilder interface {
 }
 
 type aggBuilderImpl struct {
-	aggDefs []*aggDefinition
-	flavor  Flavor
-	version *semver.Version
+	aggDefs  []*aggDefinition
+	flavor   Flavor
+	version  *semver.Version
+	interval tsdb.Interval
 }
 
-func newAggBuilder(version *semver.Version, flavor Flavor) AggBuilder {
+func newAggBuilder(version *semver.Version, flavor Flavor, interval tsdb.Interval) AggBuilder {
 	return &aggBuilderImpl{
-		aggDefs: make([]*aggDefinition, 0),
-		version: version,
-		flavor:  flavor,
+		aggDefs:  make([]*aggDefinition, 0),
+		version:  version,
+		flavor:   flavor,
+		interval: interval,
 	}
 }
 
@@ -499,7 +490,7 @@ func (b *aggBuilderImpl) Histogram(key, field string, fn func(a *HistogramAgg, b
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version, b.flavor)
+		builder := newAggBuilder(b.version, b.flavor, b.interval)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -511,7 +502,9 @@ func (b *aggBuilderImpl) Histogram(key, field string, fn func(a *HistogramAgg, b
 
 func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogramAgg, b AggBuilder)) AggBuilder {
 	innerAgg := &DateHistogramAgg{
-		Field: field,
+		Field:                 field,
+		UseFixedInterval:      b.flavor == OpenSearch,
+		ResolvedFixedInterval: fixedIntervalText(b.interval),
 	}
 	aggDef := newAggDefinition(key, &AggContainer{
 		Type:        "date_histogram",
@@ -519,7 +512,7 @@ func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogr
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version, b.flavor)
+		builder := newAggBuilder(b.version, b.flavor, b.interval)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -527,6 +520,10 @@ func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogr
 	b.aggDefs = append(b.aggDefs, aggDef)
 
 	return b
+}
+
+func fixedIntervalText(interval tsdb.Interval) string {
+	return normalizeFixedInterval(interval.Text)
 }
 
 const termsOrderTerm = "_term"
@@ -541,7 +538,7 @@ func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version, b.flavor)
+		builder := newAggBuilder(b.version, b.flavor, b.interval)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -572,7 +569,7 @@ func (b *aggBuilderImpl) Filters(key string, fn func(a *FiltersAggregation, b Ag
 		Aggregation: innerAgg,
 	})
 	if fn != nil {
-		builder := newAggBuilder(b.version, b.flavor)
+		builder := newAggBuilder(b.version, b.flavor, b.interval)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}
@@ -717,7 +714,7 @@ func (b *aggBuilderImpl) GeoHashGrid(key, field string, fn func(a *GeoHashGridAg
 	})
 
 	if fn != nil {
-		builder := newAggBuilder(b.version, b.flavor)
+		builder := newAggBuilder(b.version, b.flavor, b.interval)
 		aggDef.builders = append(aggDef.builders, builder)
 		fn(innerAgg, builder)
 	}

--- a/pkg/opensearch/client/search_request_test.go
+++ b/pkg/opensearch/client/search_request_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bitly/go-simplejson"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchRequest(t *testing.T) {
@@ -294,6 +295,115 @@ func TestSearchRequest(t *testing.T) {
 
 		})
 	})
+}
+
+func TestDateHistogramIntervalParameters(t *testing.T) {
+	version, err := semver.NewVersion("2.3.0")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		flavor           Flavor
+		interval         tsdb.Interval
+		configured       string
+		expectedKey      string
+		expectedInterval string
+	}{
+		{
+			name:             "Elasticsearch keeps the legacy interval",
+			flavor:           Elasticsearch,
+			interval:         tsdb.Interval{Text: "15s"},
+			configured:       "$__interval",
+			expectedKey:      "interval",
+			expectedInterval: "$__interval",
+		},
+		{
+			name:             "OpenSearch uses a fixed interval",
+			flavor:           OpenSearch,
+			interval:         tsdb.Interval{Text: "15s"},
+			configured:       "$__interval",
+			expectedKey:      "fixed_interval",
+			expectedInterval: "15s",
+		},
+		{
+			name:             "OpenSearch uses a fixed interval for long ranges",
+			flavor:           OpenSearch,
+			interval:         tsdb.Interval{Text: "1y", Value: 365 * 24 * time.Hour},
+			configured:       "$__interval",
+			expectedKey:      "fixed_interval",
+			expectedInterval: "365d",
+		},
+		{
+			name:             "OpenSearch normalizes a configured year",
+			flavor:           OpenSearch,
+			interval:         tsdb.Interval{Text: "15s", Value: 15 * time.Second},
+			configured:       "1y",
+			expectedKey:      "fixed_interval",
+			expectedInterval: "365d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewSearchRequestBuilder(tt.flavor, version, tt.interval)
+			builder.Agg().DateHistogram("date", "@timestamp", func(a *DateHistogramAgg, _ AggBuilder) {
+				a.Interval = tt.configured
+			})
+
+			request, err := builder.Build()
+			assert.NoError(t, err)
+			body, err := json.Marshal(request)
+			assert.NoError(t, err)
+			parsed, err := simplejson.NewJson(body)
+			assert.NoError(t, err)
+
+			histogram := parsed.GetPath("aggs", "date", "date_histogram")
+			assert.Equal(t, tt.expectedInterval, histogram.Get(tt.expectedKey).MustString())
+			if tt.expectedKey != "interval" {
+				assert.Nil(t, histogram.Get("interval").Interface())
+			}
+			assert.Nil(t, histogram.Get("calendar_interval").Interface())
+		})
+	}
+}
+
+func TestQueryStringMatchAllFilters(t *testing.T) {
+	tests := []string{"*", " *:* "}
+	for _, query := range tests {
+		t.Run(query, func(t *testing.T) {
+			builder := NewFilterQueryBuilder()
+			builder.AddQueryStringFilter(query, true)
+			filters, err := builder.Build()
+
+			assert.NoError(t, err)
+			assert.Len(t, filters, 1)
+			assert.IsType(t, &MatchAllFilter{}, filters[0])
+			body, err := json.Marshal(filters[0])
+			assert.NoError(t, err)
+			assert.JSONEq(t, `{"match_all": {}}`, string(body))
+		})
+	}
+
+	t.Run("empty queries do not add a filter", func(t *testing.T) {
+		builder := NewFilterQueryBuilder()
+		builder.AddQueryStringFilter("  ", true)
+		filters, err := builder.Build()
+		assert.NoError(t, err)
+		assert.Empty(t, filters)
+	})
+}
+
+func TestTraceListMatchAllFilter(t *testing.T) {
+	version, err := semver.NewVersion("2.3.0")
+	assert.NoError(t, err)
+
+	builder := NewSearchRequestBuilder(OpenSearch, version, tsdb.Interval{})
+	builder.SetTraceListFilters(10, 5, " *:*")
+	request, err := builder.Build()
+
+	assert.NoError(t, err)
+	require.Len(t, request.Query.Bool.MustFilters, 2)
+	assert.IsType(t, &MatchAllFilter{}, request.Query.Bool.MustFilters[1])
 }
 
 func TestMultiSearchRequest(t *testing.T) {

--- a/pkg/opensearch/lucene_handler.go
+++ b/pkg/opensearch/lucene_handler.go
@@ -553,7 +553,9 @@ func addFiltersAgg(aggBuilder client.AggBuilder, bucketAgg *BucketAgg) client.Ag
 		if label == "" {
 			label = query
 		}
-		filters[label] = &client.QueryStringFilter{Query: query, AnalyzeWildcard: true}
+		if filter := client.NewLuceneFilter(query, true); filter != nil {
+			filters[label] = filter
+		}
 	}
 
 	if len(filters) > 0 {

--- a/pkg/opensearch/query_request_test.go
+++ b/pkg/opensearch/query_request_test.go
@@ -440,7 +440,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 						"id": "2",
 						"type": "filters",
 						"settings": {
-							"filters": [ { "query": "@metric:cpu" }, { "query": "@metric:logins.count" } ]
+							"filters": [ { "query": "@metric:cpu" }, { "query": "@metric:logins.count" }, { "query": "*" } ]
 						}
 					},
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
@@ -456,6 +456,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			fAgg := filtersAgg.Aggregation.Aggregation.(*client.FiltersAggregation)
 			assert.Equal(t, "@metric:cpu", fAgg.Filters["@metric:cpu"].(*client.QueryStringFilter).Query)
 			assert.Equal(t, "@metric:logins.count", fAgg.Filters["@metric:logins.count"].(*client.QueryStringFilter).Query)
+			assert.IsType(t, &client.MatchAllFilter{}, fAgg.Filters["*"])
 
 			dateHistogramAgg := sr.Aggs[0].Aggregation.Aggs[0]
 			assert.Equal(t, "4", dateHistogramAgg.Key)
@@ -1471,13 +1472,15 @@ func TestSettingsCasting_luceneHandler_processQuery_processLogsQuery_ignores_any
 	sr := c.multisearchRequests[0].Requests[0]
 
 	assert.Equal(t, &client.DateHistogramAgg{
-		Field:          "@timestamp",
-		Interval:       "$__interval",
-		MinDocCount:    0,
-		Missing:        nil,
-		ExtendedBounds: &client.ExtendedBounds{Min: from.UnixMilli(), Max: to.UnixMilli()},
-		Format:         "epoch_millis",
-		Offset:         "",
+		Field:                 "@timestamp",
+		Interval:              "$__interval",
+		MinDocCount:           0,
+		Missing:               nil,
+		ExtendedBounds:        &client.ExtendedBounds{Min: from.UnixMilli(), Max: to.UnixMilli()},
+		Format:                "epoch_millis",
+		Offset:                "",
+		UseFixedInterval:      true,
+		ResolvedFixedInterval: "15s",
 	}, sr.Aggs[0].Aggregation.Aggregation.(*client.DateHistogramAgg))
 }
 

--- a/pkg/opensearch/snapshot_tests/lucene_logs_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_logs_test.go
@@ -45,7 +45,7 @@ func Test_logs_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"1":{"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}}]}
+{"aggs":{"1":{"date_histogram":{"field":"timestamp","fixed_interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"docvalue_fields":["timestamp"],"fields":[{"field":"timestamp","format":"strict_date_optional_time_nanos"}],"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"FlightDelayType:\"Carrier Delay\" AND Carrier:Open*"}}]}},"size":500,"sort":[{"timestamp":{"order":"desc","unmapped_type":"boolean"}}]}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }

--- a/pkg/opensearch/snapshot_tests/lucene_metric_test.go
+++ b/pkg/opensearch/snapshot_tests/lucene_metric_test.go
@@ -51,7 +51,7 @@ func Test_metric_max_group_by_terms_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"max":{"field":"AvgTicketPrice"}}},"terms":{"field":"AvgTicketPrice","size":10,"order":{"_key":"desc"},"min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"max":{"field":"AvgTicketPrice"}}},"terms":{"field":"AvgTicketPrice","size":10,"order":{"_key":"desc"},"min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -100,7 +100,7 @@ func Test_metric_percentiles_group_by_terms_large_size_raises_interval(t *testin
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"3":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice"}},"2":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice","percents":["50"]}}},"date_histogram":{"field":"timestamp","interval":"5s","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"terms":{"field":"dayOfWeek","size":1000,"order":{"1[50.0]":"desc"},"min_doc_count":1}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"3":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice"}},"2":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice","percents":["50"]}}},"date_histogram":{"field":"timestamp","fixed_interval":"5s","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"terms":{"field":"dayOfWeek","size":1000,"order":{"1[50.0]":"desc"},"min_doc_count":1}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -165,7 +165,7 @@ func Test_metric_sum_group_by_histogram_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":500,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":500,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -206,7 +206,7 @@ func Test_metric_sum_group_by_histogram_decimal_interval_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":5.5,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":5.5,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -248,7 +248,7 @@ func Test_metric_sum_group_by_histogram_invalid_interval_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":1000,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"histogram":{"interval":1000,"field":"timestamp","min_doc_count":0}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -290,7 +290,7 @@ func Test_metric_sum_group_by_date_histogram_request(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"sum":{"field":"DistanceKilometers"}}},"date_histogram":{"field":"timestamp","fixed_interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -355,7 +355,7 @@ func Test_metric_average_derivative_group_by_date_histogram_request(t *testing.T
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"2":{"aggs":{"1":{"avg":{"field":"AvgTicketPrice"}},"3":{"derivative":{"buckets_path":"1"}}},"date_histogram":{"field":"timestamp","interval":"1d","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"2":{"aggs":{"1":{"avg":{"field":"AvgTicketPrice"}},"3":{"derivative":{"buckets_path":"1"}}},"date_histogram":{"field":"timestamp","fixed_interval":"1d","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }
@@ -420,7 +420,7 @@ func Test_metric_percentiles_group_by_terms_orderby_percentile(t *testing.T) {
 
 	// assert request's header and query
 	expectedRequest := `{"ignore_unavailable":true,"index":"","search_type":"query_then_fetch"}
-{"aggs":{"3":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice"}},"2":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice","percents":["50"]}}},"date_histogram":{"field":"timestamp","interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"terms":{"field":"dayOfWeek","size":10,"order":{"1[50.0]":"desc"},"min_doc_count":1}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"size":0}
+{"aggs":{"3":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice"}},"2":{"aggs":{"1":{"percentiles":{"field":"AvgTicketPrice","percents":["50"]}}},"date_histogram":{"field":"timestamp","fixed_interval":"100ms","min_doc_count":0,"extended_bounds":{"min":1668422437218,"max":1668422625668},"format":"epoch_millis"}}},"terms":{"field":"dayOfWeek","size":10,"order":{"1[50.0]":"desc"},"min_doc_count":1}}},"query":{"bool":{"filter":[{"range":{"timestamp":{"format":"epoch_millis","gte":1668422437218,"lte":1668422625668}}},{"match_all":{}}]}},"size":0}
 `
 	assert.Equal(t, expectedRequest, string(interceptedRequest))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
OpenSearch rollup queries fail when Grafana sends a wildcard `query_string` query. The rollup interceptor expands it across mapped fields, including fields omitted from the rollup job. Exact `*` and `*:*` Lucene queries are now translated to `match_all`.

OpenSearch date histograms now use `fixed_interval` consistently. Year-based intervals such as `1y` are converted to `365d` because OpenSearch does not accept years as a fixed interval unit and `interval` [is a deprecated field that doesn't work with rollup indices](https://docs.opensearch.org/latest/aggregations/bucket/date-histogram/).

Together, these changes allow equivalent metric queries to work seamlessly against source and rollup indices without datasource-specific configuration.

**Which issue(s) this PR fixes**:

Fixes #769

**Special notes for your reviewer**:

Some screenshots (left with fix, right without fix):

<img width="1580" height="848" alt="image" src="https://github.com/user-attachments/assets/533bd2c8-7630-4f21-8532-5ffad9b907ea" />

<img width="1567" height="743" alt="image" src="https://github.com/user-attachments/assets/5d77a893-0071-48c5-a987-fdce669a654d" />
