### PR TITLE
Probe _field_caps in the backend health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Backend health check probes `_field_caps` instead of `_mapping/field`, which Amazon OpenSearch Serverless does not support, and a failed check no longer reports an empty message
 * Bump `@grafana/aws-sdk` to 0.12.1 for SigV4 per-datasource Grafana Assume Role external IDs
 
 ## 2.34.3

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -96,7 +96,11 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 	// We try the indices until one successfully queries
 	for _, indexName := range indices {
 		index = indexName
-		osUrl, err := createOpensearchURL(index+"/_mapping/field/"+url.PathEscape(timeField), req.PluginContext.DataSourceInstanceSettings.URL)
+		// _field_caps rather than _mapping/field: Amazon OpenSearch Serverless
+		// does not support the mapping API, and _field_caps is already what the
+		// frontend check and CallResource use. createOpensearchURL adds
+		// fields=* for this path.
+		osUrl, err := createOpensearchURL(index+"/_field_caps", req.PluginContext.DataSourceInstanceSettings.URL)
 		if err != nil {
 			res.Status = backend.HealthStatusError
 			res.Message = err.Error()
@@ -130,7 +134,7 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 			break
 		}
 		res.Status = backend.HealthStatusError
-		res.Message = string(body)
+		res.Message = healthCheckFailureMessage(response.StatusCode, body)
 	}
 	if res.Status == backend.HealthStatusError {
 		return res, nil
@@ -147,22 +151,23 @@ func (ds *OpenSearchDatasource) CheckHealth(ctx context.Context, req *backend.Ch
 		res.Message = fmt.Sprintf("Error parsing response: %s", err)
 		return res, nil
 	}
-	mapping, ok := jsonData.CheckGet(index)
+	fields, ok := jsonData.CheckGet("fields")
 	if !ok {
 		res.Status = backend.HealthStatusError
 		res.Message = fmt.Sprintf("Index not found: %s", index)
 		return res, nil
 	}
 
-	timeFieldMapping, ok := mapping.Get("mappings").CheckGet(timeField)
+	timeFieldCaps, ok := fields.CheckGet(timeField)
 	if !ok {
 		res.Status = backend.HealthStatusOk
 		res.Message = "Index OK. Note: No field named " + timeField + " found"
 		return res, nil
 	}
 
-	timeType := timeFieldMapping.Get("mapping").Get(timeField).Get("type")
-	if timeType.MustString() != "date" {
+	// _field_caps keys each field by its type, so a date field carries a "date"
+	// entry. This is the same shape getFields reads on the frontend.
+	if _, ok := timeFieldCaps.CheckGet("date"); !ok {
 		res.Status = backend.HealthStatusOk
 		res.Message = "Index OK. Note: " + timeField + " is not a date field"
 		return res, nil
@@ -361,6 +366,16 @@ func (ds *OpenSearchDatasource) CallResource(ctx context.Context, req *backend.C
 		Headers: responseHeaders,
 		Body:    body,
 	})
+}
+
+// healthCheckFailureMessage keeps a failed health check from reporting an empty
+// Message. A refusal can carry an empty body, and Grafana Advisor then shows a
+// high-severity failure with no text at all.
+func healthCheckFailureMessage(statusCode int, body []byte) string {
+	if msg := strings.TrimSpace(string(body)); msg != "" {
+		return msg
+	}
+	return fmt.Sprintf("Health check failed with status %d and an empty response body", statusCode)
 }
 
 func createOpensearchURL(reqPath string, urlStr string) (string, error) {

--- a/pkg/opensearch/opensearch_test.go
+++ b/pkg/opensearch/opensearch_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -352,4 +353,99 @@ func TestCreateOpensearchURL_CatIndices(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckHealth(t *testing.T) {
+	settings := func(url string) backend.PluginContext {
+		return backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				URL: url,
+				JSONData: []byte(`{
+					"flavor": "opensearch",
+					"version": "2.3.0",
+					"timeField": "@timestamp",
+					"database": "my-index"
+				}`),
+			},
+		}
+	}
+
+	t.Run("probes _field_caps rather than the mapping API", func(t *testing.T) {
+		var gotPath, gotQuery string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"indices":["my-index"],"fields":{"@timestamp":{"date":{"type":"date"}}}}`))
+		}))
+		defer server.Close()
+
+		ds := &OpenSearchDatasource{HttpClient: server.Client()}
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{PluginContext: settings(server.URL)})
+
+		require.NoError(t, err)
+		assert.Equal(t, "/my-index/_field_caps", gotPath)
+		assert.Equal(t, "fields=*", gotQuery)
+		assert.Equal(t, backend.HealthStatusOk, res.Status)
+		assert.Equal(t, "Index OK. Time field name OK.", res.Message)
+	})
+
+	t.Run("reports a missing time field without failing the check", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"indices":["my-index"],"fields":{"other":{"keyword":{"type":"keyword"}}}}`))
+		}))
+		defer server.Close()
+
+		ds := &OpenSearchDatasource{HttpClient: server.Client()}
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{PluginContext: settings(server.URL)})
+
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusOk, res.Status)
+		assert.Equal(t, "Index OK. Note: No field named @timestamp found", res.Message)
+	})
+
+	t.Run("reports a time field that is not a date", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"indices":["my-index"],"fields":{"@timestamp":{"keyword":{"type":"keyword"}}}}`))
+		}))
+		defer server.Close()
+
+		ds := &OpenSearchDatasource{HttpClient: server.Client()}
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{PluginContext: settings(server.URL)})
+
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusOk, res.Status)
+		assert.Equal(t, "Index OK. Note: @timestamp is not a date field", res.Message)
+	})
+
+	t.Run("a refusal with an empty body still carries a message", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer server.Close()
+
+		ds := &OpenSearchDatasource{HttpClient: server.Client()}
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{PluginContext: settings(server.URL)})
+
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Equal(t, "Health check failed with status 400 and an empty response body", res.Message)
+	})
+
+	t.Run("a refusal with a body reports the body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"no permissions"}`))
+		}))
+		defer server.Close()
+
+		ds := &OpenSearchDatasource{HttpClient: server.Client()}
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{PluginContext: settings(server.URL)})
+
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Equal(t, `{"error":"no permissions"}`, res.Message)
+	})
 }


### PR DESCRIPTION
`CheckHealth` probes `GET <index>/_mapping/field/<timeField>`. Serverless collections do not support the mapping API, so the probe is refused and the health check fails on a datasource the query path reads fine. `_field_caps` is supported there, and it is already what `getFields` on the frontend and the `CallResource` allowlist use, so the backend now asks the same question the rest of the plugin does. `createOpensearchURL` already appends `fields=*` for that path, so no change was needed there.

The response shape changes with it. `_field_caps` keys fields by name and then by type, so the time field check becomes "is there a `date` entry under `fields[timeField]`" rather than walking `mappings`. The four outcomes and their messages are unchanged: index not found, no field named X, X is not a date field, and time field name OK.

Second half of the issue: the loop copied the response body straight into `Message`, so a refusal with an empty body produced a high-severity Advisor failure with no text. There is now a fallback naming the status code.

Five subtests in `pkg/opensearch/opensearch_test.go` cover it against an `httptest` server: the probe path and query, the three OK-with-a-note outcomes, and both failure messages. Against the current code the first two fail as you would expect:

    expected: "/my-index/_field_caps"
    actual  : "/my-index/_mapping/field/@timestamp"

`go test ./pkg/...` is green. `gofmt -l pkg/` reports only `pkg/utils/utils_test.go`, which this branch does not touch.

I have not run this against a real Serverless collection, so the Serverless half rests on the supported-operations table the issue cites plus the fact that the frontend check already succeeds there over the same API.

Fixes #1175